### PR TITLE
Simplify game redirect URLs

### DIFF
--- a/examples/next/src/components/PlayButton.tsx
+++ b/examples/next/src/components/PlayButton.tsx
@@ -14,12 +14,12 @@ interface Game {
 const GAMES: Game[] = [
   {
     name: "Loot Survivor",
-    url: "https://x.cartridge.gg?redirect_url=https://lootsurvivor.io&preset=loot-survivor",
+    url: "https://lootsurvivor.io?controller_redirect",
     description: "Survive the adventure, earn rewards",
   },
   {
     name: "Nums",
-    url: "https://x.cartridge.gg?redirect_url=https://nums-blond.vercel.app&preset=nums",
+    url: "https://nums-blond.vercel.app?controller_redirect",
     description: "Survive the adventure, earn rewards",
   },
 ];


### PR DESCRIPTION
Simplify the game redirect URLs in the PlayButton component to use a cleaner parameter format. Changes redirect flow from `https://x.cartridge.gg?redirect_url=...&preset=...` to direct game URLs with `?controller_redirect` parameter.

This streamlines the integration between the example app and game platforms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace x.cartridge.gg redirect URLs with direct game URLs using ?controller_redirect in `examples/next/src/components/PlayButton.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b83b827b7f7730fc1ae2d4b2e2460757a6a36c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->