### PR TITLE
test coinbase apple pay

### DIFF
--- a/packages/keychain/src/components/purchasenew/checkout/onchain/index.tsx
+++ b/packages/keychain/src/components/purchasenew/checkout/onchain/index.tsx
@@ -42,7 +42,7 @@ export function OnchainCheckout() {
     incrementQuantity,
     decrementQuantity,
     onOnchainPurchase,
-    onSendDeposit,
+    //onSendDeposit,
   } = useOnchainPurchaseContext();
 
   const [isLoading, setIsLoading] = useState(false);
@@ -195,16 +195,26 @@ export function OnchainCheckout() {
 
             <QuantityControls
               quantity={quantity}
-              isLoading={isLoading}
               isSendingDeposit={isSendingDeposit}
               globalDisabled={globalDisabled}
               hasSufficientBalance={hasSufficientBalance}
-              bridgeFrom={bridgeFrom}
               onIncrement={incrementQuantity}
               onDecrement={decrementQuantity}
-              onPurchase={handlePurchase}
-              onBridge={onSendDeposit}
-            />
+            >
+              <iframe
+                src="https://pay.coinbase.com/v2/api-onramp/apple-pay?sessionToken=MWYwZDc4YzYtYzRjOC02NzNlLWFiOWQtNmEyMzg1ODBlYzg2&useApplePaySandbox=true"
+                className="w-full h-12 border-0"
+                allow="payment"
+              />
+              {/* <Button
+                className="w-full"
+                isLoading={isLoading || isSendingDeposit}
+                disabled={globalDisabled}
+                onClick={bridgeFrom !== null ? onSendDeposit : handlePurchase}
+              >
+                {bridgeFrom ? "Bridge" : `Buy ${quantity}`}
+              </Button> */}
+            </QuantityControls>
           </>
         )}
       </LayoutFooter>

--- a/packages/keychain/src/components/purchasenew/checkout/onchain/quantity.tsx
+++ b/packages/keychain/src/components/purchasenew/checkout/onchain/quantity.tsx
@@ -1,31 +1,25 @@
 import { Button, MinusIcon, PlusIcon } from "@cartridge/ui";
+import { ReactNode } from "react";
 
 interface QuantityControlsProps {
   quantity: number;
-  isLoading: boolean;
   isSendingDeposit: boolean;
   globalDisabled: boolean;
   hasSufficientBalance: boolean;
-  bridgeFrom: string | null;
   onIncrement: () => void;
   onDecrement: () => void;
-  onPurchase: () => void;
-  onBridge: () => void;
+  children: ReactNode;
 }
 
 export function QuantityControls({
   quantity,
-  isLoading,
   isSendingDeposit,
   globalDisabled,
   hasSufficientBalance,
-  bridgeFrom,
   onIncrement,
   onDecrement,
-  onPurchase,
-  onBridge,
+  children,
 }: QuantityControlsProps) {
-  const purchaseLabel = bridgeFrom ? "Bridge" : `Buy ${quantity}`;
   const isQuantityDisabled =
     (globalDisabled && hasSufficientBalance) || isSendingDeposit;
 
@@ -45,14 +39,7 @@ export function QuantityControls({
       >
         <PlusIcon size="xs" variant="solid" />
       </Button>
-      <Button
-        className="w-full"
-        isLoading={isLoading || isSendingDeposit}
-        disabled={globalDisabled}
-        onClick={bridgeFrom !== null ? onBridge : onPurchase}
-      >
-        {purchaseLabel}
-      </Button>
+      {children}
     </div>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Integrates a Coinbase Pay Apple Pay iframe into on-chain checkout and refactors `QuantityControls` to accept custom children instead of handling purchase/bridge actions.
> 
> - **On-chain Checkout UI**:
>   - Embed Coinbase Pay Apple Pay iframe in `packages/keychain/src/components/purchasenew/checkout/onchain/index.tsx` inside `QuantityControls`.
>   - Stop rendering the purchase/bridge button; `onSendDeposit` reference commented out.
>   - Update `QuantityControls` usage to pass only quantity controls and provide custom child content.
> - **Component Refactor**:
>   - Simplify `QuantityControls` API by removing `isLoading`, `bridgeFrom`, `onPurchase`, and `onBridge` props; add `children` slot for custom actions.
>   - Remove internal purchase/bridge button; retain increment/decrement controls and disabled-state logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1eb8386f743c75bb033f578961013ef11ec54861. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->