### PR TITLE
fix(oauth): listen for postMessage from TikTok OAuth popup

### DIFF
--- a/packages/keychain/src/components/settings/connections/add-connection.tsx
+++ b/packages/keychain/src/components/settings/connections/add-connection.tsx
@@ -61,8 +61,15 @@ export function AddConnection({ username }: { username?: string }) {
 
       // Listen for OAuth completion message from popup
       const handleMessage = (event: MessageEvent) => {
-        // Verify origin for security
-        if (!event.origin.includes("cartridge.gg")) return;
+        // Verify origin for security - must be cartridge.gg or a subdomain
+        try {
+          const hostname = new URL(event.origin).hostname;
+          const isValidOrigin =
+            hostname === "cartridge.gg" || hostname.endsWith(".cartridge.gg");
+          if (!isValidOrigin) return;
+        } catch {
+          return; // Invalid origin URL
+        }
         if (event.data?.type !== "tiktok-oauth") return;
 
         window.removeEventListener("message", handleMessage);


### PR DESCRIPTION
## Summary
- Listen for postMessage from TikTok OAuth popup instead of just polling for closure
- Popup now closes automatically after OAuth completes
- Falls back to polling if user closes popup manually

## Test plan
- [ ] Open TikTok OAuth popup
- [ ] Complete authorization
- [ ] Verify popup closes and parent window updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves TikTok OAuth completion from polling-only to a message-based flow.
> 
> - Adds `window.message` listener to receive `tiktok-oauth` events from the popup and removes the listener after handling
> - Validates `event.origin` to only accept messages from `cartridge.gg` or its subdomains
> - Updates UI/state on success (`CheckIcon`, clears `inProgress`) and error (`AlertIcon`, sets error message)
> - Keeps a fallback interval to detect manual popup closure and surface an appropriate error; cleans up listeners on close
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91eede31a905aba750773162dc97077b8c892d93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->