### PR TITLE
Add Starknet L2Gas error parsing

### DIFF
--- a/packages/keychain/src/utils/errors.test.ts
+++ b/packages/keychain/src/utils/errors.test.ts
@@ -71,8 +71,8 @@ describe("parseValidationError", () => {
       raw: "StarknetError { code: KnownErrorCode(ValidateFailure), message: 'Insufficient max L2Gas: max amount: 3829680, actual used: 24314560.' }",
       summary: "Insufficient max L2 gas amount",
       details: {
-        maxAmount: BigInt("3829680"),
-        actualUsed: BigInt("24314560"),
+        l2GasMaxAmount: BigInt("3829680"),
+        l2GasActualUsed: BigInt("24314560"),
       },
     });
   });

--- a/packages/keychain/src/utils/errors.ts
+++ b/packages/keychain/src/utils/errors.ts
@@ -819,8 +819,8 @@ export function parseValidationError(error: ControllerError): {
         l1gasMaxAmount?: bigint;
         l1gasMaxPrice?: bigint;
         l1gasMaxFee?: bigint;
-        maxAmount?: bigint;
-        actualUsed?: bigint;
+        l2GasMaxAmount?: bigint;
+        l2GasActualUsed?: bigint;
       }
     | string;
 } {
@@ -885,14 +885,14 @@ export function parseValidationError(error: ControllerError): {
       /Insufficient max L2Gas: max amount: (\d+), actual used: (\d+)/,
     );
     if (l2GasMatch) {
-      const maxAmount = BigInt(l2GasMatch[1]);
-      const actualUsed = BigInt(l2GasMatch[2]);
+      const l2GasMaxAmount = BigInt(l2GasMatch[1]);
+      const l2GasActualUsed = BigInt(l2GasMatch[2]);
       return {
         raw: error.data,
         summary: "Insufficient max L2 gas amount",
         details: {
-          maxAmount,
-          actualUsed,
+          l2GasMaxAmount,
+          l2GasActualUsed,
         },
       };
     }


### PR DESCRIPTION
## Background
Handle Starknet RPC errors related to insufficient L2 gas.

## Changes
- Updated `packages/keychain/src/utils/errors.ts`:
  - Added regex to parse Starknet errors for "Insufficient max L2Gas".
  - Extracts `maxAmount` and `actualUsed` as BigInt.
  - Adds `maxAmount` and `actualUsed` to the return type of `parseValidationError`.
- Added a test case in `packages/keychain/src/utils/errors.test.ts` for the insufficient L2 gas error.

## Testing
- [ ] Manually trigger an insufficient L2 gas error in a Starknet transaction.
- [ ] Verify the error is parsed correctly with `maxAmount` and `actualUsed` populated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add parsing for Starknet "Insufficient max L2Gas" validation errors with extracted amounts and tests.
> 
> - **Utils (`packages/keychain/src/utils/errors.ts`)**:
>   - Extend `parseValidationError` to parse `"Insufficient max L2Gas: max amount: X, actual used: Y"` and return summary `"Insufficient max L2 gas amount"` with details `{ l2GasMaxAmount, l2GasActualUsed }`.
>   - Update details type to include `l2GasMaxAmount` and `l2GasActualUsed`.
> - **Tests (`packages/keychain/src/utils/errors.test.ts`)**:
>   - Add test for parsing Starknet L2 gas insufficiency error in `parseValidationError`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 003d86f346579038957a869b5be317cc8964de0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->