### PR TITLE
fix: slot login infinite loop

### DIFF
--- a/packages/keychain/src/components/app.tsx
+++ b/packages/keychain/src/components/app.tsx
@@ -1,9 +1,9 @@
 import { Navigate, Outlet, Route, Routes, useLocation } from "react-router-dom";
+import { Auth } from "./slot/index";
 import { AuthOptions } from "@cartridge/controller";
 import { Session } from "./session";
 import { Failure } from "./failure";
 import { Pending } from "./pending";
-import { Slot } from "./slot";
 import { Consent, Success } from "./slot/index";
 import { Fund } from "./slot/fund";
 import { FeatureToggle } from "./feature-toggle";
@@ -124,7 +124,8 @@ export function App() {
         <Route path="/settings/delegate" element={<Delegate />} />
         <Route path="/settings/add-signer" element={<AddSignerRoute />} />
         <Route path="session" element={<Session />} />
-        <Route path="slot" element={<Slot />}>
+        <Route path="slot" element={<Outlet />}>
+          <Route index element={<Auth />} />
           <Route path="consent" element={<Consent />} />
           <Route path="fund" element={<Fund />} />
         </Route>

--- a/packages/keychain/src/components/slot/consent.tsx
+++ b/packages/keychain/src/components/slot/consent.tsx
@@ -1,8 +1,6 @@
-import Controller from "@/utils/controller";
 import { LayoutFooter, Button, Checkbox, HeaderInner } from "@cartridge/ui";
-import { useCallback, useEffect, useState } from "react";
-import { useLocation, useSearchParams } from "react-router-dom";
-import { useNavigation } from "@/context/navigation";
+import { useCallback, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 
 interface ConsentCheckboxProps {
   checked: boolean;
@@ -42,8 +40,6 @@ function ConsentCheckbox({
 }
 
 export function Consent() {
-  const { navigate } = useNavigation();
-  const { pathname } = useLocation();
   const [searchParams] = useSearchParams();
   const callback_uri = searchParams.get("callback_uri")!;
 
@@ -64,32 +60,6 @@ export function Consent() {
 
     window.location.href = url;
   }, [callback_uri, allAccepted]);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    (async () => {
-      const controller = await Controller.fromStore(
-        import.meta.env.VITE_ORIGIN!,
-      );
-      if (!controller && !cancelled) {
-        navigate(
-          `/slot?returnTo=${encodeURIComponent(pathname)}${
-            callback_uri
-              ? `&callback_uri=${encodeURIComponent(callback_uri)}`
-              : ""
-          }`,
-          {
-            replace: true,
-          },
-        );
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [navigate, callback_uri, pathname]);
 
   return (
     <>

--- a/packages/keychain/src/components/slot/fund.tsx
+++ b/packages/keychain/src/components/slot/fund.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState, useMemo } from "react";
-import Controller from "@/utils/controller";
 import { useLocation } from "react-router-dom";
 import { useTeamsQuery } from "@cartridge/ui/utils/api/cartridge";
 import { Purchase } from "../purchase";
@@ -39,31 +38,11 @@ export function Fund() {
   } = useTeamsQuery(undefined, { refetchInterval: 1000 });
 
   useEffect(() => {
-    let cancelled = false;
-
     if (error) {
       navigate(`/slot?returnTo=${encodeURIComponent(pathname)}`, {
         replace: true,
       });
-      return () => {
-        cancelled = true;
-      };
     }
-
-    (async () => {
-      const controller = await Controller.fromStore(
-        import.meta.env.VITE_ORIGIN!,
-      );
-      if (!controller && !cancelled) {
-        navigate(`/slot?returnTo=${encodeURIComponent(pathname)}`, {
-          replace: true,
-        });
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
   }, [navigate, pathname, error]);
 
   const teams: Team[] = useMemo(

--- a/packages/keychain/src/components/slot/index.tsx
+++ b/packages/keychain/src/components/slot/index.tsx
@@ -3,34 +3,16 @@ export { Consent } from "./consent";
 import { PageLoading } from "@/components/Loading";
 import { useMeQuery } from "@cartridge/ui/utils/api/cartridge";
 import { useEffect } from "react";
-import {
-  Navigate,
-  Outlet,
-  useLocation,
-  useSearchParams,
-} from "react-router-dom";
+import { Outlet, useSearchParams } from "react-router-dom";
 import { CheckIcon, HeaderInner, LayoutContent } from "@cartridge/ui";
 import { useNavigation } from "@/context/navigation";
 import { useConnection } from "@/hooks/connection";
 
 export function Slot() {
-  const { pathname } = useLocation();
-  switch (pathname) {
-    case "/slot/auth":
-      return <Navigate to="/slot" replace />;
-    case "/slot/auth/success":
-      return <Success />;
-    case "/slot/auth/failure":
-      return <Navigate to="/failure" replace />;
-    case "/slot/consent":
-    case "/slot/fund":
-      return <Outlet />;
-    default:
-      return <Auth />;
-  }
+  return <Outlet />;
 }
 
-function Auth() {
+export function Auth() {
   const { navigate } = useNavigation();
   const [searchParams] = useSearchParams();
   const { logout, controller } = useConnection();
@@ -56,7 +38,7 @@ function Auth() {
 
       navigate(target, { replace: true });
     }
-  }, [user, isFetched, controller, navigate, searchParams, logout]);
+  }, [user, isFetched, controller, navigate, searchParams]);
 
   // Logout to send user back to login
   useEffect(() => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Reworks Slot routing to use nested routes with `Auth` as the index and removes redundant controller-based redirects in `consent` and `fund` to avoid login loops.
> 
> - **Routing**:
>   - Replace `Route path="slot" element={<Slot />}` with `element={<Outlet />}` and add index route `Auth` in `packages/keychain/src/components/app.tsx`.
>   - Keep `slot/consent` and `slot/fund` as nested routes under `slot`.
> - **Slot module (`packages/keychain/src/components/slot/index.tsx`)**:
>   - Simplify `Slot` to just `return <Outlet />`.
>   - Export `Auth` and use it as the `slot` index; remove path-based switching logic and unnecessary dependencies in effects.
> - **Consent (`packages/keychain/src/components/slot/consent.tsx`)**:
>   - Remove controller/navigation checks and side-effects; keep only policy acceptance and OAuth redirect.
> - **Fund (`packages/keychain/src/components/slot/fund.tsx`)**:
>   - Drop controller existence checks and cleanup flags; on error, navigate back to `/slot`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36e224aeed1869206d873a7e04be809216651dd2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->