### PR TITLE
Disable spending limit logic

### DIFF
--- a/examples/next/src/components/providers/StarknetProvider.tsx
+++ b/examples/next/src/components/providers/StarknetProvider.tsx
@@ -186,7 +186,7 @@ if (process.env.NEXT_PUBLIC_RPC_MAINNET) {
 // }
 
 const controller = new ControllerConnector({
-  // policies,
+  policies,
   // With the defaults, you can omit chains if you want to use:
   // - chains: [
   //     { rpcUrl: "https://api.cartridge.gg/x/starknet/sepolia/rpc/v0_9" },


### PR DESCRIPTION
## Summary
- Disables spending limit logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the spending-limit flow, processes policies before session creation, and passes policies to the ControllerConnector.
> 
> - **Keychain (CreateSession)**:
>   - Remove spending-limit step and related logic; session creation proceeds directly.
>   - Add `processPolicies` to deep-copy/sanitize policies (strip `id`, optionally toggle `authorized`) before `createSession`.
>   - `createSession` now accepts `toggleOff` and uses processed policies; Skip uses `toggleOff: true`.
>   - Simplify primary button label to "create/update session" and minor UI tweak (adds `mb-3` on consent row).
> - **Provider (Starknet)**:
>   - Initialize `ControllerConnector` with `policies`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32108ae1e83f5bd7a87317402b19b7b7a351117e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->