### PR TITLE
fix: merkle claim ui stuck

### DIFF
--- a/packages/keychain/src/components/app.tsx
+++ b/packages/keychain/src/components/app.tsx
@@ -61,6 +61,7 @@ import { useEffect } from "react";
 import { StandaloneSessionCreation } from "./connect/StandaloneSessionCreation";
 import { StandaloneConnect } from "./connect/StandaloneConnect";
 import { hasApprovalPolicies } from "@/hooks/session";
+import { PurchaseStarterpack } from "./purchasenew/starterpack/starterpack";
 
 function DefaultRoute() {
   const account = useAccount();
@@ -220,7 +221,7 @@ export function App() {
           />
           <Route
             path="starterpack/:starterpackId"
-            element={<OnchainCheckout />} // Short circuit to checkout for now since we only support Starknet
+            element={<PurchaseStarterpack />}
           />
           <Route path="starterpack/collections" element={<Collections />} />
           <Route path="claim/:keys/:address/:type" element={<Claim />} />

--- a/packages/keychain/src/components/purchasenew/checkout/onchain/index.tsx
+++ b/packages/keychain/src/components/purchasenew/checkout/onchain/index.tsx
@@ -21,10 +21,8 @@ import { isOnchainStarterpack } from "@/context";
 import { num, uint256 } from "starknet";
 import { getWallet } from "../../wallet/config";
 import { LoadingState } from "../../loading";
-import { useParams } from "react-router-dom";
 
 export function OnchainCheckout() {
-  const { starterpackId } = useParams();
   const {
     isStarterpackLoading,
     isFetchingConversion,
@@ -39,7 +37,6 @@ export function OnchainCheckout() {
     conversionError,
     incrementQuantity,
     decrementQuantity,
-    setStarterpackId,
     onOnchainPurchase,
     clearError,
   } = usePurchaseContext();
@@ -135,12 +132,6 @@ export function OnchainCheckout() {
       setIsLoading(false);
     }
   }, [hasSufficientBalance, isFree, onOnchainPurchase, navigate, clearError]);
-
-  useEffect(() => {
-    if (!isStarterpackLoading && starterpackId) {
-      setStarterpackId(starterpackId);
-    }
-  }, [starterpackId, isStarterpackLoading, setStarterpackId]);
 
   // Fetch user's token balance
   useEffect(() => {

--- a/packages/keychain/src/components/purchasenew/starterpack/starterpack.tsx
+++ b/packages/keychain/src/components/purchasenew/starterpack/starterpack.tsx
@@ -68,6 +68,15 @@ export function PurchaseStarterpack() {
         replace: true,
       });
     }
+
+    // TEMP: Short circuit to checkout if onchain starterpack
+    if (
+      !isStarterpackLoading &&
+      isOnchainStarterpack(details) &&
+      !displayError
+    ) {
+      navigate(`/purchase/checkout/onchain`, { replace: true });
+    }
   }, [isStarterpackLoading, details, preimage, displayError, navigate]);
 
   if (isStarterpackLoading || preimage) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Routes starterpack purchases through a new `PurchaseStarterpack` component, moving starterpack initialization and redirects there and decoupling `OnchainCheckout` from route params.
> 
> - **Purchase Flow**:
>   - **Starterpack Routing**: Replace `purchase/starterpack/:starterpackId` element with `PurchaseStarterpack`.
>   - **Initialization**: Move `setStarterpackId` handling from `OnchainCheckout` to `PurchaseStarterpack`; remove `useParams` and related effect from `OnchainCheckout`.
>   - **Auto-Redirects**:
>     - Claim flow: when preimage is present and ETHEREUM merkle drops exist, redirect to `purchase/claim/...`.
>     - Onchain starterpacks: temporarily redirect directly to `purchase/checkout/onchain`.
>   - **Checkout**: `OnchainCheckout` now relies on context only (no route param).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a45b5c61b7e7cc88e1b07f41acdc0c8226d6a41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->