### PR TITLE
feat: add paymaster fallback to user-pays flow

### DIFF
--- a/packages/keychain/src/components/ExecutionContainer.tsx
+++ b/packages/keychain/src/components/ExecutionContainer.tsx
@@ -230,7 +230,6 @@ export function ExecutionContainer({
               // Paymaster not available, fallback to user pays flow
               return (
                 <>
-                  <ControllerErrorAlert error={ctrlError} />
                   <Fees isLoading={isEstimating} maxFee={maxFee} />
                   <Button
                     onClick={handleSubmit}
@@ -238,7 +237,7 @@ export function ExecutionContainer({
                     disabled={
                       isEstimating ||
                       !transactions ||
-                      !!(maxFee === null && transactions?.length)
+                      !!(maxFee === undefined && transactions?.length)
                     }
                   >
                     {buttonText}
@@ -254,7 +253,7 @@ export function ExecutionContainer({
                     isLoading={isLoading}
                     disabled={
                       !transactions ||
-                      !!(maxFee === null && transactions?.length)
+                      !!(maxFee === undefined && transactions?.length)
                     }
                   >
                     {buttonText}
@@ -275,7 +274,7 @@ export function ExecutionContainer({
                       isEstimating ||
                       !!ctrlError ||
                       !transactions ||
-                      !!(maxFee === null && transactions?.length)
+                      !!(maxFee === undefined && transactions?.length)
                     }
                   >
                     {buttonText}


### PR DESCRIPTION
When paymaster execution fails due to various error conditions (execution time not reached, rate limits, unsupported paymaster, etc.), gracefully fall back to the user-pays fee flow instead of showing an error state.

This improves UX by allowing transactions to still proceed when the paymaster is temporarily unavailable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Handles paymaster error codes by falling back to user-pays flow with fee display and submit, and standardizes `maxFee` undefined checks.
> 
> - **UI (Execution flow)**
>   - In `packages/keychain/src/components/ExecutionContainer.tsx`:
>     - Handle paymaster errors (`PaymasterExecutionTimeNotReached|Passed|InvalidCaller|RateLimitExceeded|NotSupported|Http|Excecution|Serialization`) by falling back to user-pays: render `Fees` and enable submit.
>     - Standardize button disable logic: replace `maxFee === null` checks with `maxFee === undefined`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47c33f0f6aa576294b7d9b58d32e9e47e93a26b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->