### PR TITLE
Revert "Brand submit button with single signer (#2281)"

### DIFF
--- a/examples/next/next-env.d.ts
+++ b/examples/next/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/keychain/src/components/connect/create/CreateController.tsx
+++ b/packages/keychain/src/components/connect/create/CreateController.tsx
@@ -61,7 +61,7 @@ interface CreateControllerViewProps {
 
 type CreateControllerFormProps = Omit<
   CreateControllerViewProps,
-  "setAuthenticationStep"
+  "setAuthenticationStep" | "authOptions"
 >;
 
 function getIOSVersion(userAgentString: string) {
@@ -91,7 +91,6 @@ function CreateControllerForm({
   submitButtonRef,
   isDropdownOpen,
   onDropdownOpenChange,
-  authOptions,
 }: CreateControllerFormProps) {
   const [{ isInApp, appKey, appName }] = useState(() => InAppSpy());
   const { isOpen: keyboardIsOpen, viewportHeight } = useDetectKeyboardOpen();
@@ -268,7 +267,6 @@ function CreateControllerForm({
             validation={validation}
             waitingForConfirmation={waitingForConfirmation}
             username={usernameField.value}
-            signupOptions={authOptions}
             onMouseDown={() => {
               if (keyboardIsOpen) {
                 // If keyboard is open, mark for pending submit after it closes
@@ -350,7 +348,6 @@ export function CreateControllerView({
           submitButtonRef={submitButtonRef}
           isDropdownOpen={isDropdownOpen}
           onDropdownOpenChange={onDropdownOpenChange}
-          authOptions={authOptions}
         />
         <ChooseSignupMethodForm
           isLoading={isLoading}


### PR DESCRIPTION
This reverts commit a55e14f28d37266cef95870dd257c106aaec0680.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies the AuthButton to generic login/signup with signer-based resolution (removing signup options and branded states) and updates CreateController accordingly, plus adds Next.js route types import.
> 
> - **Keychain UI**:
>   - **AuthButton (`packages/keychain/.../auth-button.tsx`)**:
>     - Removed `signupOptions` prop and all signup-branding logic; button text is now generic ("log in"/"sign up").
>     - Simplified option resolution to only handle existing signers; uses `webauthn` when mixed; dropped `password` and `phantom-evm` options and related icons/imports.
>     - Streamlined extension-missing check to evaluate only current signers.
>   - **CreateController (`packages/keychain/.../CreateController.tsx`)**:
>     - Updated types to omit `authOptions` from `CreateControllerFormProps` and stopped passing `authOptions` to `AuthButton`.
> - **Examples**:
>   - `examples/next/next-env.d.ts`: import `./.next/types/routes.d.ts` for route types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d8939a7efa31a6b35958793ad4daf6aef0cb2e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->