### PR TITLE
fix: starterpack crypto cost breakdown

### DIFF
--- a/packages/keychain/src/context/purchase.tsx
+++ b/packages/keychain/src/context/purchase.tsx
@@ -370,8 +370,7 @@ export const PurchaseProvider = ({
       setIsFetchingFees(true);
 
       const quote = await estimateStarterPackFees(swapInput);
-
-      const amountInCents = usdAmount * 100;
+      const amountInCents = usdAmount / 1e4;
       const cartridgeFees = amountInCents * CARTRIDGE_FEE;
       const layerswapFeesInCents = Number(quote.totalFees) / 1e4;
       const totalFeesInCents = cartridgeFees + layerswapFeesInCents;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Corrects `amountInCents` calculation in `fetchFees` to fix starter pack crypto cost breakdown and totals.
> 
> - **Fees calculation**:
>   - In `packages/keychain/src/context/purchase.tsx` (`fetchFees`), change `amountInCents` from `usdAmount * 100` to `usdAmount / 1e4`, affecting `cartridgeFees`, `totalFeesInCents`, `totalInCents`, and `costDetails`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c21c9a45588e0e2d73855f4dbaaeeac79a4ffec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->