### PR TITLE
Request storage and drop cookie on auth

### DIFF
--- a/examples/starknet-react-next/src/components/StarknetProvider.tsx
+++ b/examples/starknet-react-next/src/components/StarknetProvider.tsx
@@ -27,14 +27,14 @@ export function StarknetProvider({ children }: PropsWithChildren) {
 
 const url =
   !process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL ||
-    process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL.split(".")[0] ===
+  process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL.split(".")[0] ===
     "cartridge-starknet-react-next"
     ? process.env.XFRAME_URL
     : "https://" +
-    (process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL ?? "").replace(
-      "cartridge-starknet-react-next",
-      "keychain",
-    );
+      (process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL ?? "").replace(
+        "cartridge-starknet-react-next",
+        "keychain",
+      );
 
 const connectors = [
   new CartridgeConnector(

--- a/packages/keychain/src/components/Auth/Authenticate.tsx
+++ b/packages/keychain/src/components/Auth/Authenticate.tsx
@@ -10,7 +10,7 @@ import {
 import { Container } from "../Container";
 import { PortalBanner } from "components/PortalBanner";
 import { PortalFooter } from "components/PortalFooter";
-import { dropCookie } from "./utils";
+import { requestStorageDropCookie } from "./utils";
 
 export function Authenticate({
   name,
@@ -26,7 +26,7 @@ export function Authenticate({
   const onAuth = useCallback(async () => {
     setIsLoading(true);
     try {
-      await dropCookie();
+      await requestStorageDropCookie();
 
       const credentials: Credentials = await onCreateBegin(
         decodeURIComponent(name),

--- a/packages/keychain/src/components/Auth/Authenticate.tsx
+++ b/packages/keychain/src/components/Auth/Authenticate.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState, useCallback, useMemo } from "react";
+import React, { useEffect, useState, useCallback, useMemo } from "react";
 import { Button } from "@chakra-ui/react";
 import { Unsupported } from "./Unsupported";
-import { Credentials, onCreateBegin, onCreateFinalize } from "hooks/account";
+import { doSignup } from "hooks/account";
 import {
   FaceIDDuoIcon,
   FingerprintDuoIcon,
@@ -12,12 +12,17 @@ import { PortalBanner } from "components/PortalBanner";
 import { PortalFooter } from "components/PortalFooter";
 import { requestStorageDropCookie } from "./utils";
 
+type UserAgent = "ios" | "android" | "other";
+type AuthAction = "signup" | "login";
+``;
 export function Authenticate({
   name,
-  onComplete,
+  action,
+  onSuccess,
 }: {
   name: string;
-  onComplete: () => void;
+  action: AuthAction;
+  onSuccess: () => void;
 }) {
   const [isLoading, setIsLoading] = useState(false);
   const [userAgent, setUserAgent] = useState<UserAgent>("other");
@@ -25,23 +30,27 @@ export function Authenticate({
 
   const onAuth = useCallback(async () => {
     setIsLoading(true);
+
+    await requestStorageDropCookie();
+
     try {
-      await requestStorageDropCookie();
+      switch (action) {
+        case "signup":
+          await doSignup(decodeURIComponent(name));
+          break;
+        case "login":
+          break;
+        default:
+          throw new Error(`Unsupported action ${action}`);
+      }
 
-      const credentials: Credentials = await onCreateBegin(
-        decodeURIComponent(name),
-      );
-      await onCreateFinalize(credentials);
-
-      setTimeout(() => {
-        onComplete();
-      }, 2000);
+      onSuccess();
     } catch (e) {
       console.error(e);
       setIsLoading(false);
       throw e;
     }
-  }, [onComplete, name]);
+  }, [onSuccess, action, name]);
 
   useEffect(() => {
     const userAgent = window.navigator.userAgent;
@@ -73,23 +82,25 @@ export function Authenticate({
     return <Unsupported message={unsupportedMessage} />;
   }
 
+  const title =
+    action === "signup" ? "Authenticate Yourself" : "Hello from Cartridge!";
+  const description =
+    action === "signup" ? (
+      <>
+        You will now be asked to authenticate yourself.
+        <br />
+        Note: this experience varies from browser to browser.
+      </>
+    ) : (
+      <>Please click continue.</>
+    );
   return (
     <>
       <Container hideAccount>
         <PortalBanner
-          Icon={Icon}
-          title={isLoading ? "Creating Your Account" : "Authenticate Yourself"}
-          description={
-            isLoading ? (
-              <>This window will close automatically</>
-            ) : (
-              <>
-                You will now be asked to authenticate yourself.
-                <br />
-                Note: this experience varies from browser to browser.
-              </>
-            )
-          }
+          Icon={action === "signup" && Icon}
+          title={title}
+          description={description}
         />
 
         <PortalFooter>
@@ -101,5 +112,3 @@ export function Authenticate({
     </>
   );
 }
-
-type UserAgent = "ios" | "android" | "other";

--- a/packages/keychain/src/components/Auth/Login.tsx
+++ b/packages/keychain/src/components/Auth/Login.tsx
@@ -7,10 +7,7 @@ import {
   Formik,
   useFormikContext,
 } from "formik";
-import {
-  PortalBanner,
-  PortalFooter,
-} from "components";
+import { PortalBanner, PortalFooter } from "components";
 import { useCallback, useState } from "react";
 import Controller from "utils/controller";
 import { FormValues, LoginProps } from "./types";
@@ -19,7 +16,11 @@ import { beginLogin, onLoginFinalize } from "hooks/account";
 import { WebauthnSigner } from "utils/webauthn";
 import base64url from "base64url";
 import { useClearField } from "./hooks";
-import { fetchAccount, validateUsernameFor } from "./utils";
+import {
+  requestStorageDropCookie,
+  fetchAccount,
+  validateUsernameFor,
+} from "./utils";
 import { RegistrationLink } from "./RegistrationLink";
 import { useControllerTheme } from "hooks/theme";
 
@@ -50,6 +51,9 @@ export function Login({
 
       try {
         log({ type: "webauthn_login", address });
+        console.log("requesting storage drop cookie");
+        await requestStorageDropCookie();
+        console.log("requested storage drop cookie");
 
         const { data: beginLoginData } = await beginLogin(values.username);
         const signer = new WebauthnSigner(credentialId, publicKey);
@@ -124,7 +128,11 @@ function Form({
   return (
     <FormikForm style={{ width: "100%" }}>
       <PortalBanner
-        title={theme.id === "cartridge" ? "Play with Cartridge Controller" : `Play ${theme.name}`}
+        title={
+          theme.id === "cartridge"
+            ? "Play with Cartridge Controller"
+            : `Play ${theme.name}`
+        }
         description="Enter your Controller username"
       />
 

--- a/packages/keychain/src/components/Auth/Login.tsx
+++ b/packages/keychain/src/components/Auth/Login.tsx
@@ -1,44 +1,33 @@
-import { Field, Loading } from "@cartridge/ui";
+import { Field } from "@cartridge/ui";
 import { VStack, Button } from "@chakra-ui/react";
 import { Container } from "../Container";
-import {
-  Form as FormikForm,
-  Field as FormikField,
-  Formik,
-  useFormikContext,
-} from "formik";
+import { Form as FormikForm, Field as FormikField, Formik } from "formik";
 import { PortalBanner, PortalFooter } from "components";
 import { useCallback, useState } from "react";
 import Controller from "utils/controller";
 import { FormValues, LoginProps } from "./types";
 import { useAnalytics } from "hooks/analytics";
-import { beginLogin, onLoginFinalize } from "hooks/account";
-import { WebauthnSigner } from "utils/webauthn";
-import base64url from "base64url";
-import { useClearField } from "./hooks";
-import {
-  requestStorageDropCookie,
-  fetchAccount,
-  validateUsernameFor,
-} from "./utils";
+import { fetchAccount, validateUsernameFor } from "./utils";
 import { RegistrationLink } from "./RegistrationLink";
 import { useControllerTheme } from "hooks/theme";
+import { PopupCenter } from "utils/url";
+import { doLogin } from "hooks/account";
 
 export function Login({
   prefilledName = "",
   chainId,
   context,
   isSlot,
-  onController,
-  onComplete,
+  onSuccess,
   onSignup,
 }: LoginProps) {
-  const [isLoggingIn, setIsLoggingIn] = useState(false);
   const { event: log } = useAnalytics();
+  const theme = useControllerTheme();
+  const [isLoading, setIsLoading] = useState(false);
 
   const onSubmit = useCallback(
     async (values: FormValues) => {
-      setIsLoggingIn(true);
+      setIsLoading(true);
 
       const {
         account: {
@@ -49,44 +38,22 @@ export function Login({
         },
       } = await fetchAccount(values.username);
 
-      try {
-        log({ type: "webauthn_login", address });
-        console.log("requesting storage drop cookie");
-        await requestStorageDropCookie();
-        console.log("requested storage drop cookie");
+      log({ type: "webauthn_login", address });
 
-        const { data: beginLoginData } = await beginLogin(values.username);
-        const signer = new WebauthnSigner(credentialId, publicKey);
-        const assertion = await signer.sign(
-          base64url.toBuffer(beginLoginData.beginLogin.publicKey.challenge),
-        );
-
-        const res = await onLoginFinalize(assertion);
-        if (!res.finalizeLogin) {
-          throw Error("login failed");
-        }
-
-        const controller = new Controller(address, publicKey, credentialId);
-
-        if (onController) {
-          await onController(controller);
-        }
-
-        if (onComplete) {
-          onComplete();
-        }
-      } catch (err) {
-        setIsLoggingIn(false);
-        log({
-          type: "webauthn_login_error",
-          payload: {
-            error: err?.message,
-          },
-          address,
-        });
-      }
+      doLogin(values.username, credentialId, publicKey)
+        .then(() => onSuccess(new Controller(address, publicKey, credentialId)))
+        .catch((e) =>
+          log({
+            type: "webauthn_login_error",
+            payload: {
+              error: e?.message,
+            },
+            address,
+          }),
+        )
+        .finally(() => setIsLoading(false));
     },
-    [log, onComplete, onController],
+    [log, onSuccess],
   );
 
   return (
@@ -97,83 +64,77 @@ export function Login({
         validateOnChange={false}
         validateOnBlur={false}
       >
-        <Form
-          context={context}
-          isSlot={isSlot}
-          onSignup={onSignup}
-          isLoggingIn={isLoggingIn}
-        />
+        {(props) => (
+          <FormikForm style={{ width: "100%" }}>
+            <PortalBanner
+              title={
+                theme.id === "cartridge"
+                  ? "Play with Cartridge Controller"
+                  : `Play ${theme.name}`
+              }
+              description="Enter your Controller username"
+            />
+
+            <VStack align="stretch">
+              <FormikField
+                name="username"
+                placeholder="Username"
+                validate={validateUsernameFor("login")}
+              >
+                {({ field, meta }) => (
+                  <Field
+                    {...field}
+                    autoFocus
+                    placeholder="Username"
+                    touched={meta.touched}
+                    error={meta.error}
+                    container={{ mb: 6 }}
+                    isLoading={props.isValidating}
+                    isDisabled={isLoading}
+                  />
+                )}
+              </FormikField>
+            </VStack>
+
+            <PortalFooter
+              origin={context?.origin}
+              policies={context?.policies}
+              isSlot={isSlot}
+            >
+              <Button
+                type="submit"
+                colorScheme="colorful"
+                isLoading={isLoading}
+                onClick={async (ev) => {
+                  // Storage request must be done in onClick rather than onSubmit
+                  document.requestStorageAccess().catch((e) => {
+                    console.error(e);
+                    PopupCenter(
+                      `/authenticate?name=${encodeURIComponent(
+                        props.values.username,
+                      )}&action=login`,
+                      "Cartridge Login",
+                      480,
+                      640,
+                    );
+
+                    // Prevent onsubmit from firing
+                    ev.preventDefault();
+                  });
+                }}
+              >
+                Log in
+              </Button>
+              <RegistrationLink
+                description="Need a controller?"
+                onClick={() => onSignup(props.values.username)}
+              >
+                Sign up
+              </RegistrationLink>
+            </PortalFooter>
+          </FormikForm>
+        )}
       </Formik>
     </Container>
-  );
-}
-
-function Form({
-  context,
-  isSlot,
-  onSignup: onSignupProp,
-  isLoggingIn,
-}: Pick<LoginProps, "context" | "isSlot" | "onSignup"> & {
-  isLoggingIn: boolean;
-}) {
-  const theme = useControllerTheme();
-  const { values, isValidating } = useFormikContext<FormValues>();
-
-  const onClearUsername = useClearField("username");
-
-  const onSignup = useCallback(() => {
-    onSignupProp(values.username);
-  }, [onSignupProp, values]);
-
-  return (
-    <FormikForm style={{ width: "100%" }}>
-      <PortalBanner
-        title={
-          theme.id === "cartridge"
-            ? "Play with Cartridge Controller"
-            : `Play ${theme.name}`
-        }
-        description="Enter your Controller username"
-      />
-
-      <VStack align="stretch">
-        <FormikField
-          name="username"
-          placeholder="Username"
-          validate={validateUsernameFor("login")}
-        >
-          {({ field, meta }) => (
-            <Field
-              {...field}
-              autoFocus
-              placeholder="Username"
-              touched={meta.touched}
-              error={meta.error}
-              onClear={onClearUsername}
-              container={{ mb: 6 }}
-              isLoading={isValidating}
-            />
-          )}
-        </FormikField>
-      </VStack>
-
-      <PortalFooter
-        origin={context?.origin}
-        policies={context?.policies}
-        isSlot={isSlot}
-      >
-        <Button
-          type="submit"
-          colorScheme="colorful"
-          isLoading={isLoggingIn}
-          spinner={<Loading color="solid.primary" />}
-        >
-          log in
-        </Button>
-        <RegistrationLink description="Need a controller?" onClick={onSignup}>
-          Sign up
-        </RegistrationLink>
-      </PortalFooter>
-    </FormikForm>
   );
 }

--- a/packages/keychain/src/components/Auth/types.ts
+++ b/packages/keychain/src/components/Auth/types.ts
@@ -12,13 +12,10 @@ type AuthBaseProps = {
   prefilledName?: string;
   context?: Connect;
   isSlot?: boolean;
-  onController?: (controller: Controller) => void | Promise<void>;
-  onComplete?: () => void;
-  // onCancel?: () => void;
+  onSuccess: (controller: Controller) => void;
 };
 
 export type SignupProps = AuthBaseProps & {
-  starterPackId?: string;
   onLogin: (username: string) => void;
 };
 

--- a/packages/keychain/src/components/Auth/utils.ts
+++ b/packages/keychain/src/components/Auth/utils.ts
@@ -82,11 +82,8 @@ export function fetchAccount(username: string) {
 // Cross-site cookies access will eventually be disabled on all major browsers, use storage access api
 // for now, then migrate to CHIPS when golang 1.23 with support for partitioned cookies is released.
 // https://developers.google.com/privacy-sandbox/3pcd
-export async function dropCookie() {
-  const ok = await document.hasStorageAccess();
-  if (!ok) {
-    await document.requestStorageAccess();
-  }
+export async function requestStorageDropCookie() {
+  await document.requestStorageAccess();
 
   if (process.env.NODE_ENV === "development") {
     document.cookie = "visited=true; path=/";

--- a/packages/keychain/src/components/Auth/utils.ts
+++ b/packages/keychain/src/components/Auth/utils.ts
@@ -5,17 +5,6 @@ import {
 } from "generated/graphql";
 import { fetchData } from "hooks/fetcher";
 
-// export function validateUsername(val: string) {
-//   if (!val) {
-//     return "Username required";
-//   } else if (val.length < 3) {
-//     return "Username must be at least 3 characters";
-//   } else if (val.split(" ").length > 1) {
-//     return "Username cannot contain spaces";
-//   }
-// }
-//
-
 export function validateUsernameFor(type: "signup" | "login") {
   return async (val: string) => {
     if (!val) {
@@ -53,26 +42,6 @@ export function validateUsernameFor(type: "signup" | "login") {
   };
 }
 
-// async function validateUsername(val: string) {
-//   if (!val) {
-//     return "Username required";
-//   } else if (val.length < 3) {
-//     return "Username must be at least 3 characters";
-//   } else if (val.split(" ").length > 1) {
-//     return "Username cannot contain spaces";
-//   }
-
-//   try {
-//     await fetchAccount(val);
-//   } catch (error) {
-//     if ((error as Error).message === "ent: account not found") {
-//       return "Account not found";
-//     } else {
-//       return "An error occured.";
-//     }
-//   }
-// }
-
 export function fetchAccount(username: string) {
   return fetchData<AccountQuery, AccountQueryVariables>(AccountDocument, {
     id: username,
@@ -92,4 +61,8 @@ export async function requestStorageDropCookie() {
 
   document.cookie =
     "visited=true; domain=.cartridge.gg; path=/; samesite=none; secure";
+}
+
+export function isIframe() {
+  return typeof window !== "undefined" ? window.top !== window.self : false;
 }

--- a/packages/keychain/src/pages/authenticate.tsx
+++ b/packages/keychain/src/pages/authenticate.tsx
@@ -5,11 +5,13 @@ import { Authenticate as AuthComponent } from "components/Auth";
 // auth page used for externally embedded keychain
 const Authenticate: NextPage = () => {
   const router = useRouter();
-  const { name } = router.query as { name: string };
+  const { name, action } = router.query as { name: string; action: string };
+
   return (
     <AuthComponent
       name={decodeURIComponent(name)}
-      onComplete={() => {
+      action={decodeURIComponent(action) as "login" | "signup"}
+      onSuccess={() => {
         if (window.opener) {
           return window.close();
         }

--- a/packages/keychain/src/pages/cookie.tsx
+++ b/packages/keychain/src/pages/cookie.tsx
@@ -1,12 +1,12 @@
 import { Button } from "@chakra-ui/react";
-import { dropCookie } from "components/Auth/utils";
+import { requestStorageDropCookie } from "components/Auth/utils";
 import type { NextPage } from "next";
 
 const CookieDropper: NextPage = () => {
   return (
     <Button
       onClick={() => {
-        dropCookie()
+        requestStorageDropCookie()
           .then(() => {
             console.log("dropped it like its hot!");
           })

--- a/packages/keychain/src/pages/index.tsx
+++ b/packages/keychain/src/pages/index.tsx
@@ -286,7 +286,7 @@ const Index: NextPage = () => {
               setPrefilledUsername(username);
               setShowSignup(false);
             }}
-            onController={setController}
+            onSuccess={setController}
             context={context as Connect}
           />
         ) : (
@@ -296,7 +296,7 @@ const Index: NextPage = () => {
               setPrefilledUsername(username);
               setShowSignup(true);
             }}
-            onController={setController}
+            onSuccess={setController}
             context={context as Connect}
           />
         )}

--- a/packages/keychain/src/pages/login.tsx
+++ b/packages/keychain/src/pages/login.tsx
@@ -10,7 +10,7 @@ const Login: NextPage = () => {
     <LoginComponent
       chainId={constants.StarknetChainId.SN_SEPOLIA}
       onSignup={() => router.push({ pathname: "/signup", query: router.query })}
-      onComplete={() => {
+      onSuccess={async () => {
         if (starterPackId) {
           router.replace(
             `${process.env.NEXT_PUBLIC_ADMIN_URL}/claim/${starterPackId}`,

--- a/packages/keychain/src/pages/signup/index.tsx
+++ b/packages/keychain/src/pages/signup/index.tsx
@@ -5,7 +5,6 @@ import { useController } from "hooks/controller";
 
 const Signup: NextPage = () => {
   const router = useRouter();
-  const { sp: starterPackId } = router.query as { sp: string };
   const [controller] = useController();
 
   if (controller) {
@@ -14,9 +13,8 @@ const Signup: NextPage = () => {
 
   return (
     <SignupComponent
-      starterPackId={starterPackId}
       onLogin={() => router.push({ pathname: "/login", query: router.query })}
-      onComplete={() => {
+      onSuccess={() => {
         router.replace(`${process.env.NEXT_PUBLIC_ADMIN_URL}/profile`);
       }}
     />

--- a/packages/keychain/src/pages/slot/auth/index.tsx
+++ b/packages/keychain/src/pages/slot/auth/index.tsx
@@ -40,7 +40,7 @@ const Auth: NextPage = () => {
             setPrefilledUsername(username);
             setShowSignup(false);
           }}
-          onController={setController}
+          onSuccess={setController}
           isSlot
         />
       ) : (
@@ -50,7 +50,7 @@ const Auth: NextPage = () => {
             setPrefilledUsername(username);
             setShowSignup(true);
           }}
-          onController={setController}
+          onSuccess={setController}
           isSlot
         />
       )}


### PR DESCRIPTION
Fixes logging in on Safari, currently we use Storage Access API to enable cookies which is needed for our webauthn login flow. However, the UX is not ideal as we have to drop a cookie in a popup first (per Storage Access requirement) and then Safari will prompt user to allow cookie access. https://webkit.org/blog/11545/updates-to-the-storage-access-api/

Once CHIPS (cookies having independent partition state) is implemented in our backend it should resolve this poor UX. 