### PR TITLE
fix: show connect component for logged-in users with redirect_url

### DIFF
--- a/examples/next/src/components/PlayButton.tsx
+++ b/examples/next/src/components/PlayButton.tsx
@@ -14,7 +14,7 @@ interface Game {
 const GAMES: Game[] = [
   {
     name: "Loot Survivor",
-    url: "https://x.cartridge.gg?redirect_url=https://lootsurvivor.io",
+    url: "https://x.cartridge.gg?redirect_url=https://lootsurvivor.io&preset=loot-survivor",
     description: "Survive the adventure, earn rewards",
   },
   // Add more games here as needed

--- a/packages/keychain/src/components/app.tsx
+++ b/packages/keychain/src/components/app.tsx
@@ -62,6 +62,16 @@ import { useAccount } from "@/hooks/account";
 
 function DefaultRoute() {
   const account = useAccount();
+  const { search } = useLocation();
+
+  // Check if we have a redirect_url parameter
+  const searchParams = new URLSearchParams(search);
+  const redirectUrl = searchParams.get("redirect_url");
+
+  // If redirect_url is present, route to connect component
+  if (redirectUrl) {
+    return <Navigate to={`/connect${search}`} replace />;
+  }
 
   // When logged in and at root path, redirect to inventory
   if (account?.username) {


### PR DESCRIPTION
## Summary

When a logged-in user clicked the Play button linking to a game (e.g., `https://x.cartridge.gg?redirect_url=https://lootsurvivor.io&preset=loot-survivor`), they were redirected to their inventory instead of seeing the standalone connect confirmation screen. This prevented them from confirming the connection before being redirected to the game.

## Changes

Modified the `DefaultRoute` component in the keychain app to check for the presence of a `redirect_url` query parameter before automatically redirecting authenticated users to their inventory. When a redirect URL is present, users are now routed to the connect component instead, allowing them to confirm the connection before being redirected to the target application.

## Test plan

- Test with a logged-in user clicking the Play button that opens a game URL with `redirect_url` parameter
- Verify the user sees the standalone connect confirmation screen instead of inventory
- Verify the user can click "Connect" to be redirected to the game URL
- Verify normal inventory redirect still works when no `redirect_url` parameter is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure redirect_url flows render the connect screen instead of inventory; add preset to Loot Survivor example URL.
> 
> - **Routing (keychain)**:
>   - `packages/keychain/src/components/app.tsx` `DefaultRoute`: parse `redirect_url` from query and, if present, `Navigate` to `/connect` with the original search params; otherwise keep logged-in redirect to `account/:username/inventory`.
> - **Example app**:
>   - `examples/next/src/components/PlayButton.tsx`: append `preset=loot-survivor` to the Loot Survivor `redirect_url` link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4dfaf47f64b165fc02b42925b8701c1d951532e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->