### PR TITLE
fix: reduce Ekubo API console noise and rate limit impact

### DIFF
--- a/packages/keychain/src/components/provider/tokens.tsx
+++ b/packages/keychain/src/components/provider/tokens.tsx
@@ -254,7 +254,12 @@ export function TokensProvider({
               quote: "USDC",
             };
           } catch (error) {
-            console.error(`Failed to fetch price for ${address}:`, error);
+            // Only log non-429 errors (rate limiting is expected)
+            const is429 =
+              error instanceof Error && error.message.includes("429");
+            if (!is429) {
+              console.error(`Failed to fetch price for ${address}:`, error);
+            }
             return null;
           }
         }),
@@ -271,7 +276,7 @@ export function TokensProvider({
     {
       refetchInterval,
       enabled: debouncedAddresses.length > 0,
-      staleTime: 30000,
+      staleTime: 60000, // 1 minute - reduce Ekubo API calls
     },
   );
 


### PR DESCRIPTION
Reduces console noise from Ekubo API rate limiting (429 errors) by:

   - **Removing verbose logging**: Remove \`console.warn\` for rate limit retries and \`console.error\` for price fetch failures since these are expected behaviors
   - **Reducing retry attempts**: Change \`maxRetries\` from 5 to 3 to reduce browser network error log spam
   - **Increasing backoff**: Change \`baseBackoff\` from 500ms to 1000ms to be gentler on the API
   - **Extending cache time**: Increase price query \`staleTime\` from 30s to 60s to reduce request frequency

   ### Changes

   - \`packages/keychain/src/utils/ekubo.ts\`: Remove console.warn logs, reduce retries (5→3), increase base backoff (500ms→1000ms)
   - \`packages/keychain/src/components/provider/tokens.tsx\`: Remove console.error, increase staleTime (30s→60s)

   ### Note

   Browser-native network errors (\`GET ... 429\`) will still appear in DevTools as these cannot be suppressed from JavaScript - they are logged by the browser itself.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Suppress noisy 429 logs, reduce retries (5→3), increase backoff (500ms→1000ms), and extend price query cache (30s→60s).
> 
> - **Ekubo utils (`packages/keychain/src/utils/ekubo.ts`)**:
>   - Reduce `RETRY_CONFIG.maxRetries` 5→3 and increase `baseBackoff` 500ms→1000ms; keep `maxBackoffDelay`/`timeout`.
>   - Silence retry logging: remove `console.warn` on 429 and network retries; keep silent backoff using `Retry-After` when present.
>   - Maintain non-retryable handling (e.g., insufficient liquidity) and abort semantics.
> - **Tokens provider (`packages/keychain/src/components/provider/tokens.tsx`)**:
>   - Only log `console.error` for price fetch failures that are not 429; ignore expected rate limits.
>   - Increase price query `staleTime` 30s→60s to reduce Ekubo API calls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab3b19c68efa6f471200ece7155cd60dc9ad2c51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->