### PR TITLE
feat: show transaction hash on success screen for onchain purchases

### DIFF
--- a/packages/keychain/src/components/purchasenew/pending.tsx
+++ b/packages/keychain/src/components/purchasenew/pending.tsx
@@ -2,7 +2,6 @@ import {
   Button,
   Card,
   CardDescription,
-  CheckIcon,
   ExternalIcon,
   HeaderInner,
   LayoutContent,
@@ -332,7 +331,7 @@ export function ConfirmingTransaction({
       <CardDescription className="flex flex-row items-start gap-3 items-center">
         <div className="flex justify-between w-full">
           <div className="text-foreground-200 font-normal text-xs flex items-center gap-1">
-            {isLoading ? <Spinner size="sm" /> : <CheckIcon size="sm" />}
+            {isLoading && <Spinner size="sm" />}
             {title}
           </div>
           {externalLink && (

--- a/packages/keychain/src/components/purchasenew/success.tsx
+++ b/packages/keychain/src/components/purchasenew/success.tsx
@@ -65,7 +65,9 @@ export function PurchaseSuccessInner({
         {transactionHash && (
           <ConfirmingTransaction
             title={`${acquisitionType === StarterpackAcquisitionType.Claimed ? "Claimed" : "Confirmed"} on Starknet`}
-            externalLink={getExplorer("starknet", transactionHash, isMainnet).url}
+            externalLink={
+              getExplorer("starknet", transactionHash, isMainnet).url
+            }
             isLoading={false}
           />
         )}


### PR DESCRIPTION
## Summary

This PR adds transaction hash display to the success screen for onchain starterpack purchases, mirroring the functionality already present in the pending screen.

## Changes

- Import `ConfirmingTransaction` component and `getExplorer` utility in success.tsx
- Retrieve `transactionHash` from PurchaseContext
- Display transaction hash with explorer link in the footer when available
- Show "Confirmed on Starknet" for purchases or "Claimed on Starknet" for claims
- Transaction hash only appears for onchain purchases/claims, not for Stripe or Layerswap flows

## Implementation

The implementation reuses the existing `ConfirmingTransaction` component from the pending screen, ensuring consistency in the UI. The component displays with a checkmark (not loading) since it's shown after the transaction has been confirmed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Displays the onchain transaction hash with an explorer link on the success screen and updates the pending status to only show a spinner when loading.
> 
> - **Success screen (`success.tsx`)**:
>   - Retrieve `transactionHash` from `PurchaseContext` and pass to `PurchaseSuccessInner`.
>   - Render `ConfirmingTransaction` with explorer link via `getExplorer("starknet", transactionHash, isMainnet).url`.
>   - Title varies between "Confirmed on Starknet" and "Claimed on Starknet" based on `acquisitionType`.
> - **Pending screen (`pending.tsx`)**:
>   - Update `ConfirmingTransaction` to show a spinner only when `isLoading` (remove check icon).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1958a9a2b3f7901c0e84196fbe1bb4fd77ccae5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->