### PR TITLE
fix: redirect only after auto-creating session in standalone auth

### DIFF
--- a/packages/keychain/src/components/connect/create/useCreateController.ts
+++ b/packages/keychain/src/components/connect/create/useCreateController.ts
@@ -322,10 +322,10 @@ export function useCreateController({
         setController(controller);
 
         // Handle session creation for auto-close cases (no policies or verified policies without token approvals)
-        if (
-          !policies ||
-          (policies.verified && !hasApprovalPolicies(policies))
-        ) {
+        const shouldAutoCreateSession =
+          !policies || (policies.verified && !hasApprovalPolicies(policies));
+
+        if (shouldAutoCreateSession) {
           await createSession({
             controller,
             policies,
@@ -336,12 +336,15 @@ export function useCreateController({
           });
         }
 
-        // Check for redirect_url parameter and redirect after successful signup
-        const urlSearchParams = new URLSearchParams(window.location.search);
-        const redirectUrl = urlSearchParams.get("redirect_url");
-        if (redirectUrl) {
-          // Safely redirect to the specified URL with lastUsedConnector param
-          safeRedirect(redirectUrl, true);
+        // Only redirect if we auto-created the session
+        // Otherwise, user needs to see consent screen or spending limit screen first
+        if (shouldAutoCreateSession) {
+          const urlSearchParams = new URLSearchParams(window.location.search);
+          const redirectUrl = urlSearchParams.get("redirect_url");
+          if (redirectUrl) {
+            // Safely redirect to the specified URL with lastUsedConnector param
+            safeRedirect(redirectUrl, true);
+          }
         }
       }
 
@@ -521,7 +524,10 @@ export function useCreateController({
       setController(loginRet.controller);
 
       // Handle session creation for auto-close cases (no policies or verified policies without token approvals)
-      if (!policies || (policies.verified && !hasApprovalPolicies(policies))) {
+      const shouldAutoCreateSession =
+        !policies || (policies.verified && !hasApprovalPolicies(policies));
+
+      if (shouldAutoCreateSession) {
         await createSession({
           controller: loginRet.controller,
           policies,
@@ -535,12 +541,15 @@ export function useCreateController({
       // Call the authentication success callback
       onAuthenticationSuccess?.();
 
-      // Check for redirect_url parameter and redirect after successful login
-      const urlSearchParams = new URLSearchParams(window.location.search);
-      const redirectUrl = urlSearchParams.get("redirect_url");
-      if (redirectUrl) {
-        // Safely redirect to the specified URL with lastUsedConnector param
-        safeRedirect(redirectUrl, true);
+      // Only redirect if we auto-created the session
+      // Otherwise, user needs to see consent screen or spending limit screen first
+      if (shouldAutoCreateSession) {
+        const urlSearchParams = new URLSearchParams(window.location.search);
+        const redirectUrl = urlSearchParams.get("redirect_url");
+        if (redirectUrl) {
+          // Safely redirect to the specified URL with lastUsedConnector param
+          safeRedirect(redirectUrl, true);
+        }
       }
     },
     [


### PR DESCRIPTION
## Summary

Fixed standalone auth flow to only redirect **after** showing necessary consent/spending limit screens, not before. Previously, users were redirected before these critical interaction screens appeared.

## Problem

When `redirect_url` was present in standalone mode, the flow would redirect unconditionally after signup/login, even when the user needed to see:
- Consent screens for unverified presets
- Spending limit screens for verified presets with token approvals

## Solution

Wrapped redirect logic in the same condition as session auto-creation, so redirects only happen when no additional screens are needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Redirect only occurs if a session was auto-created; otherwise user remains to view consent/spending limit screens.
> 
> - **Standalone auth flow (`packages/keychain/src/components/connect/create/useCreateController.ts`)**:
>   - Introduce `shouldAutoCreateSession` to centralize policy checks for auto session creation.
>   - Gate session creation and subsequent redirect behind `shouldAutoCreateSession` in both signup and login paths.
>   - Prevent redirect when additional UI is required (consent or spending limits); only redirect after auto-created session via `safeRedirect`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58506ab4e408b573300147452a95a3e140be492b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->