### PR TITLE
Remove controller_redirect functionality

### DIFF
--- a/examples/next/src/components/PlayButton.tsx
+++ b/examples/next/src/components/PlayButton.tsx
@@ -14,12 +14,12 @@ interface Game {
 const GAMES: Game[] = [
   {
     name: "Loot Survivor",
-    url: "https://lootsurvivor.io?controller_redirect",
+    url: `${process.env.NEXT_PUBLIC_KEYCHAIN_FRAME_URL}?redirect_url=https://lootsurvivor.io&preset=loot-survivor`,
     description: "Survive the adventure, earn rewards",
   },
   {
     name: "Nums",
-    url: "https://nums-blond.vercel.app?controller_redirect",
+    url: `${process.env.NEXT_PUBLIC_KEYCHAIN_FRAME_URL}?redirect_url=https://nums-blond.vercel.app&preset=nums`,
     description: "Survive the adventure, earn rewards",
   },
 ];
@@ -44,9 +44,7 @@ export const PlayButton = () => {
     <div className="border border-border rounded-lg p-6 bg-surface">
       <h2 className="text-2xl font-bold mb-4">Play Games</h2>
       <p className="text-muted mb-6">
-        Launch games with your Cartridge controller. First-time users will be
-        redirected through standalone authentication to enable seamless login
-        across all games.
+        Launch games with your Cartridge controller.
       </p>
       <div className="grid gap-4">
         {GAMES.map((game) => (

--- a/packages/controller/src/controller.ts
+++ b/packages/controller/src/controller.ts
@@ -72,36 +72,6 @@ export default class ControllerProvider extends BaseProvider {
 
     this.options = { ...options, chains, defaultChainId };
 
-    // Handle automatic redirect to keychain for standalone flow
-    // When controller_redirect is present, automatically redirect to keychain
-    // This establishes first-party storage access for the keychain
-    // IMPORTANT: Check this BEFORE cleaning up URL parameters
-    if (typeof window !== "undefined") {
-      // Check if controller_redirect flag is present (any value or just the key)
-      const hasControllerRedirect = urlParams?.has("controller_redirect");
-      if (hasControllerRedirect) {
-        // Use configured keychain URL (not user-provided)
-        const keychainUrl = new URL(options.url || KEYCHAIN_URL);
-
-        // Build redirect URL preserving all query params and hash except controller_redirect
-        // This matches the behavior of open() method which uses window.location.href
-        const currentUrl = new URL(window.location.href);
-        currentUrl.searchParams.delete("controller_redirect");
-        const redirectUrl = currentUrl.toString();
-
-        keychainUrl.searchParams.set("redirect_url", redirectUrl);
-
-        // Preserve the preset if it was configured in options
-        if (options.preset) {
-          keychainUrl.searchParams.set("preset", options.preset);
-        }
-
-        // Redirect to keychain
-        window.location.href = keychainUrl.toString();
-        return; // Stop further initialization
-      }
-    }
-
     // Auto-detect and set lastUsedConnector from URL parameter
     // This is set by the keychain after redirect flow completion
     if (typeof window !== "undefined" && typeof localStorage !== "undefined") {
@@ -130,12 +100,6 @@ export default class ControllerProvider extends BaseProvider {
 
         if (lastUsedConnector) {
           urlParams.delete("lastUsedConnector");
-          needsCleanup = true;
-        }
-
-        // Also remove controller_redirect if present (shouldn't be after redirect, but just in case)
-        if (urlParams.has("controller_redirect")) {
-          urlParams.delete("controller_redirect");
           needsCleanup = true;
         }
 


### PR DESCRIPTION
## Summary

Removes the automatic redirect to keychain flow that was using the `controller_redirect` parameter, simplifying the authentication architecture and eliminating unnecessary intermediate redirects.

## Changes

- Removed redirect logic in ControllerProvider that checked for `controller_redirect` parameter
- Updated PlayButton example to use environment variable-based keychain URLs
- Removes 36+ lines of redirect handling code

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the controller_redirect auto-redirect logic and updates the example PlayButton to use env-based keychain URLs with presets.
> 
> - **Controller (`packages/controller/src/controller.ts`)**:
>   - Remove automatic keychain redirect logic tied to `controller_redirect` and related URL cleanup.
>   - Keep standalone return handling via `controller_standalone` and `lastUsedConnector`, with URL param cleanup.
> - **Example (`examples/next/src/components/PlayButton.tsx`)**:
>   - Change game links to use `process.env.NEXT_PUBLIC_KEYCHAIN_FRAME_URL` with `redirect_url` and `preset` params.
>   - Shorten helper text copy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00f82fc941e8d2ba8ee26c3d4793bb6e9d2e407e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->