### PR TITLE
fix: pass setRpcUrl to connect for backwards compatibility

### DIFF
--- a/packages/keychain/src/utils/connection/connect.ts
+++ b/packages/keychain/src/utils/connection/connect.ts
@@ -121,11 +121,13 @@ export function parseConnectParams(searchParams: URLSearchParams): {
 
 export function connect({
   navigate,
+  setRpcUrl,
 }: {
   navigate: (
     to: string | number,
     options?: { replace?: boolean; state?: unknown },
   ) => void;
+  setRpcUrl: (url: string) => void;
 }) {
   return () => {
     // Support both old and new signatures for backwards compatibility
@@ -144,6 +146,8 @@ export function connect({
         // In the old signature, the first arg is policies (not used in new flow)
         // and the third arg is signupOptions
         signers = signupOptions;
+        // Set the RPC URL for backwards compatibility
+        setRpcUrl(rpcUrl);
       } else {
         // New signature: connect(signupOptions)
         signers = policiesOrSigners as AuthOptions | undefined;

--- a/packages/keychain/src/utils/connection/index.ts
+++ b/packages/keychain/src/utils/connection/index.ts
@@ -30,6 +30,7 @@ export function connectToController<ParentMethods extends object>({
       connect: normalize(
         connect({
           navigate,
+          setRpcUrl,
         }),
       ),
       deploy: () => deployFactory({ navigate }),


### PR DESCRIPTION
## Summary
- Updated `connect()` function to accept `setRpcUrl` as a parameter from the connection context
- Added logic to call `setRpcUrl(rpcUrl)` when the legacy connect signature is used (with explicit rpcUrl parameter)
- Ensures RPC URL is properly set in the backwards compatible path

## Changes
- `packages/keychain/src/utils/connection/connect.ts`: Added `setRpcUrl` parameter and call it in legacy path
- `packages/keychain/src/utils/connection/index.ts`: Pass `setRpcUrl` to connect function

## Test plan
- [ ] Verify legacy connect signature `connect(policies, rpcUrl, signupOptions)` properly sets RPC URL
- [ ] Verify new connect signature `connect(signupOptions)` continues to work as expected
- [ ] Test that RPC URL state is correctly updated in the connection context

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Passes setRpcUrl into connect and invokes it when rpcUrl is provided via the legacy connect(policies, rpcUrl, signupOptions) signature.
> 
> - **Connection utils**:
>   - `packages/keychain/src/utils/connection/connect.ts`:
>     - Add `setRpcUrl` param to `connect()` and call `setRpcUrl(rpcUrl)` when using legacy `connect(policies, rpcUrl, signupOptions)`.
>   - `packages/keychain/src/utils/connection/index.ts`:
>     - Pass `setRpcUrl` into `connect()` within `connectToController()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 925e2e881a9a360e96a7e0d464190edda9837640. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->