### PR TITLE
fix: restore propagateSessionErrors functionality for contract execution

### DIFF
--- a/packages/controller/src/iframe/keychain.ts
+++ b/packages/controller/src/iframe/keychain.ts
@@ -33,10 +33,15 @@ export class KeychainIFrame extends IFrame<Keychain> {
     username,
     onSessionCreated,
     encryptedBlob,
+    propagateSessionErrors,
     ...iframeOptions
   }: KeychainIframeOptions) {
     const _url = new URL(url ?? KEYCHAIN_URL);
     const walletBridge = new WalletBridge();
+
+    if (propagateSessionErrors) {
+      _url.searchParams.set("propagate_error", "true");
+    }
 
     if (version) {
       _url.searchParams.set("v", encodeURIComponent(version));

--- a/packages/keychain/src/components/provider/connection.tsx
+++ b/packages/keychain/src/components/provider/connection.tsx
@@ -21,6 +21,7 @@ export type ConnectionContextValue = {
   rpcUrl: string;
   project: string | null;
   namespace: string | null;
+  propagateError: boolean;
   tokens?: string[];
   policies?: ParsedSessionPolicies;
   theme: VerifiableControllerTheme;

--- a/packages/keychain/src/hooks/connection.ts
+++ b/packages/keychain/src/hooks/connection.ts
@@ -230,6 +230,7 @@ export function useConnectionValue() {
     tokens: string[];
     ref: string | null;
     refGroup: string | null;
+    propagateError: boolean;
   }>();
 
   const urlParams = useMemo(() => {
@@ -245,6 +246,8 @@ export function useConnectionValue() {
     const namespace = urlParams.get("ns");
     const ref = urlParams.get("ref");
     const refGroup = urlParams.get("ref_group");
+    const propagateError = urlParams.get("propagate_error") === "true";
+
     const erc20Param = urlParams.get("erc20");
     const tokens = erc20Param
       ? decodeURIComponent(erc20Param)
@@ -274,6 +277,8 @@ export function useConnectionValue() {
       tokens: erc20Param ? tokens : urlParamsRef.current?.tokens || tokens,
       ref: ref || urlParamsRef.current?.ref || null,
       refGroup: refGroup || urlParamsRef.current?.refGroup || null,
+      propagateError:
+        propagateError || urlParamsRef.current?.propagateError || false,
     };
 
     // Store the new params for future reference
@@ -579,6 +584,7 @@ export function useConnectionValue() {
         setRpcUrl,
         setController,
         navigate,
+        propagateError: urlParams.propagateError,
       });
 
       connection.promise
@@ -763,6 +769,7 @@ export function useConnectionValue() {
     project: urlParams.project,
     namespace: urlParams.namespace,
     tokens: urlParams.tokens,
+    propagateError: urlParams.propagateError,
     isConfigLoading,
     isMainnet,
     verified,

--- a/packages/keychain/src/test/mocks/connection.tsx
+++ b/packages/keychain/src/test/mocks/connection.tsx
@@ -37,6 +37,7 @@ export const defaultMockConnection: ConnectionContextValue = {
     icon: "test-icon",
     cover: "test-cover",
   },
+  propagateError: false,
   setController: vi.fn(),
   setRpcUrl: vi.fn(),
   openSettings: vi.fn(),

--- a/packages/keychain/src/utils/connection/execute.ts
+++ b/packages/keychain/src/utils/connection/execute.ts
@@ -104,11 +104,13 @@ export async function executeCore(
 
 export function execute({
   navigate,
+  propagateError,
 }: {
   navigate: (
     to: string | number,
     options?: { replace?: boolean; state?: unknown },
   ) => void;
+  propagateError?: boolean;
 }) {
   return (origin: string) =>
     async (
@@ -159,6 +161,18 @@ export function execute({
           } catch (e) {
             const error = e as ControllerError;
             const parsedError = parseControllerError(error);
+
+            if (
+              propagateError &&
+              parsedError.code !== ErrorCode.SessionRefreshRequired &&
+              parsedError.code !== ErrorCode.ManualExecutionRequired
+            ) {
+              return resolve({
+                code: ResponseCodes.ERROR,
+                message: parsedError.message,
+                error: parsedError,
+              });
+            }
 
             // Check for specific error codes that require user interaction
             // SessionRefreshRequired and ManualExecutionRequired both need UI

--- a/packages/keychain/src/utils/connection/index.ts
+++ b/packages/keychain/src/utils/connection/index.ts
@@ -18,6 +18,7 @@ export function connectToController<ParentMethods extends object>({
   setRpcUrl,
   setController,
   navigate,
+  propagateError,
 }: {
   setRpcUrl: (url: string) => void;
   setController: (controller?: Controller) => void;
@@ -25,6 +26,7 @@ export function connectToController<ParentMethods extends object>({
     to: string | number,
     options?: { replace?: boolean; state?: unknown },
   ) => void;
+  propagateError?: boolean;
 }) {
   return connectToParent<ParentMethods>({
     methods: {
@@ -35,7 +37,7 @@ export function connectToController<ParentMethods extends object>({
         }),
       ),
       deploy: () => deployFactory({ navigate }),
-      execute: normalize(execute({ navigate })),
+      execute: normalize(execute({ navigate, propagateError })),
       estimateInvokeFee: () => estimateInvokeFee,
       probe: normalize(probe({ setController })),
       signMessage: normalize(


### PR DESCRIPTION
This PR fixes a regression where the \`propagateSessionErrors\` option was being ignored for contract executions.

When enabled, contract execution errors (like reverts) are now correctly propagated back to the caller instead of displaying the manual approval modal in the keychain.

### Fixes:
- Pass \`propagate_error\` via iframe URL from SDK to Keychain to ensure awareness.
- Parse and store \`propagateError\` preference in Keychain context.
- Update Keychain \`execute\` logic to return \`ERROR\` instead of \`USER_INTERACTION_REQUIRED\` when propagation is enabled.
- Correctly bypass manual fallback UI when developer chooses to handle errors.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores error propagation for contract executions and bypasses manual approval UI when enabled.
> 
> - Controller: add `propagate_error` URL param from `KeychainIFrame`
> - Keychain hooks/context: parse/store `propagate_error` as `propagateError`; include in `ConnectionContextValue` and test mocks
> - Connection wiring: pass `propagateError` into `connectToController` and down to `execute`
> - Execute logic: when `propagateError` is true, return `ERROR` with parsed details for non-`SessionRefreshRequired`/`ManualExecutionRequired` cases; otherwise navigate to `/execute` for UI interaction
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3148adf1571567ea6b38389160949a869d3b6e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->