### PR TITLE
Fix connect URL parsing for undefined signers

### DIFF
--- a/examples/next/src/components/providers/StarknetProvider.tsx
+++ b/examples/next/src/components/providers/StarknetProvider.tsx
@@ -204,7 +204,7 @@ const controller = new ControllerConnector({
   ],
   slot: "arcade-pistols",
   namespace: "pistols",
-  // preset: "pistols",
+  preset: "pistols",
   // By default, preset policies take precedence over manually provided policies
   // Set shouldOverridePresetPolicies to true if you want your policies to override preset
   // shouldOverridePresetPolicies: true,


### PR DESCRIPTION
## Background
A backward compatibility issue was introduced in the `connect()` function. When `signupOptions` was undefined, it was stringified as `"undefined"` in the URL, causing `JSON.parse("undefined")` to throw an error. This prevented the connect flow from completing.

## Changes
- `packages/keychain/src/utils/connection/connect.ts`:
  - Modified `createConnectUrl` to only include the `signers` query parameter if `signupOptions` is defined.
  - Updated `parseConnectParams` to include more robust error handling for parsing the `signers` parameter, specifically accounting for stringified `"undefined"` or `"null"` values.

## Testing
- [ ] Test login flow with `signupOptions` explicitly passed as `undefined`.
- [ ] Test login flow with `signupOptions` omitted (implicitly `undefined`).
- [ ] Test login flow with `signupOptions` provided.
- [ ] Verify that no errors are thrown during the connect URL parsing in the keychain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make connect URL building/parsing robust when `signers` is undefined; enable `pistols` preset in example provider.
> 
> - **Keychain (`packages/keychain/src/utils/connection/connect.ts`)**:
>   - `createConnectUrl`: Use `URLSearchParams`; only include `signers` when defined.
>   - `parseConnectParams`: Guard against stringified `"undefined"`/`"null"`, wrap JSON parsing in try/catch, fall back to `undefined` on errors.
> - **Examples**:
>   - `examples/next/src/components/providers/StarknetProvider.tsx`: Enable preset `"pistols"` in `ControllerConnector` config.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c643a9166f45e5473efbeae56fbbfc0175bbd47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->