### PR TITLE
fix: improve multicall error parsing to extract meaningful messages

### DIFF
--- a/packages/keychain/src/utils/errors.ts
+++ b/packages/keychain/src/utils/errors.ts
@@ -552,7 +552,7 @@ export function parseExecutionError(
       } else {
         // Try to find a meaningful error message instead of raw hex or technical errors
         const meaningfulError = lastError.find(
-          (err) =>
+          (err: string) =>
             !err.match(/^0x[0-9a-fA-F]+$/) &&
             err !== "ENTRYPOINT_FAILED" &&
             err !== "0x0" &&


### PR DESCRIPTION
## Summary
- Enhanced error parsing to correctly extract user-facing error messages from multicall failures
- Improved filtering to exclude hex separators and validate hex patterns more strictly  
- Updated default error handling to show "Execution error" instead of raw stack traces

## Test plan
- [x] Added test case for "Already joined in\!" error pattern
- [x] All existing tests pass
- [x] Linting and formatting pass

🤖 Generated with [Claude Code](https://claude.ai/code)