### PR TITLE
chore: downgrade @cartridge/controller-wasm to 0.3.10

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: 0.3.5
       version: 0.3.5
     '@cartridge/controller-wasm':
-      specifier: 0.3.12
-      version: 0.3.12
+      specifier: 0.3.10
+      version: 0.3.10
     '@cartridge/penpal':
       specifier: ^6.2.4
       version: 6.2.4
@@ -282,7 +282,7 @@ importers:
         version: link:../../packages/controller
       '@cartridge/controller-wasm':
         specifier: 'catalog:'
-        version: 0.3.12
+        version: 0.3.10
       starknet:
         specifier: 'catalog:'
         version: 8.5.4
@@ -393,7 +393,7 @@ importers:
     dependencies:
       '@cartridge/controller-wasm':
         specifier: 'catalog:'
-        version: 0.3.12
+        version: 0.3.10
       '@cartridge/penpal':
         specifier: 'catalog:'
         version: 6.2.4
@@ -521,7 +521,7 @@ importers:
         version: link:../controller
       '@cartridge/controller-wasm':
         specifier: 'catalog:'
-        version: 0.3.12
+        version: 0.3.10
       '@cartridge/penpal':
         specifier: 'catalog:'
         version: 6.2.4
@@ -1189,8 +1189,8 @@ packages:
   '@cartridge/controller-wasm@0.2.1':
     resolution: {integrity: sha512-uB0ffQEHAlu7+2E4Y/EoWUgbIYNrjMXks2FYHS8lg9ngaFwETvrUFI5Y+Pp71VQTthEnuwVcNKBqluO5TSPAug==}
 
-  '@cartridge/controller-wasm@0.3.12':
-    resolution: {integrity: sha512-CWAvc+nQFXd9KVcJQPUqUu7YUsHdYb4hmIbZlimQibDpZF6YLoODKkhAOUvXsP+VScinrEth4h4vDTcN+V5F7w==}
+  '@cartridge/controller-wasm@0.3.10':
+    resolution: {integrity: sha512-VUSlP1pRw4ulGa2fZbz9PdNkalhR+7T+d4jRlxQHAXf+S9cZz1mMIP64VOHOLdLZTXzO6ZEPy/cpzJPw53kKcg==}
 
   '@cartridge/controller@0.9.0':
     resolution: {integrity: sha512-bIikpiIR+N16MaEyxjab/AN3uDvOj+pdixWbJLSVqGpItpUq58AiQ0GFwPKXnpAwKVT66aqNrVBINSuMWemRhQ==}
@@ -11135,7 +11135,7 @@ snapshots:
 
   '@cartridge/controller-wasm@0.2.1': {}
 
-  '@cartridge/controller-wasm@0.3.12': {}
+  '@cartridge/controller-wasm@0.3.10': {}
 
   '@cartridge/controller@0.9.0(@metamask/sdk@0.32.1(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@solana/web3.js@1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10))(@types/react@18.3.20)(bufferutil@4.0.9)(encoding@0.1.13)(open@10.1.2)(react@18.3.1)(starknet@8.5.4)(starknetkit@2.10.4(bufferutil@4.0.9)(starknet@8.5.4)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.4))(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.4)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,7 @@ packages:
   - packages/*
 catalog:
   "@cartridge/arcade": "0.3.5"
-  "@cartridge/controller-wasm": "0.3.12"
+  "@cartridge/controller-wasm": "0.3.10"
   "@cartridge/penpal": "^6.2.4"
   "@cartridge/ui": "github:cartridge-gg/ui#1a53ba8"
   "@eslint/js": "^9.18.0"


### PR DESCRIPTION
## Summary
- Downgrades `@cartridge/controller-wasm` from version 0.3.12 to 0.3.10 in workspace catalog
- Updates associated lock file

## Test plan
- [ ] Verify build passes with downgraded version
- [ ] Check that functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Downgrades `@cartridge/controller-wasm` from 0.3.12 to 0.3.10 across the workspace catalog and lockfile entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a49b87f9b577d8525bc70b2c615b424af06d81f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->