### PR TITLE
Change default chain from Sepolia to mainnet in keychain

### DIFF
--- a/packages/keychain/src/hooks/connection.ts
+++ b/packages/keychain/src/hooks/connection.ts
@@ -178,7 +178,7 @@ export function useConnectionValue() {
   const [context, setContext] = useState<ConnectionCtx>();
   const [origin, setOrigin] = useState<string>(window.location.origin);
   const [rpcUrl, setRpcUrl] = useState<string>(
-    import.meta.env.VITE_RPC_SEPOLIA,
+    import.meta.env.VITE_RPC_MAINNET,
   );
   const [policies, setPolicies] = useState<ParsedSessionPolicies>();
   const [verified, setVerified] = useState<boolean>(false);


### PR DESCRIPTION
## Summary
- Changes the default RPC URL in the keychain connection hook from Sepolia to mainnet

## Changes
- Updated `packages/keychain/src/hooks/connection.ts` to use `VITE_RPC_MAINNET` instead of `VITE_RPC_SEPOLIA` as the default RPC URL

## Test plan
- [x] Ran controller package tests - all pass
- [x] Ran linting and formatting - all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Change default RPC URL in `packages/keychain/src/hooks/connection.ts` (`useConnectionValue`) from `VITE_RPC_SEPOLIA` to `VITE_RPC_MAINNET`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 585ad852f17fbf440eebc38bd04dd7dc91cdc2d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->