### PR TITLE
fix: prevent Turnkey nonce mismatch by clearing cached Auth0 tokens

### DIFF
--- a/packages/keychain/src/utils/api/generated.ts
+++ b/packages/keychain/src/utils/api/generated.ts
@@ -1868,6 +1868,8 @@ export enum LayerswapStatus {
   Expired = "EXPIRED",
   Failed = "FAILED",
   Pending = "PENDING",
+  PendingLsTransfer = "PENDING_LS_TRANSFER",
+  PendingUserTransfer = "PENDING_USER_TRANSFER",
 }
 
 export type Lock = Node & {


### PR DESCRIPTION
## Summary

Prevents the "Nonce mismatch" error in Turnkey/Auth0 authentication by proactively clearing the Auth0 token cache before each connection attempt. This ensures a fresh token is obtained with the correct nonce, rather than reusing a cached token with a stale nonce.

## Technical Details

Each Turnkey connection generates a new nonce from the iframe's public key. However, cached Auth0 tokens contained old nonces that didn't match, causing validation failures. The fix clears the Auth0 cache upfront before nonce generation, simplifying the error handling flow.

## Changes

- Proactively logout cached Auth0 session before nonce generation
- Remove redundant reactive error handling for invalid cached tokens
- Simplify connect flow from ~25 lines to ~5 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Turnkey Auth0 login now validates token nonce against iframe key (clearing stale sessions, using cached session when valid) and GraphQL adds two new Layerswap pending statuses.
> 
> - **Auth/Wallet – Turnkey (`packages/keychain/src/wallets/social/turnkey.ts`)**:
>   - Validate cached Auth0 ID token by comparing `tknonce` to iframe-derived `nonce`; logout if mismatched.
>   - Fast-path connect using cached session when nonce matches; otherwise proceed with normal OAuth flow.
>   - Retain fallback to clear session on `OIDC_INVALID_TOKEN_ERROR`.
> - **API Types (`packages/keychain/src/utils/api/generated.ts`)**:
>   - Extend `LayerswapStatus` with `PENDING_LS_TRANSFER` and `PENDING_USER_TRANSFER`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bcfbcfa11ed0ee39a8a0e70eb56ca2c23b965e7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->