### PR TITLE
fix(keychain/turnkey): update error around OIDC token management

### DIFF
--- a/packages/keychain/src/wallets/social/turnkey.ts
+++ b/packages/keychain/src/wallets/social/turnkey.ts
@@ -247,9 +247,6 @@ export class TurnkeyWallet {
 
     const tokenClaims = await auth0Client.getIdTokenClaims();
     const oidcTokenString = await getAuth0OidcToken(tokenClaims, nonce);
-    if (!oidcTokenString) {
-      throw new Error("No oidcTokenString");
-    }
 
     const subOrganizationId = this.username
       ? await getOrCreateTurnkeySuborg(

--- a/packages/keychain/src/wallets/social/turnkey_utils.ts
+++ b/packages/keychain/src/wallets/social/turnkey_utils.ts
@@ -82,7 +82,7 @@ const WALLET_CONFIG = {
 export const getAuth0OidcToken = async (
   tokenClaims: IdToken | undefined,
   expectedNonce: string,
-) => {
+): Promise<string> => {
   if (!tokenClaims) {
     throw new Error("Not authenticated with Auth0 yet");
   }
@@ -94,7 +94,7 @@ export const getAuth0OidcToken = async (
 
   const decodedToken = jwtDecode<DecodedIdToken>(oidcTokenString);
   if (!decodedToken.tknonce) {
-    return undefined;
+    throw new Error("Provider nonce not found in decoded token");
   }
 
   if (decodedToken.tknonce !== expectedNonce) {
@@ -102,7 +102,8 @@ export const getAuth0OidcToken = async (
       `Nonce mismatch: expected ${expectedNonce}, got ${decodedToken.tknonce}`,
     );
   }
-  return tokenClaims.__raw;
+
+  return oidcTokenString;
 };
 
 interface DecodedIdToken extends JwtPayload {


### PR DESCRIPTION
If we are expecting the OIDC, we shouldn't return `undefined`. The `getAuth0OidcToken` will throw if any error is encountered while decoding the token.

In this PR, the goal is to have more context when the `no oidcTokenString available` error used to happen.

@broody also suggested of logging out the user if this happen, since it may be due to the local storage state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens OIDC token handling by making `getAuth0OidcToken` strictly validate and throw on errors, and simplifies its usage in `turnkey.ts`.
> 
> - **Keychain / Turnkey**:
>   - **`getAuth0OidcToken` (`packages/keychain/src/wallets/social/turnkey_utils.ts`)**:
>     - Adds explicit `Promise<string>` return type.
>     - Throws on missing `__raw`, missing `tknonce`, or nonce mismatch; returns OIDC token string on success.
>   - **`finishConnect` (`packages/keychain/src/wallets/social/turnkey.ts`)**:
>     - Removes redundant `undefined` check for `oidcTokenString`; relies on `getAuth0OidcToken` to throw.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98064ec561df9e1f3ed55645a6987e63a4bf30a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->