### PR TITLE
fix: grouped claim counter

### DIFF
--- a/packages/keychain/src/components/purchasenew/claim/claim.tsx
+++ b/packages/keychain/src/components/purchasenew/claim/claim.tsx
@@ -223,7 +223,7 @@ export function Claim() {
       network: claims[0].network,
       totalAmount: claims
         .filter((c) => !c.claimed)
-        .reduce((acc, c) => acc + c.data.length, 0),
+        .reduce((acc, c) => acc + Number(c.data[0] || 0), 0),
       allClaimed: claims.every((c) => c.claimed),
       isLoading: claims.every((c) => c.loading),
     }));


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fix grouped claim totals by summing claim amounts (`Number(c.data[0])`) instead of counting array length.
> 
> - **Claims UI (`packages/keychain/src/components/purchasenew/claim/claim.tsx`)**:
>   - Adjust `groupedClaims.totalAmount` to sum unclaimed amounts via `Number(c.data[0] || 0)` rather than `c.data.length`, ensuring accurate grouped counters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09db79c538bfc789a8949dd81ec5d0a43636e5bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->