### PR TITLE
fix: remove warning logs related to ekubo quote

### DIFF
--- a/packages/keychain/src/hooks/starterpack/onchain.ts
+++ b/packages/keychain/src/hooks/starterpack/onchain.ts
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useState, useMemo } from "react";
 import { useController } from "@/hooks/controller";
 import { useConnection } from "@/hooks/connection";
-import { CairoByteArray, Call, constants, uint256 } from "starknet";
+import { CairoByteArray, Call, uint256 } from "starknet";
 import {
+  chainIdToEkuboNetwork,
   fetchSwapQuote,
   USDC_ADDRESSES,
-  type EkuboNetwork,
 } from "@/utils/ekubo";
 import { getCurrentReferral } from "@/utils/referral";
 import { Quote } from "@/context";
@@ -56,21 +56,6 @@ function convertMetadata(
       imageUri: item.image_uri,
     })),
   };
-}
-
-/**
- * Convert chainId to Ekubo network type
- */
-function chainIdToEkuboNetwork(chainId: string): EkuboNetwork {
-  switch (chainId) {
-    case constants.StarknetChainId.SN_MAIN:
-      return "mainnet";
-    case constants.StarknetChainId.SN_SEPOLIA:
-      return "sepolia";
-    default:
-      console.warn(`Unknown chainId ${chainId}, defaulting to mainnet`);
-      return "mainnet";
-  }
 }
 
 export const useOnchainStarterpack = (

--- a/packages/keychain/src/utils/ekubo/index.ts
+++ b/packages/keychain/src/utils/ekubo/index.ts
@@ -552,7 +552,7 @@ export function chainIdToEkuboNetwork(chainId: string): EkuboNetwork {
     case constants.StarknetChainId.SN_SEPOLIA:
       return "sepolia";
     default:
-      console.warn(`Unknown chainId ${chainId}, defaulting to mainnet`);
+      //console.warn(`Unknown chainId ${chainId}, defaulting to mainnet`);
       return "mainnet";
   }
 }


### PR DESCRIPTION
Hide the warnings for now. This issue is related to ekubo quotes being called on init rather than on demand, leading to a lot of 429 rate limit errors and console warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Silences Ekubo network warning and refactors onchain starterpack hook to use the shared `chainIdToEkuboNetwork` util instead of a local implementation.
> 
> - **Utils (`packages/keychain/src/utils/ekubo/index.ts`)**
>   - Suppress warning on unknown chain IDs in `chainIdToEkuboNetwork` (comment out console.warn).
> - **Hooks (`packages/keychain/src/hooks/starterpack/onchain.ts`)**
>   - Remove local `chainIdToEkuboNetwork` implementation and import it from `@/utils/ekubo`.
>   - Drop unused `constants` import from `starknet`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c80fc45c5eaff895d2ce3cdbb651497ad421eb2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->