### PR TITLE
Fix incorrect update session request

### DIFF
--- a/examples/next/src/components/Transfer.tsx
+++ b/examples/next/src/components/Transfer.tsx
@@ -29,7 +29,7 @@ export const Transfer = () => {
           },
           {
             contractAddress: STRK_CONTRACT_ADDRESS,
-            entrypoint: "increaseAllowance",
+            entrypoint: "transfer",
             calldata: [account?.address, amount, "0x0"],
           },
         ])

--- a/packages/keychain/src/components/transaction/ConfirmTransaction.stories.tsx
+++ b/packages/keychain/src/components/transaction/ConfirmTransaction.stories.tsx
@@ -2,7 +2,6 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import { ConfirmTransaction } from "./ConfirmTransaction";
 import { ETH_CONTRACT_ADDRESS } from "@cartridge/ui/utils";
-import { VerifiableControllerTheme } from "@/components/provider/connection";
 
 const meta = {
   component: ConfirmTransaction,
@@ -14,6 +13,7 @@ const meta = {
         }),
         hasSession: () => true,
         session: () => true,
+        isRequestedSession: () => Promise.resolve(true),
       },
       context: {
         origin: "http://localhost:6001",
@@ -48,28 +48,21 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  args: {
+    onComplete: (transaction_hash: string) => {
+      console.log("Transaction completed:", transaction_hash);
+    },
+  },
+};
 
 export const WithTheme: Story = {
   parameters: {
     preset: "eternum",
   },
   args: {
-    theme: {
-      name: "Eternum",
-    } as VerifiableControllerTheme,
-    usernameField: {
-      value: "",
-      error: undefined,
+    onComplete: (transaction_hash: string) => {
+      console.log("Transaction completed:", transaction_hash);
     },
-    validation: {
-      status: "valid",
-      exists: false,
-    },
-    isLoading: false,
-    onUsernameChange: () => {},
-    onUsernameFocus: () => {},
-    onUsernameClear: () => {},
-    onSubmit: () => {},
   },
 };


### PR DESCRIPTION
Execute context was using stale session detection variable, so after login if transaction call was not part of policies it would request user to unnecessarily update session instead of showing transaction confirmation modal.



