### PR TITLE
fix_claim_counters

### DIFF
--- a/packages/keychain/src/components/purchasenew/claim/claim.tsx
+++ b/packages/keychain/src/components/purchasenew/claim/claim.tsx
@@ -104,7 +104,7 @@ export function Claim() {
   const totalClaimable = useMemo(() => {
     return claimsData
       .filter((claim) => !claim.claimed)
-      .reduce((acc, claim) => acc + claim.data.length, 0);
+      .reduce((acc, claim) => acc + Number(claim.data[0] || 0), 0);
   }, [claimsData]);
 
   // Filter starterpack items based on matchStarterpackItem flag
@@ -176,7 +176,7 @@ export function Claim() {
 
         // Calculate total amount from matching claims
         const totalAmount = matchingClaims.reduce(
-          (acc, claim) => acc + claim.data.length,
+          (acc, claim) => acc + Number(claim.data[0] || 0),
           0,
         );
 
@@ -268,7 +268,9 @@ export function Claim() {
                           <CollectionItem
                             name={claim.description ?? claim.key}
                             network={claim.network}
-                            numAvailable={claim.claimed ? 0 : claim.data.length}
+                            numAvailable={
+                              claim.claimed ? 0 : Number(claim.data[0] || 0)
+                            }
                             isLoading={claim.loading}
                           />
                           {!claim.loading && (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Corrects claim counts by summing numeric amounts from `claim.data[0]` rather than using `claim.data.length` across totals and per-item displays.
> 
> - **Frontend — Claim UI (`packages/keychain/src/components/purchasenew/claim/claim.tsx`)**:
>   - **Totals**: `totalClaimable` now sums `Number(claim.data[0] || 0)` instead of `claim.data.length`.
>   - **Item labels**: Amount prefix in starterpack item titles uses `Number(claim.data[0] || 0)` when matching claims.
>   - **Individual claims list**: `numAvailable` for each claim uses `Number(claim.data[0] || 0)` instead of `claim.data.length`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74b390b211dbef1e06a8738b63b6bd8351edfc64. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->