### PR TITLE
fix: resolve inventory assets disappearing after tab navigation

### DIFF
--- a/packages/keychain/src/hooks/token.ts
+++ b/packages/keychain/src/hooks/token.ts
@@ -295,15 +295,23 @@ export function useTokens(accountAddress?: string): UseTokensResponse {
     return newData;
   }, [rpcData, toriiTokens, countervalues]);
 
-  // Determine combined status - only show loading if both sources are loading
+  // Determine combined status based on actual data availability
   const combinedStatus = useMemo(() => {
-    // If we have tokens from either source, consider it success
-    if (tokens.tokens.length > 0) return "success";
-    // Only show loading if torii is actively loading
-    if (toriiStatus === "loading") return "loading";
-    // Default to success to prevent empty state flickering
+    // If torii is still loading on initial mount, show loading
+    if (
+      toriiStatus === "loading" &&
+      toriiTokens.length === 0 &&
+      rpcData.length === 0
+    ) {
+      return "loading";
+    }
+    // If torii had an error, return error
+    if (toriiStatus === "error") {
+      return "error";
+    }
+    // Otherwise we have successfully loaded (even if empty)
     return "success";
-  }, [tokens.tokens.length, toriiStatus]);
+  }, [toriiStatus, toriiTokens.length, rpcData.length]);
 
   return { tokens: tokens.tokens, credits, status: combinedStatus };
 }


### PR DESCRIPTION
## Summary

Fixes a race condition in the `useTokens` hook where assets would disappear when navigating between tabs in the keychain inventory. Previously, only credits would remain visible after switching to another tab and back to inventory.

## Root Cause

The issue was caused by a race condition where:
1. When navigating between tabs, the component remounts and `toriiStatus` temporarily becomes "loading"
2. The original logic was filtering out token addresses during loading state (`if (toriiStatus === "loading") return []`)
3. This caused RPC data fetching to be skipped, leaving only credits (which are fetched separately) visible

## Changes

- **Remove toriiStatus dependency** from contractAddress filtering logic to prevent empty arrays during loading
- **Improve status determination** to consider both torii and RPC data sources instead of only relying on toriiStatus
- **Prevent empty state flickering** during navigation by defaulting to "success" when tokens are available

## Test plan

- [ ] Navigate to inventory tab and verify assets are displayed correctly
- [ ] Navigate to achievements/leaderboard/activity tabs
- [ ] Navigate back to inventory tab and verify all assets (not just credits) are still displayed
- [ ] Repeat navigation multiple times to ensure consistency

🤖 Generated with [Claude Code](https://claude.ai/code)