### PR TITLE
Fix expandable footer height when it's open

### DIFF
--- a/packages/keychain/src/components/Container/index.tsx
+++ b/packages/keychain/src/components/Container/index.tsx
@@ -46,7 +46,8 @@ export function Container({
         w="full"
         h={10}
         borderTopWidth={1}
-        borderTopColor="solid.spacer"
+        borderColor="solid.tertiary"
+
         alignItems="center"
         justify="center"
       >

--- a/packages/keychain/src/components/PortalFooter/index.tsx
+++ b/packages/keychain/src/components/PortalFooter/index.tsx
@@ -41,10 +41,12 @@ export function PortalFooter({
       left={0}
       bg="solid.bg"
       h="auto"
-      minH={isOpen ? 478 : 0}
+      minH={isOpen ? "calc(100vh - 164px)" : 0}
       transition="all 0.40s ease-out"
       p={4}
       pt={0}
+      borderTopWidth={1}
+      borderColor="solid.tertiary"
     >
       {isExpandable && (
         <Box // mimic top border
@@ -78,12 +80,9 @@ export function PortalFooter({
 
       <VStack
         pt={6}
-        pb={isExpandable ? 4 : undefined}
         align="stretch"
         w="full"
         h="full"
-        borderTopWidth={1}
-        borderColor="solid.tertiary"
         overflowY={isOpen ? "scroll" : "hidden"}
         css={{
           "::-webkit-scrollbar": {
@@ -139,4 +138,4 @@ export function PortalFooter({
   );
 }
 
-export const PORTAL_FOOTER_MIN_HEIGHT = 212;
+export const PORTAL_FOOTER_MIN_HEIGHT = 252;


### PR DESCRIPTION
The expand button should align with portal banner logo when expand.


https://github.com/cartridge-gg/cartridge/assets/8398372/13a3dcfe-96fb-44da-9e7d-2444c495070f

