### PR TITLE
feat: add disconnect redirect url for session provider

### DIFF
--- a/examples/next/src/components/providers/StarknetProvider.tsx
+++ b/examples/next/src/components/providers/StarknetProvider.tsx
@@ -208,6 +208,7 @@ const session = new SessionConnector({
   rpc: process.env.NEXT_PUBLIC_RPC_MAINNET!,
   chainId: constants.StarknetChainId.SN_MAIN,
   redirectUrl: typeof window !== "undefined" ? window.location.origin : "",
+  disconnectRedirectUrl: "whatsapp://",
   keychainUrl: getKeychainUrl(),
   apiUrl: process.env.NEXT_PUBLIC_CARTRIDGE_API_URL,
 });

--- a/packages/controller/src/session/provider.ts
+++ b/packages/controller/src/session/provider.ts
@@ -29,6 +29,7 @@ export type SessionOptions = {
   chainId: string;
   policies: SessionPolicies;
   redirectUrl: string;
+  disconnectRedirectUrl?: string;
   keychainUrl?: string;
   apiUrl?: string;
 };
@@ -41,6 +42,7 @@ export default class SessionProvider extends BaseProvider {
   protected _rpcUrl: string;
   protected _username?: string;
   protected _redirectUrl: string;
+  protected _disconnectRedirectUrl?: string;
   protected _policies: ParsedSessionPolicies;
   protected _keychainUrl: string;
   protected _apiUrl: string;
@@ -53,6 +55,7 @@ export default class SessionProvider extends BaseProvider {
     chainId,
     policies,
     redirectUrl,
+    disconnectRedirectUrl,
     keychainUrl,
     apiUrl,
   }: SessionOptions) {
@@ -83,6 +86,7 @@ export default class SessionProvider extends BaseProvider {
     this._rpcUrl = rpc;
     this._chainId = chainId;
     this._redirectUrl = redirectUrl;
+    this._disconnectRedirectUrl = disconnectRedirectUrl;
     this._keychainUrl = keychainUrl || KEYCHAIN_URL;
     this._apiUrl = apiUrl ?? API_URL;
 
@@ -251,7 +255,16 @@ export default class SessionProvider extends BaseProvider {
     localStorage.removeItem("sessionPolicies");
     this.account = undefined;
     this._username = undefined;
-    const openedWindow = window.open(`${this._keychainUrl}/disconnect`);
+    const disconnectUrl = new URL(`${this._keychainUrl}`);
+    disconnectUrl.pathname = "disconnect";
+
+    this._disconnectRedirectUrl &&
+      disconnectUrl.searchParams.append(
+        "redirect_url",
+        this._disconnectRedirectUrl,
+      );
+
+    const openedWindow = window.open(disconnectUrl);
     if (openedWindow === null) return Promise.resolve();
 
     const { resolve, promise } = Promise.withResolvers<void>();

--- a/packages/keychain/src/components/disconnect.tsx
+++ b/packages/keychain/src/components/disconnect.tsx
@@ -1,19 +1,27 @@
 import { useConnection } from "@/hooks/connection";
 import { HeaderInner, LayoutContent } from "@cartridge/ui";
 import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { Layout } from "./layout";
 
 export const Disconnect = () => {
+  const [urlSearchParams] = useSearchParams();
   const [isDone, setIsDone] = useState(false);
   const { controller } = useConnection();
 
   useEffect(() => {
     (async () => {
-      if (!controller) return;
+      if (!controller || isDone) return;
       await controller.disconnect();
       setIsDone(true);
+      if (urlSearchParams) {
+        const redirectUrl = urlSearchParams.get("redirect_url");
+        if (redirectUrl) {
+          window.location.href = redirectUrl;
+        }
+      }
     })();
-  }, [setIsDone, controller]);
+  }, [urlSearchParams, controller, isDone]);
 
   return (
     <Layout>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an optional disconnectRedirectUrl to session disconnect flow and updates keychain to redirect after logout; example app passes a sample redirect URL.
> 
> - **Session/Controller**:
>   - `SessionOptions` adds optional `disconnectRedirectUrl` and stored as `_disconnectRedirectUrl` in `SessionProvider`.
>   - `disconnect()` now builds `keychainUrl/disconnect` with optional `redirect_url` query param before opening the window.
> - **Keychain**:
>   - `components/disconnect.tsx` reads `redirect_url` from search params and navigates after `controller.disconnect()`; avoids duplicate calls using `isDone`.
> - **Example App**:
>   - `examples/next/.../StarknetProvider.tsx`: passes `disconnectRedirectUrl` (e.g., `"whatsapp://"`) to `SessionConnector`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48f670699cc57c0311184fc59cf198aecda6bab4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->