### PR TITLE
fix: check collection button

### DIFF
--- a/packages/keychain/src/components/purchasenew/starterpack/starterpack.tsx
+++ b/packages/keychain/src/components/purchasenew/starterpack/starterpack.tsx
@@ -150,16 +150,6 @@ export function StarterPackInner({
             mintAllowance={mintAllowance}
             starterpackItems={starterpackItems}
           />
-          {acquisitionType === StarterpackAcquisitionType.Claimed && !error && (
-            <Card>
-              <CardContent
-                className="flex flex-row justify-center items-center text-foreground-300 text-sm cursor-pointer h-[40px]"
-                onClick={() => navigate("/purchase/starterpack/collections")}
-              >
-                View Eligible Collections
-              </CardContent>
-            </Card>
-          )}
         </div>
       </LayoutContent>
       <LayoutFooter>
@@ -168,6 +158,16 @@ export function StarterPackInner({
         ) : acquisitionType === StarterpackAcquisitionType.Paid ? (
           <CostBreakdown rails="stripe" costDetails={price} />
         ) : null}
+        {acquisitionType === StarterpackAcquisitionType.Claimed && !error && (
+          <Card>
+            <CardContent
+              className="flex flex-row justify-center items-center text-foreground-300 text-sm cursor-pointer h-[40px]"
+              onClick={() => navigate("/purchase/starterpack/collections")}
+            >
+              View Eligible Collections
+            </CardContent>
+          </Card>
+        )}
         <Button onClick={onProceed} disabled={!!error || supply === 0}>
           {acquisitionType === StarterpackAcquisitionType.Paid
             ? "Purchase"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Relocates the "View Eligible Collections" card to the footer for claimed starterpacks, shown only when there’s no error.
> 
> - **Starterpack UI**
>   - **Action placement**: Move `"View Eligible Collections"` card from `LayoutContent` to `LayoutFooter`.
>   - **Visibility**: Render only when `acquisitionType === StarterpackAcquisitionType.Claimed` and no `error` is present.
>   - **Navigation**: Clicking still routes to `/purchase/starterpack/collections`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08672946da251f9e17bdb88b2608001159c81d2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->