### PR TITLE
feat: add balance_of fallback and error handling for token balance checks

### DIFF
--- a/packages/keychain/src/components/purchasenew/checkout/onchain/index.tsx
+++ b/packages/keychain/src/components/purchasenew/checkout/onchain/index.tsx
@@ -73,6 +73,9 @@ export function OnchainCheckout() {
 
   // Determine if we're still loading balance/conversion data
   const isLoadingBalance = useMemo(() => {
+    // If there's a balance error, stop showing loading state
+    if (balanceError) return false;
+
     // If there's a conversion error and we need conversion, stop showing loading state
     if (conversionError && tokenToCheck?.needsConversion) return false;
 
@@ -89,6 +92,7 @@ export function OnchainCheckout() {
     balance,
     tokenToCheck,
     conversionError,
+    balanceError,
   ]);
 
   // Check if user has sufficient balance (only when not loading)
@@ -146,19 +150,14 @@ export function OnchainCheckout() {
           setBalance(balanceBN);
           setBalanceError(null);
           setIsChecking(false);
-          return; // Success, exit early
+          return;
         } catch (error) {
           lastError = error;
           const errorMessage =
             error instanceof Error ? error.message : String(error);
 
           // If it's an EntrypointNotFound error, try the next entrypoint
-          if (
-            errorMessage.includes("EntrypointNotFound") ||
-            errorMessage.includes("Entry point") ||
-            errorMessage.includes("not found")
-          ) {
-            console.log(`Entrypoint '${entrypoint}' not found, trying next...`);
+          if (errorMessage.includes("EntrypointNotFound")) {
             continue;
           }
 


### PR DESCRIPTION
## Summary

This PR improves the robustness of token balance checking in the onchain checkout flow by implementing a fallback mechanism and better error handling.

## Changes

- **Fallback mechanism**: Try `balance_of` (snake_case) first, then `balanceOf` (camelCase) if the first fails with `EntrypointNotFound`
- **Error handling**: Display a clear error message when balance retrieval fails with both entrypoints
- **UI improvements**:
  - Added error state display when balance check fails completely
  - Disable purchase button when balance check fails
  - Changed conversion error styling to use error variant for consistency
  - Simplified conversion error message

## Motivation

Token contracts on Starknet may use different naming conventions for their balance query functions. By trying both conventions, we ensure compatibility with a wider range of token contracts and provide better feedback when balance checks fail.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds balance check fallback (`balance_of` → `balanceOf`), displays balance retrieval failures in UI, and disables purchase on error with refined conversion error styling/message.
> 
> - **Onchain Checkout (`packages/keychain/src/components/purchasenew/checkout/onchain/index.tsx`)**
>   - **Balance fetching**:
>     - Implement fallback: try `balance_of`, then `balanceOf`; continue on `EntrypointNotFound`.
>     - Add `balanceError` state; stop loading when set and log failures.
>   - **UI/UX**:
>     - Show error card for balance retrieval failures ("Balance Check Failed").
>     - Disable purchase button and update label based on `balanceError`/liquidity/balance states.
>     - Use error styling for conversion errors and simplify message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04102f1a7d25a61dc0508f28d64dd52231ef3e9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->