### PR TITLE
fix: return RPC spec compliant USER_REFUSED_OP error on transaction rejection

### DIFF
--- a/packages/controller/src/types.ts
+++ b/packages/controller/src/types.ts
@@ -48,6 +48,12 @@ export enum ResponseCodes {
   USER_INTERACTION_REQUIRED = "USER_INTERACTION_REQUIRED",
 }
 
+// RPC spec compliant error codes
+export const USER_REFUSED_OP = {
+  code: 113,
+  message: "An error occurred (USER_REFUSED_OP)",
+} as const;
+
 export type ConnectError = {
   code: ResponseCodes;
   message: string;

--- a/packages/keychain/src/components/Execute.tsx
+++ b/packages/keychain/src/components/Execute.tsx
@@ -1,7 +1,11 @@
 import { useConnection } from "@/hooks/connection";
 import { cleanupCallbacks, getCallbacks } from "@/utils/connection/callbacks";
 import { ExecuteParams } from "@/utils/connection/execute";
-import { ConnectError, ResponseCodes } from "@cartridge/controller";
+import {
+  ConnectError,
+  ResponseCodes,
+  USER_REFUSED_OP,
+} from "@cartridge/controller";
 import { useEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { InvokeFunctionResponse } from "starknet";
@@ -64,14 +68,8 @@ export function Execute() {
       return;
     }
     setOnModalClose(() => {
-      params.resolve!({
-        code: ResponseCodes.ERROR,
-        message: "User canceled",
-        error: {
-          message: "User canceled",
-          code: 0,
-        },
-      });
+      // Return RPC spec compliant USER_REFUSED_OP error
+      params.reject!(USER_REFUSED_OP);
     });
   }, [params?.reject, params?.resolve, setOnModalClose]);
 

--- a/packages/keychain/src/components/home.tsx
+++ b/packages/keychain/src/components/home.tsx
@@ -1,6 +1,6 @@
 import { Signature } from "starknet";
 import { useEffect, useCallback } from "react";
-import { ResponseCodes } from "@cartridge/controller";
+import { ResponseCodes, USER_REFUSED_OP } from "@cartridge/controller";
 import { useConnection } from "@/hooks/connection";
 import { DeployCtx, SignMessageCtx, ConnectCtx } from "@/utils/connection";
 import { CreateController, CreateSession, Upgrade } from "./connect";
@@ -120,12 +120,7 @@ export function Home() {
               <SignMessage
                 typedData={ctx.typedData}
                 onSign={(sig: Signature) => context.resolve(sig)}
-                onCancel={() =>
-                  ctx.resolve({
-                    code: ResponseCodes.CANCELED,
-                    message: "Canceled",
-                  })
-                }
+                onCancel={() => ctx.reject(USER_REFUSED_OP)}
               />
             );
           }
@@ -133,14 +128,7 @@ export function Home() {
           case "deploy": {
             const ctx = context as DeployCtx;
             return (
-              <DeployController
-                onClose={() =>
-                  ctx.resolve({
-                    code: ResponseCodes.CANCELED,
-                    message: "Canceled",
-                  })
-                }
-              />
+              <DeployController onClose={() => ctx.reject(USER_REFUSED_OP)} />
             );
           }
           default:


### PR DESCRIPTION
## Summary
- Implement proper USER_REFUSED_OP error handling for transaction rejections
- Ensure compliance with StarkNet RPC spec for wallet API errors
- Return standardized error with code 113 when users reject/cancel transactions

## Changes
- Added USER_REFUSED_OP constant with code 113 per RPC spec
- Updated Execute component to reject with USER_REFUSED_OP on modal close
- Updated SignMessage to reject with USER_REFUSED_OP on cancel
- Updated DeployController to reject with USER_REFUSED_OP on close

## Context
Previously, when users rejected transactions by closing the modal or clicking cancel, the keychain would return inconsistent error responses. This change ensures that client applications receive the standardized USER_REFUSED_OP error (code 113) as specified in the StarkNet wallet API specification.

## Test Plan
- [x] Build passes without errors
- [x] Linting passes
- [ ] Test transaction rejection returns USER_REFUSED_OP error
- [ ] Test sign message cancellation returns USER_REFUSED_OP error
- [ ] Test deploy cancellation returns USER_REFUSED_OP error

🤖 Generated with [Claude Code](https://claude.ai/code)