### PR TITLE
Revert "Fix Turnkey nonce mismatch by persisting across redirect (#22…

### DIFF
--- a/packages/keychain/src/wallets/social/turnkey.ts
+++ b/packages/keychain/src/wallets/social/turnkey.ts
@@ -149,8 +149,6 @@ export class TurnkeyWallet {
 
       localStorage.setItem(URL_PARAMS_KEY, urlParamsString);
       localStorage.setItem(RPC_URL_KEY, this.rpcUrl);
-      // Store nonce for use after redirect (iframe will be recreated)
-      localStorage.setItem("turnkey-nonce", nonce);
 
       const redirectUri =
         windowUri.pathname === "/session"
@@ -195,15 +193,12 @@ export class TurnkeyWallet {
         },
         { popup },
       );
-      // Clean up stored nonce after successful popup auth
-      localStorage.removeItem("turnkey-nonce");
       return await this.finishConnect({
         nonce,
       });
     } catch (error) {
       localStorage.removeItem(URL_PARAMS_KEY);
       localStorage.removeItem(RPC_URL_KEY);
-      localStorage.removeItem("turnkey-nonce");
       console.error(`Error connecting to Turnkey:`, error);
       return {
         success: false,
@@ -239,23 +234,15 @@ export class TurnkeyWallet {
         : undefined;
 
       const rpcUrl = localStorage.getItem(RPC_URL_KEY);
-      // Use stored nonce (iframe was recreated during redirect)
-      const storedNonce = localStorage.getItem("turnkey-nonce");
-      localStorage.removeItem("turnkey-nonce");
-
       return {
         ...(await this.finishConnect({
-          nonce: storedNonce || result.appState.nonce,
+          nonce: result.appState.nonce,
         })),
         ...result.appState,
         rpcUrl,
         searchParams,
       };
     } catch (error) {
-      // Clean up any stored values on error
-      localStorage.removeItem("turnkey-nonce");
-      localStorage.removeItem(URL_PARAMS_KEY);
-      localStorage.removeItem(RPC_URL_KEY);
       setError(new Error(`Final error: ${(error as Error).message}`));
       throw error;
     }


### PR DESCRIPTION
…10)"

This reverts commit 7762412111872e24c983d3a92ddc2c3f480ae1f5.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stop persisting Turnkey nonce in localStorage; always use Auth0 appState nonce during connect/redirect.
> 
> - **Auth flow (Turnkey/Auth0)**:
>   - Remove use of `localStorage` for `turnkey-nonce` (no set/get/remove).
>   - In `handleRedirect`, always pass `result.appState.nonce` to `finishConnect` (no stored nonce fallback).
>   - Drop nonce cleanup after popup and on errors; retain only `URL_PARAMS_KEY`/`RPC_URL_KEY` handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2af7a64492c271a9be923599d254953cf72b093. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->