### PR TITLE
fix: don't throw err on popup

### DIFF
--- a/packages/keychain/src/utils/url.ts
+++ b/packages/keychain/src/utils/url.ts
@@ -45,11 +45,8 @@ export const PopupCenter = (
   features.push("scrollbars=1");
 
   const newWindow = window.open(url, title, features.join(","));
-  if (!newWindow || newWindow.closed) {
-    throw new Error("Popup blocked: " + url);
-  }
 
-  newWindow.focus();
+  newWindow?.focus();
 
   return newWindow;
 };


### PR DESCRIPTION
This reverts it to original behavior, related to mobile popup, don't throw error otherwise flow breaks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stop throwing when popup is blocked and safely focus the new window in `PopupCenter`.
> 
> - **Utils (`packages/keychain/src/utils/url.ts`)**:
>   - **`PopupCenter`**: Remove thrown error when `window.open` returns `null`/closed; use `newWindow?.focus()` to safely focus the popup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b0af1b613ec659c314d04eb11e064f8465a44e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->