### PR TITLE
feat: include all EVM merkle drops when claiming with any EVM wallet

### DIFF
--- a/packages/keychain/src/components/purchasenew/claim/claim.tsx
+++ b/packages/keychain/src/components/purchasenew/claim/claim.tsx
@@ -19,7 +19,7 @@ import { ErrorAlert } from "@/components/ErrorAlert";
 import { CollectionItem } from "../starterpack/collections";
 import { StarterpackReceiving } from "../starterpack/starterpack";
 import { ExternalWalletType } from "@cartridge/controller";
-import { getWallet } from "../wallet/data";
+import { getWallet } from "../wallet/config";
 import { formatAddress } from "@cartridge/ui/utils";
 import type { BackendStarterpackDetails } from "@/context";
 

--- a/packages/keychain/src/components/purchasenew/method.tsx
+++ b/packages/keychain/src/components/purchasenew/method.tsx
@@ -9,7 +9,7 @@ import {
 } from "@cartridge/ui";
 import { useState } from "react";
 import { ControllerErrorAlert } from "../ErrorAlert";
-import { networkWalletData } from "./wallet/data";
+import { networkWalletData } from "./wallet/config";
 import { useParams } from "react-router-dom";
 
 export function PaymentMethod() {

--- a/packages/keychain/src/components/purchasenew/wallet/config.ts
+++ b/packages/keychain/src/components/purchasenew/wallet/config.ts
@@ -28,7 +28,14 @@ import {
 } from "@cartridge/ui";
 import { NetworkWalletData, Wallet } from "../types";
 import { constants } from "starknet";
-import { ExternalWalletType } from "@cartridge/controller";
+import { ExternalPlatform, ExternalWalletType } from "@cartridge/controller";
+
+export const evmNetworks = [
+  "ethereum",
+  "base",
+  "arbitrum",
+  "optimism",
+] as ExternalPlatform[];
 
 const evmWallets = new Map<string, Wallet>([
   [

--- a/packages/keychain/src/components/purchasenew/wallet/network.tsx
+++ b/packages/keychain/src/components/purchasenew/wallet/network.tsx
@@ -4,7 +4,7 @@ import {
   LayoutContent,
   PurchaseCard,
 } from "@cartridge/ui";
-import { networkWalletData } from "./data";
+import { networkWalletData } from "./config";
 import { useNavigation } from "@/context";
 import { useParams } from "react-router-dom";
 

--- a/packages/keychain/src/components/purchasenew/wallet/wallet.tsx
+++ b/packages/keychain/src/components/purchasenew/wallet/wallet.tsx
@@ -5,7 +5,7 @@ import {
   PurchaseCard,
   WalletIcon,
 } from "@cartridge/ui";
-import { networkWalletData } from "./data";
+import { networkWalletData, evmNetworks } from "./config";
 import {
   useNavigation,
   usePurchaseContext,
@@ -13,12 +13,9 @@ import {
 } from "@/context";
 import { useParams } from "react-router-dom";
 import { useEffect, useState, useMemo, useCallback } from "react";
-import { ExternalWallet } from "@cartridge/controller";
+import { ExternalPlatform, ExternalWallet } from "@cartridge/controller";
 import { ErrorAlert } from "@/components/ErrorAlert";
-import {
-  MerkleDropNetwork,
-  StarterpackAcquisitionType,
-} from "@cartridge/ui/utils/api/cartridge";
+import { StarterpackAcquisitionType } from "@cartridge/ui/utils/api/cartridge";
 import { Network } from "../types";
 import { useConnection } from "@/hooks/connection";
 
@@ -160,12 +157,19 @@ export function SelectWallet() {
         }
 
         // Claim starterpack
+        const isCurrentEvm = evmNetworks.includes(network.platform);
+
         const keys = starterpackDetails?.merkleDrops
-          ?.filter(
-            (drop) =>
-              drop.network ===
-              (network.platform.toUpperCase() as MerkleDropNetwork),
-          )
+          ?.filter((drop) => {
+            const dropNetwork = drop.network.toLowerCase() as ExternalPlatform;
+
+            // For EVM networks, include all EVM merkle drops
+            if (isCurrentEvm) {
+              return evmNetworks.includes(dropNetwork);
+            }
+            // For non-EVM networks, only include drops for that specific network
+            return dropNetwork === network.platform;
+          })
           .map((drop) => drop.key)
           .join(";");
 


### PR DESCRIPTION
## Summary

This PR modifies the merkle claim logic to allow users to claim drops from all EVM networks (Ethereum, Base, Arbitrum, Optimism) when connecting with any EVM wallet.

## Changes

### Core Logic Update
- **Modified merkle drop filtering**: When a user selects an EVM wallet, the system now includes merkle drops from ALL EVM networks instead of just the selected network
- **Non-EVM networks preserved**: Starknet and Solana wallets continue to only claim drops for their specific network

### Code Organization Improvements
- **Renamed `wallet/data.ts` to `wallet/config.ts`**: Better reflects the file's purpose as a configuration file
- **Centralized EVM network definitions**: Created `evmNetworks` constant array containing all EVM `MerkleDropNetwork` enum values
- **Removed redundant helper**: Eliminated `isEvmPlatform` function and simplified logic by checking network membership directly in the `evmNetworks` array
- **Updated imports**: Updated all import paths from `./data` to `./config` in affected files

## Rationale

EVM wallets use the same address across all EVM-compatible chains (Ethereum, Base, Arbitrum, Optimism). This allows users to claim all their EVM merkle drops in a single transaction using any EVM wallet, providing a better user experience.

## Files Changed

- `packages/keychain/src/components/purchasenew/wallet/wallet.tsx`: Updated merkle drop filter logic
- `packages/keychain/src/components/purchasenew/wallet/data.ts → config.ts`: Renamed and added `evmNetworks` constant
- `packages/keychain/src/components/purchasenew/wallet/network.tsx`: Updated import path
- `packages/keychain/src/components/purchasenew/claim/claim.tsx`: Updated import path
- `packages/keychain/src/components/purchasenew/method.tsx`: Updated import path

## Testing

The logic now correctly:
- ✅ Includes all EVM drops when claiming with any EVM wallet (Ethereum, Base, Arbitrum, Optimism)
- ✅ Excludes EVM drops when claiming with non-EVM wallets (Starknet, Solana)
- ✅ Only includes the specific network's drops for non-EVM networks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allows claiming all EVM merkle drops when connected with any EVM wallet and consolidates wallet/network config into `wallet/config.ts`.
> 
> - **Claim/Checkout Logic**
>   - In `wallet/wallet.tsx`, when an EVM wallet/network is selected, filter `starterpackDetails.merkleDrops` to include keys from all EVM networks via `evmNetworks`; non-EVM networks only include their specific network.
> - **Configuration**
>   - Introduce `wallet/config.ts` with centralized `networkWalletData`, `evmNetworks` list, and `getWallet` helper; adds `ExternalPlatform` typing.
> - **Imports/Usage**
>   - Update references from `./wallet/data` to `./wallet/config` in `claim.tsx`, `method.tsx`, and `wallet/network.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e96251117284e5197372b3575b0551fbdb91abaf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->