### PR TITLE
fix: loading controller

### DIFF
--- a/packages/keychain/src/components/provider/upgrade.tsx
+++ b/packages/keychain/src/components/provider/upgrade.tsx
@@ -147,13 +147,13 @@ export const UpgradeProvider: React.FC<UpgradeProviderProps> = ({
 
   // Load feature flag
   useEffect(() => {
-    if (!posthog || !controller) return;
+    if (!posthog || !controller || featureFlagLoaded) return;
     posthog.onFeatureFlag("controller-beta", (value: string | boolean) => {
       const newValue = typeof value === "boolean" ? value : value === "true";
       setIsBeta(newValue);
       setFeatureFlagLoaded(true);
     });
-  }, [posthog, controller]);
+  }, [posthog, controller, featureFlagLoaded]);
 
   // Sync controller class hash
   useEffect(() => {
@@ -198,12 +198,12 @@ export const UpgradeProvider: React.FC<UpgradeProviderProps> = ({
 
   // Recalculate upgrade availability when effective controller changes
   useEffect(() => {
-    if (current && featureFlagLoaded && controllerSynced) {
+    if (current && controllerSynced) {
       const { available: newAvailable } = determineUpgradePath(current, isBeta);
       setAvailable(newAvailable);
       setIsSynced(true);
     }
-  }, [current, featureFlagLoaded, controllerSynced, isBeta]);
+  }, [current, controllerSynced, isBeta]);
 
   useEffect(() => {
     if (!controller || !effectiveController) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prevents duplicate feature-flag registration and recalculates upgrade availability without waiting on the flag, updating effect guards and dependencies.
> 
> - **Provider `packages/keychain/src/components/provider/upgrade.tsx`**:
>   - **Feature flag loading**: Add `featureFlagLoaded` guard to avoid re-registering; include `featureFlagLoaded` in effect deps.
>   - **Upgrade availability**: Remove `featureFlagLoaded` check and dep; recompute when `current` and `controllerSynced` (and `isBeta`) change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd6974b173c62fc8b6edb9d92d4465cd7d34e7e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->