### PR TITLE
fix: add payment permission to iframe for Stripe checkout

### DIFF
--- a/packages/controller/src/iframe/base.ts
+++ b/packages/controller/src/iframe/base.ts
@@ -55,7 +55,7 @@ export class IFrame<CallSender extends {}> implements Modal {
     iframe.sandbox.add("allow-scripts");
     iframe.sandbox.add("allow-same-origin");
     iframe.allow =
-      "publickey-credentials-create *; publickey-credentials-get *; clipboard-write; local-network-access *";
+      "publickey-credentials-create *; publickey-credentials-get *; clipboard-write; local-network-access *; payment *";
     iframe.style.scrollbarWidth = "none";
     iframe.style.setProperty("-ms-overflow-style", "none");
     iframe.style.setProperty("-webkit-scrollbar", "none");


### PR DESCRIPTION
## Summary

Adds the `payment` permission to the keychain iframe's `allow` attribute to enable Payment Request API access for Stripe checkout.

## Problem

When using Stripe Payment Element inside the keychain iframe, the browser logs a console error:

```
[Violation] Potential permissions policy violation: payment is not allowed in this document.
```

This occurs because Stripe tries to detect if the Payment Request API is available (used for Apple Pay, Google Pay, browser-saved cards), but the iframe didn't have the required `payment` permission.

## Solution

Added `payment *` to the iframe's `allow` attribute in `packages/controller/src/iframe/base.ts`.

## Changes

- Added `payment *` permission to enable Payment Request API access in the iframe

## Benefits

- Silences the browser console warning/violation
- Enables Stripe to offer Apple Pay, Google Pay, and browser-saved card options if available
- Existing card form checkout continues to work unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `payment *` to the iframe `allow` attribute to enable Payment Request API usage (e.g., Stripe).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 281558bade7d715eca3d15964ec219d9cec110f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->