### PR TITLE
Refactor session creation to load controller from store

### DIFF
--- a/packages/keychain/src/components/connect/StandaloneSessionCreation.tsx
+++ b/packages/keychain/src/components/connect/StandaloneSessionCreation.tsx
@@ -133,7 +133,15 @@ export function StandaloneSessionCreation({ username }: { username?: string }) {
         setIsConnecting(false);
       }
     },
-    [closeModal, policies, expiresAt, redirectUrl, parent, origin, setController],
+    [
+      closeModal,
+      policies,
+      expiresAt,
+      redirectUrl,
+      parent,
+      origin,
+      setController,
+    ],
   );
 
   const handlePrimaryAction = useCallback(async () => {


### PR DESCRIPTION
Move controller initialization from context to Component, loading from storage on demand after requesting storage access. Remove auto-approve logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors standalone session creation to request storage access, load the controller from storage on demand, and remove the auto-approve flow for verified presets.
> 
> - **StandaloneSessionCreation (`packages/keychain/src/components/connect/StandaloneSessionCreation.tsx`)**
>   - Load `controller` from storage via `Controller.fromStore()` after storage access grant; set on `window` and via `setController`.
>   - Remove auto-approve logic for verified presets and related state/effect (`hasAutoApproved`).
>   - Update `createSession` flow: guard `policies`, request storage access, create session, notify parent, and redirect.
>   - Replace `useConnection` usage to pull `setController` (not `controller`); update hook dependencies accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2d18d9e8dc50356521332554e434376f744cd5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->