### PR TITLE
Reduce est fee multiplier

### DIFF
--- a/packages/keychain/src/utils/account.ts
+++ b/packages/keychain/src/utils/account.ts
@@ -28,7 +28,7 @@ import Storage from "./storage";
 import { CartridgeAccount } from "@cartridge/account-wasm";
 import { Session } from "@cartridge/controller";
 
-const EST_FEE_MULTIPLIER = 100n;
+const EST_FEE_MULTIPLIER = 2n;
 
 export enum Status {
   COUNTERFACTUAL = "COUNTERFACTUAL",


### PR DESCRIPTION
Sepolia fee estimate fluctuates way too much, now this is causing fee estimation to be more than balance. Reducing the multiplier here and let dapp set it if necessary. 