### PR TITLE
fix: serialize BigInt values in execute URL parameters

### DIFF
--- a/packages/keychain/src/utils/connection/execute.ts
+++ b/packages/keychain/src/utils/connection/execute.ts
@@ -53,7 +53,11 @@ export function createExecuteUrl(
     error: options.error,
   };
 
-  const paramString = encodeURIComponent(JSON.stringify(executeParams));
+  const paramString = encodeURIComponent(
+    JSON.stringify(executeParams, (_, value) =>
+      typeof value === "bigint" ? value.toString() : value,
+    ),
+  );
   return `/execute?data=${paramString}`;
 }
 


### PR DESCRIPTION
## Summary
- Fixes BigInt serialization error in `createExecuteUrl` function
- Adds custom JSON replacer to convert BigInt values to strings
- Adds comprehensive test coverage for BigInt serialization

## Problem
The `createExecuteUrl` function failed when transactions contained BigInt values in calldata. This is common in StarkNet transactions for large token amounts (e.g., wei values for ETH transfers).

`JSON.stringify()` cannot natively serialize BigInt values and throws a TypeError.

## Solution
Added a JSON replacer function to `JSON.stringify` that converts BigInt values to strings:

```typescript
JSON.stringify(executeParams, (_, value) =>
  typeof value === "bigint" ? value.toString() : value,
)
```

## Test plan
- [x] Added test for BigInt values in calldata
- [x] Added test for mixed BigInt and string calldata
- [x] Verified existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Convert BigInt values to strings in createExecuteUrl params and add tests verifying BigInt and mixed calldata serialization.
> 
> - **Key change (packages/keychain/src/utils/connection/execute.ts)**
>   - Update `createExecuteUrl` to use `JSON.stringify` with a replacer converting `bigint` to string before `encodeURIComponent`, ensuring BigInt calldata serializes correctly.
> - **Tests (packages/keychain/src/utils/connection/execute.test.ts)**
>   - Add tests for serializing BigInt values in `transactions[].calldata`.
>   - Add tests for mixed BigInt and string calldata serialization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9f83a7d11273e8fa50079c66b2ce022d2e6457c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->