### PR TITLE
fix(ekubo): specify cors and no auth on fetch

### DIFF
--- a/packages/keychain/src/utils/ekubo/index.ts
+++ b/packages/keychain/src/utils/ekubo/index.ts
@@ -218,9 +218,8 @@ export async function fetchSwapQuote(
       const response = await fetch(url, {
         method: "GET",
         signal: abortSignal,
-        headers: {
-          "Content-Type": "application/json",
-        },
+        mode: "cors",
+        credentials: "omit",
       });
 
       // Success case


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates Ekubo swap quote fetch to use CORS with no credentials and removes the Content-Type header.
> 
> - **Ekubo utils (`packages/keychain/src/utils/ekubo/index.ts`)**:
>   - Update `fetchSwapQuote` request options:
>     - Add `mode: "cors"` and `credentials: "omit"`.
>     - Remove `Content-Type` header.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed3529c0acad8e87fa1f8ab4b8409124c5b7db48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->