### PR TITLE
Fix standalone redirect

### DIFF
--- a/examples/next/src/components/Header.tsx
+++ b/examples/next/src/components/Header.tsx
@@ -180,7 +180,9 @@ const Header = () => {
         <div className="flex gap-2">
           <Button
             onClick={() => {
-              controllerConnector.controller.open();
+              controllerConnector.controller.open({
+                redirectUrl: window.location.href,
+              });
             }}
             disabled={!isControllerReady}
           >

--- a/examples/next/src/components/PlayButton.tsx
+++ b/examples/next/src/components/PlayButton.tsx
@@ -14,7 +14,7 @@ interface Game {
 const GAMES: Game[] = [
   {
     name: "Loot Survivor",
-    url: "https://lootsurvivor.io",
+    url: "https://x.cartridge.gg?redirect_url=https://lootsurvivor.io",
     description: "Survive the adventure, earn rewards",
   },
   // Add more games here as needed
@@ -43,7 +43,7 @@ export const PlayButton = () => {
       if (!hasAccess) {
         // Redirect through standalone auth first to establish first-party storage
         controllerConnector.controller.open({
-          redirectTo: game.url,
+          redirectUrl: game.url,
         });
       } else {
         // Direct navigation - user already authenticated via standalone

--- a/packages/controller/src/controller.ts
+++ b/packages/controller/src/controller.ts
@@ -23,7 +23,7 @@ import {
   ProbeReply,
   ProfileContextTypeVariant,
   ResponseCodes,
-  StandaloneAuthOptions,
+  OpenOptions,
 } from "./types";
 import { validateRedirectUrl } from "./url-validator";
 import { parseChainId } from "./utils";
@@ -398,7 +398,7 @@ export default class ControllerProvider extends BaseProvider {
    * This establishes first-party storage, enabling seamless iframe access across all games.
    * @param options - Configuration for redirect after authentication
    */
-  open(options: StandaloneAuthOptions = {}) {
+  open(options: OpenOptions = {}) {
     if (typeof window === "undefined") {
       console.error("open can only be called in browser context");
       return;
@@ -407,19 +407,19 @@ export default class ControllerProvider extends BaseProvider {
     const keychainUrl = new URL(this.options.url || KEYCHAIN_URL);
 
     // Add redirect target (defaults to current page)
-    const redirectTo = options.redirectTo || window.location.href;
+    const redirectUrl = options.redirectUrl || window.location.href;
 
     // Validate redirect URL to prevent XSS and open redirect attacks
-    const validation = validateRedirectUrl(redirectTo);
+    const validation = validateRedirectUrl(redirectUrl);
     if (!validation.isValid) {
       console.error(
         `Invalid redirect URL: ${validation.error}`,
-        `URL: ${redirectTo}`,
+        `URL: ${redirectUrl}`,
       );
       return;
     }
 
-    keychainUrl.searchParams.set("redirect_to", redirectTo);
+    keychainUrl.searchParams.set("redirect_url", redirectUrl);
 
     // Add controller configuration parameters
     if (this.options.slot) {

--- a/packages/controller/src/types.ts
+++ b/packages/controller/src/types.ts
@@ -275,7 +275,7 @@ export interface StarterPackItem {
   call?: Call[];
 }
 
-export type StandaloneAuthOptions = {
+export type OpenOptions = {
   /** The URL to redirect to after authentication (defaults to current page) */
-  redirectTo?: string;
+  redirectUrl?: string;
 };

--- a/packages/controller/src/url-validator.ts
+++ b/packages/controller/src/url-validator.ts
@@ -5,7 +5,7 @@
  * support redirecting to external game domains (e.g., lootsurvivor.io)
  * after authentication, while blocking dangerous attack vectors.
  *
- * @param redirectUrl - The URL to validate (from redirectTo option)
+ * @param redirectUrl - The URL to validate (from redirectUrl option)
  * @returns Object with isValid boolean and optional error message
  */
 export function validateRedirectUrl(redirectUrl: string): {

--- a/packages/keychain/src/components/app.tsx
+++ b/packages/keychain/src/components/app.tsx
@@ -59,6 +59,8 @@ import { Disconnect } from "./disconnect";
 import { PurchaseProvider } from "@/context";
 import { OnchainCheckout } from "./purchasenew/checkout/onchain";
 import { useAccount } from "@/hooks/account";
+import { safeRedirect } from "@/utils/url-validator";
+import { useEffect } from "react";
 
 function DefaultRoute() {
   const account = useAccount();
@@ -77,6 +79,29 @@ function Authentication() {
   const { pathname, search } = useLocation();
 
   const upgrade = useUpgrade();
+
+  // Check for redirect_url when user is already authenticated
+  useEffect(() => {
+    if (
+      controller &&
+      upgrade.isSynced &&
+      !isConfigLoading &&
+      !upgrade.available
+    ) {
+      const searchParams = new URLSearchParams(search);
+      const redirectUrl = searchParams.get("redirect_url");
+      if (redirectUrl) {
+        // Safely redirect to the specified URL
+        safeRedirect(redirectUrl);
+      }
+    }
+  }, [
+    controller,
+    upgrade.isSynced,
+    upgrade.available,
+    isConfigLoading,
+    search,
+  ]);
 
   // Popup flow authentication
   if (pathname.startsWith("/authenticate")) {

--- a/packages/keychain/src/components/connect/create/useCreateController.ts
+++ b/packages/keychain/src/components/connect/create/useCreateController.ts
@@ -218,12 +218,12 @@ export function useCreateController({
         window.controller = controller;
         setController(controller);
 
-        // Check for redirect_to parameter and redirect after successful signup
+        // Check for redirect_url parameter and redirect after successful signup
         const searchParams = new URLSearchParams(window.location.search);
-        const redirectTo = searchParams.get("redirect_to");
-        if (redirectTo) {
+        const redirectUrl = searchParams.get("redirect_url");
+        if (redirectUrl) {
           // Safely redirect to the specified URL
-          safeRedirect(redirectTo);
+          safeRedirect(redirectUrl);
         }
       }
     },
@@ -390,12 +390,12 @@ export function useCreateController({
       window.controller = loginRet.controller;
       setController(loginRet.controller);
 
-      // Check for redirect_to parameter and redirect after successful login
+      // Check for redirect_url parameter and redirect after successful login
       const searchParams = new URLSearchParams(window.location.search);
-      const redirectTo = searchParams.get("redirect_to");
-      if (redirectTo) {
+      const redirectUrl = searchParams.get("redirect_url");
+      if (redirectUrl) {
         // Safely redirect to the specified URL
-        safeRedirect(redirectTo);
+        safeRedirect(redirectUrl);
       }
     },
     [origin, setController],
@@ -624,12 +624,12 @@ export function useCreateController({
             });
           }
 
-          // Check for redirect_to parameter after social auth
-          const redirectTo = new URLSearchParams(window.location.search).get(
-            "redirect_to",
+          // Check for redirect_url parameter after social auth
+          const redirectUrl = new URLSearchParams(window.location.search).get(
+            "redirect_url",
           );
-          if (redirectTo) {
-            safeRedirect(redirectTo);
+          if (redirectUrl) {
+            safeRedirect(redirectUrl);
           }
         } catch (e) {
           setError(e as Error);

--- a/packages/keychain/src/utils/api/generated.ts
+++ b/packages/keychain/src/utils/api/generated.ts
@@ -943,6 +943,7 @@ export type CreateMerkleDropInput = {
   description?: InputMaybe<Scalars["String"]>;
   entrypoint: Scalars["String"];
   key: Scalars["String"];
+  matchStarterpackItem?: InputMaybe<Scalars["Boolean"]>;
   merkleRoot: Scalars["String"];
   network: MerkleDropNetwork;
   salt: Scalars["String"];
@@ -2080,6 +2081,7 @@ export type MerkleDrop = Node & {
   entrypoint: Scalars["String"];
   id: Scalars["ID"];
   key: Scalars["String"];
+  matchStarterpackItem: Scalars["Boolean"];
   merkleRoot: Scalars["String"];
   network: MerkleDropNetwork;
   salt: Scalars["String"];
@@ -2229,6 +2231,9 @@ export type MerkleDropWhereInput = {
   keyLTE?: InputMaybe<Scalars["String"]>;
   keyNEQ?: InputMaybe<Scalars["String"]>;
   keyNotIn?: InputMaybe<Array<Scalars["String"]>>;
+  /** match_starterpack_item field predicates */
+  matchStarterpackItem?: InputMaybe<Scalars["Boolean"]>;
+  matchStarterpackItemNEQ?: InputMaybe<Scalars["Boolean"]>;
   /** merkle_root field predicates */
   merkleRoot?: InputMaybe<Scalars["String"]>;
   merkleRootContains?: InputMaybe<Scalars["String"]>;
@@ -5822,6 +5827,7 @@ export type UpdateMerkleDropInput = {
   description?: InputMaybe<Scalars["String"]>;
   entrypoint?: InputMaybe<Scalars["String"]>;
   key?: InputMaybe<Scalars["String"]>;
+  matchStarterpackItem?: InputMaybe<Scalars["Boolean"]>;
   merkleRoot?: InputMaybe<Scalars["String"]>;
   network?: InputMaybe<MerkleDropNetwork>;
   removeClaimIDs?: InputMaybe<Array<Scalars["ID"]>>;

--- a/packages/keychain/src/utils/url-validator.ts
+++ b/packages/keychain/src/utils/url-validator.ts
@@ -5,7 +5,7 @@
  * support redirecting to external game domains (e.g., lootsurvivor.io)
  * after authentication, while blocking dangerous attack vectors.
  *
- * @param redirectUrl - The URL to validate (from redirect_to parameter)
+ * @param redirectUrl - The URL to validate (from redirect_url parameter)
  * @returns Object with isValid boolean and optional error message
  */
 export function validateRedirectUrl(redirectUrl: string): {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Standardizes standalone auth redirect to redirect_url across controller, keychain, and example app, and adds post-auth safe redirects; minor GraphQL additions for MerkleDrop.
> 
> - **Controller**:
>   - Rename `StandaloneAuthOptions` → `OpenOptions`; change `open()` to accept `{ redirectUrl }` and pass `redirect_url` query param; update validator docs.
> - **Keychain**:
>   - Implement safe post-auth redirects via `redirect_url` in `Authentication` flow and after signup/login (including social auth) using `safeRedirect`.
>   - Update internal validator comment to reference `redirect_url`.
> - **Example App (Next.js)**:
>   - Use `controller.open({ redirectUrl })` in `Header` and `PlayButton`; switch game link to `https://x.cartridge.gg?redirect_url=...`.
> - **Types/Schema**:
>   - Add `matchStarterpackItem` to `MerkleDrop` model, filters, and create/update inputs in generated API types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 666d9482b6f72b22086adf152aabb0c0d85b939a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->