### PR TITLE
fix: refresh starterpack data by unmounting purchase context

### DIFF
--- a/packages/keychain/src/components/app.tsx
+++ b/packages/keychain/src/components/app.tsx
@@ -48,6 +48,7 @@ import { PurchaseType } from "@cartridge/ui/utils/api/cartridge";
 import { ChooseNetwork } from "./purchasenew/wallet/network";
 import { Claim } from "./purchasenew/claim/claim";
 import { Collections } from "./purchasenew/starterpack/collections";
+import { PurchaseProvider } from "@/context";
 
 export function App() {
   const { navigate } = useNavigation();
@@ -67,7 +68,14 @@ export function App() {
         <Route path="success" element={<Success />} />
         <Route path="failure" element={<Failure />} />
         <Route path="pending" element={<Pending />} />
-        <Route path="/purchase" element={<Outlet />}>
+        <Route
+          path="/purchase"
+          element={
+            <PurchaseProvider>
+              <Outlet />
+            </PurchaseProvider>
+          }
+        >
           <Route
             path="credits"
             element={<Purchase type={PurchaseType.Credits} />}

--- a/packages/keychain/src/main.tsx
+++ b/packages/keychain/src/main.tsx
@@ -7,7 +7,6 @@ import { NavigationProvider } from "@/context/navigation";
 import { BrowserRouter } from "react-router-dom";
 import "./index.css";
 import Controller from "./utils/controller";
-import { PurchaseProvider } from "./context";
 
 // Controller type is already declared in vite-env.d.ts
 
@@ -19,9 +18,7 @@ async function bootstrap() {
       <BrowserRouter>
         <NavigationProvider>
           <Provider>
-            <PurchaseProvider>
-              <App />
-            </PurchaseProvider>
+            <App />
           </Provider>
         </NavigationProvider>
         <SonnerToaster position="bottom-right" />


### PR DESCRIPTION
Move PurchaseProvider from root to purchase routes wrapper. This ensures the provider and all its state (including starterpack data) is unmounted when navigating away from purchase routes, automatically refreshing data on next visit.

Changes:
- Wrap /purchase routes with PurchaseProvider
- Remove PurchaseProvider from main.tsx root

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Move `PurchaseProvider` from root to wrap only `/purchase` routes, ensuring its state unmounts when leaving and data refreshes on return.
> 
> - **Routing**:
>   - Wrap `/purchase` route group in `packages/keychain/src/components/app.tsx` with `PurchaseProvider` to localize purchase state.
> - **Bootstrap**:
>   - Remove `PurchaseProvider` wrapper from `packages/keychain/src/main.tsx`, eliminating global purchase context.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06a3d35db0ba9cadb98d4211dc680f930f6ae111. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->