### PR TITLE
Remove gateway provider from keychain account methods

### DIFF
--- a/packages/keychain/src/utils/account.ts
+++ b/packages/keychain/src/utils/account.ts
@@ -239,7 +239,7 @@ class Account extends BaseAccount {
           .toString(),
       });
 
-      this.gateway
+      this.rpc
         .waitForTransaction(responses[1].transaction_hash, 1000, [
           "ACCEPTED_ON_L1",
           "ACCEPTED_ON_L2",
@@ -259,7 +259,7 @@ class Account extends BaseAccount {
         .toString(),
     });
 
-    this.gateway
+    this.rpc
       .waitForTransaction(res.transaction_hash, 1000, [
         "ACCEPTED_ON_L1",
         "ACCEPTED_ON_L2",


### PR DESCRIPTION
NOTE: account.gateway is still referenced in bridge eth feature. The `estimateMessageFee` method would fail since gateway is deprecated but fixing that is out of scope for this PR. I leave a reminder to replace it with rpc for future PR.

https://github.com/cartridge-gg/cartridge/blob/e8bb2ea69a9146694f847ca9293f7fba21808be9/packages/keychain/src/components/bridge/TransferButton.tsx#L49