### PR TITLE
feat: hookup devconnect claim

### DIFF
--- a/packages/keychain/src/hooks/merkle-claim.ts
+++ b/packages/keychain/src/hooks/merkle-claim.ts
@@ -44,7 +44,7 @@ export const useMerkleClaim = ({
   preimage,
 }: {
   keys: string;
-  address: string;
+  address?: string;
   type: ExternalWalletType | "controller" | "preimage";
   preimage?: string;
 }) => {
@@ -56,6 +56,10 @@ export const useMerkleClaim = ({
   const checkedClaimsRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
+    if (!address) {
+      return;
+    }
+
     setIsLoading(true);
     client
       .request<MerkleClaimsForAddressQuery>(MerkleClaimsForAddressDocument, {
@@ -94,7 +98,7 @@ export const useMerkleClaim = ({
 
   const checkAllClaims = useCallback(
     async (claimsToCheck: MerkleClaim[]) => {
-      if (claimsToCheck.length === 0 || !controller) {
+      if (claimsToCheck.length === 0 || !controller || !address) {
         return;
       }
 
@@ -161,7 +165,13 @@ export const useMerkleClaim = ({
   // TODO: Use ABI to generate the calldata
   const onSendClaim = useCallback(
     async (claimIndices?: number[]) => {
-      if (!merkleTreeKey || !leafData || !controller || !claims.length) {
+      if (
+        !merkleTreeKey ||
+        !leafData ||
+        !controller ||
+        !claims.length ||
+        !address
+      ) {
         const error = new Error("Missing required data");
         setError(error);
         throw error;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Integrates Merkle claim retrieval/submission into Booster Pack using a preimage-derived EVM address, adds claim loading/status handling, and updates eligibility checks and UI states.
> 
> - **Booster Pack UI (`packages/keychain/src/components/booster-pack/index.tsx`)**
>   - Derives `ethereumAddress` via `useMemo(privateKey)` and uses it for eligibility and claims.
>   - Integrates `useMerkleClaim` with aggregated `keys`, `type: "preimage"`, `address`, and `preimage`.
>   - Loads claims, surfaces "No claims found", and sets `isClaimed` based on claim statuses.
>   - Calls `onSendClaim()` during claim; logs `{ claimHash, isMainnet }`.
>   - Expands loading/disabled logic to include `isLoadingClaims`; updates button text to reflect claim loading; requires `controller` for post-claim play button.
>   - Updates asset eligibility check to depend on `ethereumAddress`.
> - **Merkle Claim Hook (`packages/keychain/src/hooks/merkle-claim.ts`)**
>   - Makes `address` optional; early-returns when missing.
>   - Requires `address` in claim checks and submissions; resets checked state on new claims.
>   - Supports EVM preimage signing for `externalSignMessage`; blocks preimage for Starknet typed-data.
>   - Validates homogeneous EVM/non-EVM claims; constructs signature payloads; submits via `controller.executeFromOutsideV3`.
>   - Improves error handling and loading management for claim discovery and verification.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe7b5b60f8b54bd7417519c426a8f020436cdd66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->