### PR TITLE
fix: use redirect URI origin for app ID in standalone auth

### DIFF
--- a/packages/keychain/src/hooks/connection.ts
+++ b/packages/keychain/src/hooks/connection.ts
@@ -597,26 +597,37 @@ export function useConnectionValue() {
     } else {
       const localWalletBridge = new WalletBridge();
       const iframeMethods = localWalletBridge.getIFrameMethods();
-      const currentOrigin = window.location.origin;
 
-      setOrigin(currentOrigin);
+      // In standalone mode with redirect, use redirect URI's origin for app ID
+      const searchParams = new URLSearchParams(window.location.search);
+      const redirectUrl = searchParams.get("redirect_url");
+      let appOrigin = window.location.origin;
+
+      if (redirectUrl) {
+        try {
+          const redirectUrlObj = new URL(redirectUrl);
+          appOrigin = redirectUrlObj.origin;
+        } catch (error) {
+          console.error("Failed to parse redirect_url for app ID:", error);
+          // Fall back to window.location.origin if redirect URL is invalid
+        }
+      }
+
+      setOrigin(appOrigin);
 
       setParent({
         close: async () => {},
         reload: async () => {},
-        externalDetectWallets:
-          iframeMethods.externalDetectWallets(currentOrigin),
-        externalConnectWallet:
-          iframeMethods.externalConnectWallet(currentOrigin),
-        externalSignMessage: iframeMethods.externalSignMessage(currentOrigin),
-        externalSignTypedData:
-          iframeMethods.externalSignTypedData(currentOrigin),
+        externalDetectWallets: iframeMethods.externalDetectWallets(appOrigin),
+        externalConnectWallet: iframeMethods.externalConnectWallet(appOrigin),
+        externalSignMessage: iframeMethods.externalSignMessage(appOrigin),
+        externalSignTypedData: iframeMethods.externalSignTypedData(appOrigin),
         externalSendTransaction:
-          iframeMethods.externalSendTransaction(currentOrigin),
-        externalGetBalance: iframeMethods.externalGetBalance(currentOrigin),
-        externalSwitchChain: iframeMethods.externalSwitchChain(currentOrigin),
+          iframeMethods.externalSendTransaction(appOrigin),
+        externalGetBalance: iframeMethods.externalGetBalance(appOrigin),
+        externalSwitchChain: iframeMethods.externalSwitchChain(appOrigin),
         externalWaitForTransaction:
-          iframeMethods.externalWaitForTransaction(currentOrigin),
+          iframeMethods.externalWaitForTransaction(appOrigin),
       });
     }
 


### PR DESCRIPTION
## Summary
When using standalone auth with redirect, derive the app ID from the redirect URI's origin instead of the current x.cartridge.gg origin. This ensures the correct app ID is used for authentication.

## Changes
- Extract `redirect_url` query parameter in standalone mode
- Use redirect URI origin as `appOrigin` for app ID derivation
- Fall back to `window.location.origin` if redirect URL is invalid or not present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> In standalone mode, use the redirect_url origin for app ID and all wallet bridge calls, falling back to window origin on parse errors.
> 
> - **Keychain (`packages/keychain/src/hooks/connection.ts`)**:
>   - Standalone mode: parse `redirect_url` and set `appOrigin` (fallback to `window.location.origin` on errors).
>   - Use `appOrigin` for `setOrigin` and all wallet bridge methods: `externalDetectWallets`, `externalConnectWallet`, `externalSignMessage`, `externalSignTypedData`, `externalSendTransaction`, `externalGetBalance`, `externalSwitchChain`, `externalWaitForTransaction`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0f367648c71c04c6fadfe4fb7c2dc1b385553fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->