### PR TITLE
fix: ifarme allow local network

### DIFF
--- a/examples/next/src/components/providers/StarknetProvider.tsx
+++ b/examples/next/src/components/providers/StarknetProvider.tsx
@@ -204,7 +204,7 @@ const controller = new ControllerConnector({
   //
   // However, if you want to use custom RPC URLs, you can still specify them:
   chains: controllerConnectorChains,
-  url: "https://x.cartridge.gg",
+  url: getKeychainUrl(),
   signupOptions,
   slot: "arcade-pistols",
   namespace: "pistols",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `local-network-access *` to the iframe `allow` attribute to enable local network access.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63c64a1368ab017aa05c3fcad999b72ecc9be5ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->