### PR TITLE
refactor: remove unused onAuthenticationSuccess callback

### DIFF
--- a/packages/keychain/src/components/connect/create/useCreateController.ts
+++ b/packages/keychain/src/components/connect/create/useCreateController.ts
@@ -141,11 +141,9 @@ const createSession = async ({
 export function useCreateController({
   isSlot,
   signers,
-  onAuthenticationSuccess,
 }: {
   isSlot?: boolean;
   signers?: AuthOptions;
-  onAuthenticationSuccess?: () => void;
 }) {
   const [waitingForConfirmation, setWaitingForConfirmation] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -347,9 +345,6 @@ export function useCreateController({
           }
         }
       }
-
-      // Call the authentication success callback
-      onAuthenticationSuccess?.();
     },
     [
       setController,
@@ -357,7 +352,6 @@ export function useCreateController({
       policies,
       handleCompletion,
       params,
-      onAuthenticationSuccess,
       closeModal,
       searchParams,
     ],
@@ -538,9 +532,6 @@ export function useCreateController({
         });
       }
 
-      // Call the authentication success callback
-      onAuthenticationSuccess?.();
-
       // Only redirect if we auto-created the session
       // Otherwise, user needs to see consent screen or spending limit screen first
       if (shouldAutoCreateSession) {
@@ -558,7 +549,6 @@ export function useCreateController({
       policies,
       handleCompletion,
       params,
-      onAuthenticationSuccess,
       closeModal,
       searchParams,
     ],


### PR DESCRIPTION
## Summary

Removed the unused `onAuthenticationSuccess` callback parameter from `useCreateController`. This parameter was never passed by any callers and represented dead code that was safe to remove.

## Changes

- Removed parameter definition from the hook signature
- Removed two callback invocations (one after signup, one after login)
- Removed parameter from dependency arrays

All 314 tests pass after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove unused `onAuthenticationSuccess` callback from `useCreateController`, along with its invocations and dependencies.
> 
> - **Keychain Connect**:
>   - **`packages/keychain/src/components/connect/create/useCreateController.ts`**:
>     - Remove unused `onAuthenticationSuccess` parameter from `useCreateController`.
>     - Delete callback invocations after signup and login flows.
>     - Clean up dependency arrays to drop `onAuthenticationSuccess`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9a2e8c0dc6c6cf792e16027f66b5a7a77fde167. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->