### PR TITLE
fix: clear lastUsedConnector on session expiration

### DIFF
--- a/packages/controller/src/session/provider.ts
+++ b/packages/controller/src/session/provider.ts
@@ -253,6 +253,7 @@ export default class SessionProvider extends BaseProvider {
     localStorage.removeItem("sessionSigner");
     localStorage.removeItem("session");
     localStorage.removeItem("sessionPolicies");
+    localStorage.removeItem("lastUsedConnector");
     this.account = undefined;
     this._username = undefined;
     const disconnectUrl = new URL(`${this._keychainUrl}`);
@@ -368,5 +369,6 @@ export default class SessionProvider extends BaseProvider {
     localStorage.removeItem("sessionSigner");
     localStorage.removeItem("session");
     localStorage.removeItem("sessionPolicies");
+    localStorage.removeItem("lastUsedConnector");
   }
 }


### PR DESCRIPTION
## Summary

- Fixed an issue where expired sessions would skip the login screen and go directly to session registration
- When a session expires, the app now properly forces a full logout by clearing the `lastUsedConnector` localStorage item
- This prevents `autoConnect` from automatically reconnecting with an expired SessionConnector

## Changes

- Updated `SessionProvider.clearStoredSession()` to remove `lastUsedConnector` from localStorage
- Updated `SessionProvider.disconnect()` to remove `lastUsedConnector` for consistency

## Test plan

1. Login using SessionConnector in the app
2. Wait until session expires (or manually set expiration in localStorage to a past date)
3. Refresh/reopen the app
4. Verify that the app shows the login screen instead of going directly to "Register session"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clear lastUsedConnector during disconnect and when sessions expire to prevent unintended auto-reconnect.
> 
> - **SessionProvider (`packages/controller/src/session/provider.ts`)**:
>   - Clear `lastUsedConnector` in `disconnect()` and `clearStoredSession()` to prevent auto-connect after logout or session expiration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84d7ec1e36b40f56fef7d5e2d360c99a71f429c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->