### PR TITLE
Disable vite visualizer auto-open in production

### DIFF
--- a/packages/keychain/vite.config.ts
+++ b/packages/keychain/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig(({ mode }) => ({
     // Add visualizer in build mode
     mode === "production" &&
       visualizer({
-        open: true,
+        open: false,
         gzipSize: true,
         brotliSize: true,
       }),


### PR DESCRIPTION
Prevents the bundle analyzer from automatically opening in the browser when building the keychain package for production, streamlining the build process.

This change disables the `open: true` setting in the Vite visualizer plugin, which was opening the bundle analysis report in the default browser after each production build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stops the Vite visualizer from auto-opening the bundle report during production builds of the keychain package.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de4cf2eca69261300204bd79f7969d2515c19775. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->