### PR TITLE
Fix Turnkey nonce mismatch by persisting across redirect

### DIFF
--- a/packages/keychain/src/wallets/social/turnkey.ts
+++ b/packages/keychain/src/wallets/social/turnkey.ts
@@ -252,6 +252,10 @@ export class TurnkeyWallet {
         searchParams,
       };
     } catch (error) {
+      // Clean up any stored values on error
+      localStorage.removeItem("turnkey-nonce");
+      localStorage.removeItem(URL_PARAMS_KEY);
+      localStorage.removeItem(RPC_URL_KEY);
       setError(new Error(`Final error: ${(error as Error).message}`));
       throw error;
     }


### PR DESCRIPTION
Store nonce in localStorage before Auth0 redirect and reuse it on return since the Turnkey iframe gets recreated during the flow. Minimal, focused fix with no additional logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Persist nonce in localStorage to survive iframe recreation during Auth0 redirect, use it on return, and clean it up after popup or on errors.
> 
> - **Turnkey Auth Flow (`packages/keychain/src/wallets/social/turnkey.ts`)**
>   - Persist `nonce` in `localStorage` (`turnkey-nonce`) before Auth0 redirect to survive iframe recreation.
>   - Use stored `turnkey-nonce` in `handleRedirect`, falling back to `appState.nonce`; remove it afterward.
>   - Cleanup: remove `turnkey-nonce` on successful popup auth and on error, alongside existing `URL_PARAMS_KEY` and `RPC_URL_KEY` removals.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1b137fc8d0ba8421d4fa33a832b43a2691f44a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->