### PR TITLE
refactor: move preimage into options for future extensibility

### DIFF
--- a/examples/next/src/components/Starterpack.tsx
+++ b/examples/next/src/components/Starterpack.tsx
@@ -108,7 +108,9 @@ export const Starterpack = () => {
                   if (claimSpId.trim()) {
                     controllerConnector.controller.openStarterPack(
                       claimSpId.trim(),
-                      claimPreimage.trim() || undefined,
+                      {
+                        preimage: claimPreimage.trim(),
+                      },
                     );
                   }
                 }}

--- a/packages/controller/src/controller.ts
+++ b/packages/controller/src/controller.ts
@@ -24,6 +24,7 @@ import {
   ProfileContextTypeVariant,
   ResponseCodes,
   OpenOptions,
+  StarterpackOptions,
 } from "./types";
 import { validateRedirectUrl } from "./url-validator";
 import { parseChainId } from "./utils";
@@ -452,8 +453,8 @@ export default class ControllerProvider extends BaseProvider {
   }
 
   async openStarterPack(
-    starterpackId: string | number,
-    preimage?: string,
+    id: string | number,
+    options?: StarterpackOptions,
   ): Promise<void> {
     if (!this.iframes) {
       return;
@@ -464,7 +465,7 @@ export default class ControllerProvider extends BaseProvider {
       return;
     }
 
-    await this.keychain.openStarterPack(starterpackId, preimage);
+    await this.keychain.openStarterPack(id, options);
     this.iframes.keychain?.open();
   }
 

--- a/packages/controller/src/types.ts
+++ b/packages/controller/src/types.ts
@@ -162,8 +162,8 @@ export interface Keychain {
   openExecute(calls: Call[]): Promise<void>;
   switchChain(rpcUrl: string): Promise<void>;
   openStarterPack(
-    starterpackId: string | number,
-    preimage?: string,
+    id: string | number,
+    options?: StarterpackOptions,
   ): Promise<void>;
   navigate(path: string): Promise<void>;
   hasStorageAccess(): Promise<boolean>;
@@ -266,4 +266,9 @@ export type Tokens = {
 export type OpenOptions = {
   /** The URL to redirect to after authentication (defaults to current page) */
   redirectUrl?: string;
+};
+
+export type StarterpackOptions = {
+  /** The preimage to use */
+  preimage?: string;
 };

--- a/packages/keychain/src/utils/connection/index.ts
+++ b/packages/keychain/src/utils/connection/index.ts
@@ -11,6 +11,7 @@ import { signMessageFactory } from "./sign";
 import { switchChain } from "./switchChain";
 import { navigateFactory } from "./navigate";
 import { hasStorageAccessFactory } from "./storage-access";
+import { StarterpackOptions } from "@cartridge/controller";
 
 export type { ControllerError } from "./execute";
 
@@ -66,9 +67,9 @@ export function connectToController<ParentMethods extends object>({
         navigate("/funding", { replace: true });
       },
       openStarterPack:
-        () => (starterpackId: string | number, preimage?: string) => {
+        () => (id: string | number, options?: StarterpackOptions) => {
           navigate(
-            `/purchase/starterpack/${starterpackId}${preimage ? `?preimage=${preimage}` : ""}`,
+            `/purchase/starterpack/${id}${options?.preimage ? `?preimage=${options.preimage}` : ""}`,
             { replace: true },
           );
         },


### PR DESCRIPTION
## Summary

This PR refactors the `openStarterPack` method to accept an options object instead of a direct `preimage` parameter. This change makes the API more extensible for future additions.

## Changes

- Refactored `openStarterPack` method signature from `(starterpackId, preimage?)` to `(id, options?)`
- Introduced new `StarterpackOptions` type with `preimage` as an optional property
- Updated all call sites to use the new options object format:
  - `packages/controller/src/controller.ts`
  - `packages/controller/src/types.ts`
  - `packages/keychain/src/utils/connection/index.ts`
  - `examples/next/src/components/Starterpack.tsx`

## Benefits

- More extensible API: future options can be added to `StarterpackOptions` without breaking changes
- Consistent with other methods that use options objects
- Better type safety and developer experience

Close we're moving preimage into options so if in the future we decide to add more it'll be easier

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors openStarterPack to accept `{ id, options }` with `StarterpackOptions` (optional `preimage`) and updates controller, keychain navigation, types, and example usage.
> 
> - **API Refactor**
>   - Change `openStarterPack(starterpackId, preimage?)` to `openStarterPack(id, options?)` across `packages/controller` and `packages/keychain`.
>   - Introduce `StarterpackOptions` with optional `preimage` in `packages/controller/src/types.ts`.
> - **Controller**
>   - Update method signature and forward call: `keychain.openStarterPack(id, options)`.
>   - Extend imports to include `StarterpackOptions`.
> - **Keychain**
>   - Update controller bridge to accept `(id, options?)` and build URL with `options.preimage` query param.
> - **Example App**
>   - Update `examples/next/src/components/Starterpack.tsx` to call `openStarterPack(id, { preimage })`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd51466c2b2895cfbfc3b2e370f86e9499354ff4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->