### PR TITLE
fix: include link in message

### DIFF
--- a/packages/keychain/src/components/connect/create/useUsernameValidation.ts
+++ b/packages/keychain/src/components/connect/create/useUsernameValidation.ts
@@ -57,7 +57,7 @@ export function useUsernameValidation(username: string) {
         setValidation({
           status: "invalid",
           error: new Error(
-            "Please come to the Cartridge Discord so we can help resolve your account.",
+            "Please come to the Cartridge Discord so we can help resolve your account: https://discord.com/invite/cartridge",
           ),
         });
         return;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Include Discord invite link in the blocked-username validation error message.
> 
> - **Keychain Connect**:
>   - Update `packages/keychain/src/components/connect/create/useUsernameValidation.ts` to include `https://discord.com/invite/cartridge` in the error for the specific blocked username `bramkaselo`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83451c126b38b78076f14681c375f89f4930f531. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->