### PR TITLE
fix: starterpack flicker on load

### DIFF
--- a/packages/keychain/src/components/purchasenew/starterpack/starterpack.tsx
+++ b/packages/keychain/src/components/purchasenew/starterpack/starterpack.tsx
@@ -80,7 +80,10 @@ export function PurchaseStarterpack() {
     }
   }, [isStarterpackLoading, details, preimage, displayError, navigate]);
 
-  if (isStarterpackLoading || preimage) {
+  if (
+    (isStarterpackLoading || isOnchainStarterpack(details) || preimage) &&
+    !displayError
+  ) {
     return <LoadingState />;
   }
 
@@ -104,12 +107,6 @@ export function PurchaseStarterpack() {
     );
   }
 
-  // If no details and no error, keep showing loading (shouldn't happen)
-  if (!details) {
-    return <LoadingState />;
-  }
-
-  // Handle backend starterpacks (GraphQL)
   if (isClaimStarterpack(details)) {
     return (
       <ClaimStarterPackInner
@@ -120,21 +117,6 @@ export function PurchaseStarterpack() {
     );
   }
 
-  // Handle onchain starterpacks (Smart contract)
-  if (isOnchainStarterpack(details)) {
-    return (
-      <OnchainStarterPackInner
-        name={details.name}
-        description={details.description}
-        icon={details.imageUri}
-        items={details.items}
-        quote={details.quote}
-        error={displayError}
-      />
-    );
-  }
-
-  // Fallback (should never reach here with proper types)
   return <LoadingState />;
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Show LoadingState during loading/onchain/preimage states and drop inline onchain rendering, keeping claim flow and onchain redirect to checkout.
> 
> - **Starterpack UI (`packages/keychain/src/components/purchasenew/starterpack/starterpack.tsx`)**
>   - **Loading behavior**: Render `LoadingState` when `isStarterpackLoading`, `isOnchainStarterpack(details)`, or `preimage` is present, provided no `displayError`.
>   - **Routing**:
>     - Maintain auto-redirect to onchain checkout when onchain starterpack detected.
>     - Maintain auto-redirect to claim page when eligible preimage is present.
>   - **Rendering changes**:
>     - Remove inline onchain starterpack rendering branch (`OnchainStarterPackInner`).
>     - Remove generic `!details` loading fallback; retain explicit error handling.
>     - Keep claim starterpack rendering path (`ClaimStarterPackInner`); otherwise fall back to `LoadingState`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57cca2f3cd6195149bd8f29c69608d3011812672. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->