### PR TITLE
fix: default to USDC and fallback to first available token in selection

### DIFF
--- a/packages/keychain/src/components/purchasenew/review/cost.tsx
+++ b/packages/keychain/src/components/purchasenew/review/cost.tsx
@@ -121,10 +121,11 @@ export function OnchainCostBreakdown({
   const { displayError } = useStarterpackContext();
   const { decimals } = quote.paymentTokenMetadata;
 
-  // Get default token (USDC if available) for fallback
-  const defaultToken = availableTokens.find(
-    (t) => t.address.toLowerCase() === quote.paymentToken.toLowerCase(),
-  );
+  // Get default token (matching quote if available) or fallback to the first available token
+  const defaultToken =
+    availableTokens.find(
+      (t) => t.address.toLowerCase() === quote.paymentToken.toLowerCase(),
+    ) || availableTokens[0];
 
   // Use selectedToken or fallback to defaultToken for display
   const displayToken = selectedToken || defaultToken;

--- a/packages/keychain/src/hooks/starterpack/token-selection.ts
+++ b/packages/keychain/src/hooks/starterpack/token-selection.ts
@@ -159,7 +159,6 @@ export function useTokenSelection({
       USDC_ADDRESSES[constants.StarknetChainId.SN_MAIN];
 
     const tokens: ERC20Metadata[] = [
-      ...DEFAULT_TOKENS,
       {
         address: usdcAddress,
         name: "USD Coin",
@@ -167,6 +166,7 @@ export function useTokenSelection({
         decimals: 6,
         icon: "https://static.cartridge.gg/tokens/usdc.svg",
       },
+      ...DEFAULT_TOKENS,
     ];
 
     const isIncluded = (address: string) =>
@@ -309,10 +309,11 @@ export function useTokenSelection({
 
         // Set selected token to payment token if not set
         if (!selectedToken) {
-          const paymentToken = availableTokens.find(
-            (token: TokenOption) =>
-              token.address.toLowerCase() === paymentTokenAddress,
-          );
+          const paymentToken =
+            availableTokens.find(
+              (token: TokenOption) =>
+                token.address.toLowerCase() === paymentTokenAddress,
+            ) || availableTokens[0];
           if (paymentToken) {
             setSelectedToken(paymentToken);
           }


### PR DESCRIPTION
## Summary
This PR improves the token selection experience for onchain purchases:
- **Default Fallback**: If the payment token from the quote is not found in the available tokens list, it now falls back to the first available token instead of showing "Select Token".
- **USDC Priority**: Reordered the default tokens to place USDC at the beginning, making it the default choice in the selection list and the primary fallback.

## Changes
- `packages/keychain/src/components/purchasenew/review/cost.tsx`: Added fallback to `availableTokens[0]` for `defaultToken`.
- `packages/keychain/src/hooks/starterpack/token-selection.ts`: 
    - Reordered `tokens` array to start with USDC.
    - Added fallback to `availableTokens[0]` when auto-selecting the payment token.