### PR TITLE
fix: sync issues

### DIFF
--- a/keychain/src/utils/account.ts
+++ b/keychain/src/utils/account.ts
@@ -152,6 +152,10 @@ class Account extends BaseAccount {
         }
       }
 
+      if (this.status === Status.PENDING_REGISTER) {
+        return;
+      }
+
       const classHash = await this.rpc.getClassHashAt(this.address, "pending");
       Storage.update(this.selector, {
         classHash,

--- a/keychain/src/utils/account.ts
+++ b/keychain/src/utils/account.ts
@@ -117,6 +117,8 @@ class Account extends BaseAccount {
           Storage.update(this.selector, {
             status: Status.COUNTERFACTUAL,
           });
+          // async deployed, poll for contract
+          setTimeout(() => this.sync(), 5000);
           return;
         }
 


### PR DESCRIPTION
@tarrencev in the case where we deploy, I think we need to poll for contract after signup otherwise user is stuck in `COUNTERFACTUAL` unless try start triggering actions. Or maybe only poll if deployAccount api is called?

Also, `PENDING_REGISTRATION` gets overridden by `DEPLOYED` after login. Tho with this fix, device registration isn't getting triggered still 