### PR TITLE
Potential fix for code scanning alert no. 155: Client-side cross-site scripting

### DIFF
--- a/packages/keychain/src/utils/url-validator.ts
+++ b/packages/keychain/src/utils/url-validator.ts
@@ -11,6 +11,7 @@
 export function validateRedirectUrl(redirectUrl: string): {
   isValid: boolean;
   error?: string;
+  validatedUrl?: string;
 } {
   // Check for empty or undefined
   if (!redirectUrl || redirectUrl.trim() === "") {
@@ -66,7 +67,7 @@ export function validateRedirectUrl(redirectUrl: string): {
   }
 
   // URL is safe to redirect to
-  return { isValid: true };
+  return { isValid: true, validatedUrl: url.href };
 }
 
 /**
@@ -88,6 +89,7 @@ export function safeRedirect(redirectUrl: string): boolean {
   }
 
   // Safe to redirect
-  window.location.href = redirectUrl;
+  // Use the canonical, validated URL instead of the raw input
+  window.location.href = validation.validatedUrl!;
   return true;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/cartridge-gg/controller/security/code-scanning/155](https://github.com/cartridge-gg/controller/security/code-scanning/155)

To eliminate any risk of client-side cross-site scripting or open redirect, ensure that the validated URL is always absolute, uses only "http:" or "https:" protocols, and cannot be "javascript:" or another dangerous protocol—even in edge cases. In the redirection step, use the already-parsed result from `validateRedirectUrl` (not the raw user input) by returning and reusing the safely-parsed absolute URL (e.g., via `url.href`). This prevents manipulation via tricky input strings that might be mis-parsed. Adjust the validator to always return the canonical, validated, `url.href` and update the redirector to strictly use this, never the raw `redirectUrl` string. This also future-proofs against possible developer changes that introduce new vector(s).

**Steps needed:**
1. In `validateRedirectUrl`, if valid, return the parsed/canonicalized URL as a property (e.g., `validatedUrl` or similar) along with the `isValid` flag.
2. In `safeRedirect`, use this `validatedUrl` instead of the original `redirectUrl` for assignment to `window.location.href`.
3. No new dependencies are required; `URL` is built in.
4. No change to existing validator logic, just enhancement of its output to provide canonical data.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
