### PR TITLE
fix(purchase): empty flicker on network select

### DIFF
--- a/packages/keychain/src/components/purchasenew/wallet/wallet.tsx
+++ b/packages/keychain/src/components/purchasenew/wallet/wallet.tsx
@@ -29,6 +29,7 @@ export function SelectWallet() {
     useOnchainPurchaseContext();
   const [error, setError] = useState<Error | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [isDetecting, setIsDetecting] = useState(true);
   const [chainIds, setChainIds] = useState<Map<string, string>>(new Map());
   const [availableWallets, setAvailableWallets] = useState<
     Map<string, ExternalWallet[]>
@@ -62,10 +63,12 @@ export function SelectWallet() {
   useEffect(() => {
     if (!selectedNetworks.length) {
       setAvailableWallets(new Map());
+      setIsDetecting(false);
       return;
     }
 
     const getWallets = async () => {
+      setIsDetecting(true);
       const newAvailableWallets = new Map<string, ExternalWallet[]>();
       const newChainIds = new Map<string, string>();
       const wallets = await externalDetectWallets();
@@ -97,9 +100,13 @@ export function SelectWallet() {
 
       setChainIds(newChainIds);
       setAvailableWallets(newAvailableWallets);
+      setIsDetecting(false);
     };
 
-    getWallets().catch((e) => setError(e as Error));
+    getWallets().catch((e) => {
+      setError(e as Error);
+      setIsDetecting(false);
+    });
   }, [externalDetectWallets, isMainnet, selectedNetworks]);
 
   useEffect(() => {
@@ -192,6 +199,10 @@ export function SelectWallet() {
     const wallets = availableWallets.get(network.platform);
     return wallets && wallets.length > 0;
   });
+
+  if (isDetecting) {
+    return <></>;
+  }
 
   return (
     <>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add an `isDetecting` state to suppress the empty UI while detecting wallets and ensure it resets on no networks and on errors.
> 
> - **Wallet selection (`packages/keychain/src/components/purchasenew/wallet/wallet.tsx`)**:
>   - Introduce `isDetecting` state to track external wallet detection lifecycle.
>     - Set `isDetecting` true before detection, false after completion, when no networks, and on detection errors.
>     - Early-return empty fragment while detecting to avoid rendering the empty state.
>   - Update detection flow: ensure catch handler also clears `isDetecting`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96647e02df6ba9b033f8f99d1192ff4dcc5d6c27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->