### PR TITLE
fix: starterpack fetch symbol

### DIFF
--- a/packages/keychain/src/hooks/starterpack-onchain.ts
+++ b/packages/keychain/src/hooks/starterpack-onchain.ts
@@ -128,7 +128,7 @@ async function fetchTokenMetadata(
   ]);
 
   return {
-    symbol: shortString.decodeShortString(symbolRes[0]),
+    symbol: shortString.decodeShortString(symbolRes[1]),
     decimals: Number(decimalsRes[0]),
   };
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fix token symbol fetching by decoding the second felt from `symbol` call response.
> 
> - **On-chain token metadata**: Decode `symbol` from `symbolRes[1]` instead of `symbolRes[0]` in `packages/keychain/src/hooks/starterpack-onchain.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bdb0f90947cf1e009ddd21e4dd85cfa54a6f1944. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->