### PR TITLE
fix(ekubo): update API URL to new format with chain ID

### DIFF
--- a/packages/keychain/src/components/provider/tokens.tsx
+++ b/packages/keychain/src/components/provider/tokens.tsx
@@ -14,7 +14,7 @@ import {
 import { Price } from "@cartridge/ui/utils/api/cartridge";
 import { useQuery } from "react-query";
 import { getChecksumAddress } from "starknet";
-import { fetchSwapQuoteInUsdc, chainIdToEkuboNetwork } from "@/utils/ekubo";
+import { fetchSwapQuoteInUsdc } from "@/utils/ekubo";
 
 export const DEFAULT_TOKENS = [
   {
@@ -217,7 +217,6 @@ export function TokensProvider({
     async () => {
       if (debouncedAddresses.length === 0 || !chainId) return [];
 
-      const network = chainIdToEkuboNetwork(chainId);
       const USDC_DECIMALS = 6;
       const ONE_USDC = BigInt(10 ** USDC_DECIMALS); // 1 USDC
 
@@ -244,7 +243,7 @@ export function TokensProvider({
             const tokenAmount = await fetchSwapQuoteInUsdc(
               address,
               BigInt(10 ** (tokenDecimals + 1)),
-              network,
+              chainId,
             );
 
             return {

--- a/packages/keychain/src/context/starterpack/onchain-purchase.tsx
+++ b/packages/keychain/src/context/starterpack/onchain-purchase.tsx
@@ -12,11 +12,7 @@ import { usdcToUsd } from "@/utils/starterpack";
 import { uint256, Call, num, cairo } from "starknet";
 import { isOnchainStarterpack } from "./types";
 import { getCurrentReferral } from "@/utils/referral";
-import {
-  chainIdToEkuboNetwork,
-  prepareSwapCalls,
-  type SwapQuote,
-} from "@/utils/ekubo";
+import { prepareSwapCalls, type SwapQuote } from "@/utils/ekubo";
 import { Item } from "./types";
 import { useStarterpackContext } from "./starterpack";
 import {
@@ -140,7 +136,6 @@ export const OnchainPurchaseProvider = ({
     resetTokenSelection,
   } = useTokenSelection({
     controller,
-    isMainnet,
     starterpackDetails: onchainDetails,
     quantity,
     selectedPlatform,
@@ -246,8 +241,6 @@ export const OnchainPurchaseProvider = ({
           throw new Error("No swap quote found");
         }
 
-        const network = chainIdToEkuboNetwork(controller.chainId());
-
         // Note: swapQuote is already fetched with quantity applied in useTokenSelection,
         // so prepareSwapCalls uses it directly without additional scaling
         const { allCalls: swapCalls } = prepareSwapCalls({
@@ -255,7 +248,7 @@ export const OnchainPurchaseProvider = ({
           paymentToken: quote.paymentToken,
           totalCostWithQuantity,
           swapQuote,
-          network,
+          chainId: controller.chainId(),
         });
 
         allCalls = swapCalls;

--- a/packages/keychain/src/hooks/starterpack/onchain.ts
+++ b/packages/keychain/src/hooks/starterpack/onchain.ts
@@ -2,11 +2,7 @@ import { useCallback, useEffect, useState, useMemo } from "react";
 import { useController } from "@/hooks/controller";
 import { useConnection } from "@/hooks/connection";
 import { CairoByteArray, Call, uint256 } from "starknet";
-import {
-  chainIdToEkuboNetwork,
-  fetchSwapQuote,
-  USDC_ADDRESSES,
-} from "@/utils/ekubo";
+import { fetchSwapQuote, USDC_ADDRESSES } from "@/utils/ekubo";
 import { getCurrentReferral } from "@/utils/referral";
 import { Quote } from "@/context";
 import {
@@ -185,15 +181,18 @@ export const useOnchainStarterpack = (
         };
 
         // Convert price to target token if specified and different from payment token
-        const network = chainIdToEkuboNetwork(controller.chainId());
-        const targetTokenAddress = targetToken || USDC_ADDRESSES[network];
-        if (paymentToken.toLowerCase() !== targetTokenAddress.toLowerCase()) {
+        const chainId = controller.chainId();
+        const targetTokenAddress = targetToken || USDC_ADDRESSES[chainId];
+        if (
+          targetTokenAddress &&
+          paymentToken.toLowerCase() !== targetTokenAddress.toLowerCase()
+        ) {
           try {
             const swapQuote = await fetchSwapQuote(
               totalCost,
               paymentToken,
               targetTokenAddress,
-              network,
+              chainId,
             );
 
             // Get target token metadata (use cache or fetch via RPC)

--- a/packages/keychain/src/utils/ekubo/swap-calls.test.ts
+++ b/packages/keychain/src/utils/ekubo/swap-calls.test.ts
@@ -4,7 +4,7 @@ import {
   type SwapCallsParams,
   type SwapQuote,
 } from "./index";
-import { uint256 } from "starknet";
+import { uint256, constants } from "starknet";
 
 // Must match SLIPPAGE_PERCENTAGE in index.ts
 const SLIPPAGE_PERCENTAGE = 5n;
@@ -101,7 +101,7 @@ describe("prepareSwapCalls", () => {
         paymentToken: STRK_ADDRESS,
         totalCostWithQuantity: 2100000000000000000n, // 2.1 STRK (18 decimals)
         swapQuote: REAL_EKUBO_RESPONSE,
-        network: "sepolia",
+        chainId: constants.StarknetChainId.SN_SEPOLIA,
       };
 
       const result = prepareSwapCalls(params);
@@ -136,7 +136,7 @@ describe("prepareSwapCalls", () => {
         paymentToken: STRK_ADDRESS,
         totalCostWithQuantity: 2100000000000000000n, // 2.1 STRK
         swapQuote: REAL_EKUBO_RESPONSE,
-        network: "sepolia",
+        chainId: constants.StarknetChainId.SN_SEPOLIA,
       };
 
       const result = prepareSwapCalls(params);
@@ -174,7 +174,7 @@ describe("prepareSwapCalls", () => {
         paymentToken: STRK_ADDRESS,
         totalCostWithQuantity: 300000000n, // 300 USDC (for 3 items)
         swapQuote,
-        network: "mainnet",
+        chainId: constants.StarknetChainId.SN_MAIN,
       };
 
       const result = prepareSwapCalls(params);
@@ -212,7 +212,7 @@ describe("prepareSwapCalls", () => {
         paymentToken: STRK_ADDRESS,
         totalCostWithQuantity: totalCost,
         swapQuote,
-        network: "mainnet",
+        chainId: constants.StarknetChainId.SN_MAIN,
       };
 
       const result = prepareSwapCalls(params);
@@ -245,7 +245,7 @@ describe("prepareSwapCalls", () => {
         paymentToken: STRK_ADDRESS,
         totalCostWithQuantity: 10000000000n, // 10000 USDC
         swapQuote,
-        network: "mainnet",
+        chainId: constants.StarknetChainId.SN_MAIN,
       };
 
       const result = prepareSwapCalls(params);
@@ -273,7 +273,7 @@ describe("prepareSwapCalls", () => {
         paymentToken: STRK_ADDRESS,
         totalCostWithQuantity: 100000000n,
         swapQuote,
-        network: "mainnet",
+        chainId: constants.StarknetChainId.SN_MAIN,
       };
 
       const result = prepareSwapCalls(params);
@@ -293,7 +293,7 @@ describe("prepareSwapCalls", () => {
         paymentToken: STRK_ADDRESS,
         totalCostWithQuantity: 100000000n,
         swapQuote,
-        network: "mainnet",
+        chainId: constants.StarknetChainId.SN_MAIN,
       };
 
       const result = prepareSwapCalls(params);

--- a/packages/keychain/src/utils/token-metadata.ts
+++ b/packages/keychain/src/utils/token-metadata.ts
@@ -1,4 +1,4 @@
-import { Call, RpcProvider, shortString } from "starknet";
+import { Call, RpcProvider, shortString, constants } from "starknet";
 import { USDC_ADDRESSES } from "@/utils/ekubo";
 import {
   USDT_CONTRACT_ADDRESS,
@@ -16,12 +16,12 @@ export interface TokenMetadata {
  */
 const CACHED_TOKEN_METADATA: Record<string, TokenMetadata> = {
   // USDC on mainnet
-  [USDC_ADDRESSES.mainnet.toLowerCase()]: {
+  [USDC_ADDRESSES[constants.StarknetChainId.SN_MAIN].toLowerCase()]: {
     symbol: "USDC",
     decimals: 6,
   },
   // USDC on sepolia
-  [USDC_ADDRESSES.sepolia.toLowerCase()]: {
+  [USDC_ADDRESSES[constants.StarknetChainId.SN_SEPOLIA].toLowerCase()]: {
     symbol: "USDC",
     decimals: 6,
   },


### PR DESCRIPTION
## Summary

Updates the Ekubo quoter API URL to use the new format that Ekubo has migrated to.

### Changes

The Ekubo API URL format has changed:

**Old format:**
```
https://starknet-{network}-quoter-api.ekubo.org/{amount}/{tokenFrom}/{tokenTo}
```

**New format:**
```
https://prod-api-quoter.ekubo.org/{chainId}/{amount}/{tokenFrom}/{tokenTo}
```

Where `chainId` is the decimal representation of the StarkNet chain ID:
- **Mainnet (SN_MAIN):** `23448594291968334`
- **Sepolia (SN_SEPOLIA):** `393402133025997798000961`

### Implementation

Uses `num.toBigInt(constants.StarknetChainId.SN_MAIN)` and `num.toBigInt(constants.StarknetChainId.SN_SEPOLIA)` from starknet.js to derive the chain IDs programmatically rather than hardcoding them.

### Testing

All existing ekubo swap tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch Ekubo integration to chain ID–based API/addresses and update all swap/price flows to pass Starknet chainId directly.
> 
> - **Ekubo Utils**:
>   - Replace `network` with `chainId` across API and router/USDC address resolution.
>   - Update API base URL to `https://prod-api-quoter.ekubo.org/{chainId}` and construct paths with decimal chain ID.
>   - `EKUBO_ROUTER_ADDRESSES` and `USDC_ADDRESSES` now keyed by Starknet `chainId`; add guard errors when missing.
>   - Update `fetchSwapQuote`, `fetchSwapQuoteInUsdc`, `prepareSwapCalls`, and internal call generation to use `chainId`.
> - **Starterpack**:
>   - `onchain-purchase`: pass `controller.chainId()` to `prepareSwapCalls`.
>   - `onchain`: use `controller.chainId()` for quotes and USDC lookup; remove network mapping.
>   - `token-selection`: remove `isMainnet`; derive USDC via `USDC_ADDRESSES[chainId]` with mainnet fallback; pass `chainId` to `fetchSwapQuote`.
> - **Tokens Provider**:
>   - Price fetching now calls `fetchSwapQuoteInUsdc(address, amount, chainId)`.
> - **Token Metadata**:
>   - Cache USDC entries keyed by `USDC_ADDRESSES[SN_MAIN|SN_SEPOLIA]`.
> - **Tests**:
>   - Update swap call tests to use `constants.StarknetChainId.*` instead of `network`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04ee39724710e13d71a57b6fcf7f50a56ea6d88c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->