### PR TITLE
feat(ui): Add story about semantic color naming

### DIFF
--- a/packages/ui/src/stories/Color.stories.tsx
+++ b/packages/ui/src/stories/Color.stories.tsx
@@ -5,6 +5,8 @@ import { colors } from "../theme/colors";
 /**
  *
  * Collection of colors based on local variables from [Figma](https://www.figma.com/file/6ZQgwNrqpRlMg9GFbA41dv/Components?type=design&node-id=1%3A3070&mode=design&t=ITTcq5pR4KR2VzOu-1).
+ *
+ * Check out `Color (Senmantic Tokens)` page also for real usage of colors.
  */
 const meta: Meta<typeof Palette> = {
   title: "Color",
@@ -96,7 +98,7 @@ function Palette({ colorName }: ColorsProps) {
         Object.entries(values)
           .sort(([k1], [k2]) => (k1 < k2 ? -1 : 1))
           .map(([gradient, colorValue]) => (
-            <Item
+            <ColorSample
               key={colorName + gradient}
               colorName={colorName}
               gradient={gradient}
@@ -104,13 +106,13 @@ function Palette({ colorName }: ColorsProps) {
             />
           ))
       ) : (
-        <Item colorName={colorName} colorValue={values} />
+        <ColorSample colorName={colorName} colorValue={values} />
       )}
     </HStack>
   );
 }
 
-function Item({
+function ColorSample({
   colorName,
   gradient,
   colorValue,

--- a/packages/ui/src/stories/SemanticColor.stories.tsx
+++ b/packages/ui/src/stories/SemanticColor.stories.tsx
@@ -1,0 +1,85 @@
+import { VStack, HStack, Text as CText, Box } from "@chakra-ui/react";
+import { Meta, StoryObj } from "@storybook/react";
+import { semanticColors } from "../theme/colors";
+
+/**
+ *
+ * Semantic color names. It's like an arias. Check `Color` page also for more.
+ */
+const meta: Meta<typeof Palette> = {
+  title: "Color (Semtantic Tokens)",
+  component: Palette,
+  tags: ["autodocs"],
+  argTypes: {
+    colorName: {
+      control: "select",
+      description: "Base color name",
+      options: Object.keys(semanticColors),
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Palette>;
+
+export const Text: Story = {
+  args: {
+    colorName: "text",
+  },
+};
+
+export const Brand: Story = {
+  args: {
+    colorName: "brand",
+  },
+};
+
+export const Solid: Story = {
+  args: {
+    colorName: "solid",
+  },
+};
+
+export const Translucent: Story = {
+  args: {
+    colorName: "translucent",
+  },
+};
+
+type ColorsProps = {
+  colorName: keyof typeof semanticColors;
+};
+
+function Palette({ colorName }: ColorsProps) {
+  return (
+    <HStack overflowX="auto">
+      {Object.keys(semanticColors[colorName])
+        .sort((k1, k2) => (k1 < k2 ? -1 : 1))
+        .map((variant) => (
+          <ColorSample
+            key={colorName + variant}
+            colorName={colorName}
+            variant={variant}
+          />
+        ))}
+    </HStack>
+  );
+}
+
+function ColorSample({
+  colorName,
+  variant,
+}: {
+  colorName: string;
+  variant: string;
+}) {
+  const bgColor = `${colorName}.${variant}`;
+
+  return (
+    <VStack>
+      <Box w={32} h={32} bgColor={bgColor} />
+      <CText fontSize="xs">{variant}</CText>
+    </VStack>
+  );
+}


### PR DESCRIPTION
<img width="1624" alt="Screenshot 2023-08-02 at 20 46 40" src="https://github.com/cartridge-gg/cartridge/assets/8398372/bec1bdf7-d7d7-4a22-aefe-a09acd125b9c">

## What

Chakra UI allows you to map custom color names to base colors. This PR adds storybook page to demonstrate all names.