### PR TITLE
fix: improve onchain starterpack bridge flow and UI

### DIFF
--- a/packages/keychain/src/components/purchasenew/checkout/onchain/quantity.tsx
+++ b/packages/keychain/src/components/purchasenew/checkout/onchain/quantity.tsx
@@ -25,7 +25,7 @@ export function QuantityControls({
   onPurchase,
   onBridge,
 }: QuantityControlsProps) {
-  const purchaseLabel = bridgeFrom ? "Bridge" : `Buy ${quantity}`;
+  const purchaseLabel = quantity > 1 ? `Buy ${quantity}` : "Buy";
   const isQuantityDisabled =
     (globalDisabled && hasSufficientBalance) || isSendingDeposit;
 

--- a/packages/keychain/src/components/purchasenew/pending/base.tsx
+++ b/packages/keychain/src/components/purchasenew/pending/base.tsx
@@ -23,6 +23,8 @@ export interface TransactionPendingBaseProps {
   transactionHash: string;
   /** Title for the confirming card (e.g., "Claiming", "Confirming on Starknet") */
   confirmingTitle: string;
+  /** Title for the confirming card when completed (e.g. "Claimed", "Confirmed on Starknet") */
+  completedTitle?: string;
   /** Button text while pending */
   buttonText: string;
   /** Optional quantity text to show in Receiving component */
@@ -38,11 +40,12 @@ export function TransactionPendingBase({
   items,
   transactionHash,
   confirmingTitle,
+  completedTitle,
   buttonText,
   quantityText,
 }: TransactionPendingBaseProps) {
-  const { isMainnet, controller } = useConnection();
-  const { navigate } = useNavigation();
+  const { isMainnet, controller, closeModal } = useConnection();
+  const { navigateToRoot } = useNavigation();
   const [isPending, setIsPending] = useState(true);
 
   useEffect(() => {
@@ -58,14 +61,13 @@ export function TransactionPendingBase({
       )
         .then(() => {
           setIsPending(false);
-          navigate("/purchase/success", { reset: true });
         })
         .catch((error) => {
           console.error("Failed to wait for transaction after retries:", error);
           // Could set an error state here if needed
         });
     }
-  }, [controller, transactionHash, navigate]);
+  }, [controller, transactionHash]);
 
   const receivingTitle = quantityText
     ? `Receiving ${quantityText}`
@@ -79,13 +81,23 @@ export function TransactionPendingBase({
       </LayoutContent>
       <LayoutFooter>
         <ConfirmingTransaction
-          title={confirmingTitle}
+          title={
+            !isPending && completedTitle ? completedTitle : confirmingTitle
+          }
           externalLink={
             getExplorer("starknet", transactionHash, isMainnet)?.url
           }
           isLoading={isPending}
         />
-        <Button className="w-full" variant="primary" disabled={true}>
+        <Button
+          className="w-full"
+          variant="primary"
+          disabled={isPending}
+          onClick={() => {
+            closeModal?.();
+            navigateToRoot();
+          }}
+        >
           {buttonText}
         </Button>
       </LayoutFooter>

--- a/packages/keychain/src/components/purchasenew/pending/claim.tsx
+++ b/packages/keychain/src/components/purchasenew/pending/claim.tsx
@@ -25,6 +25,7 @@ export function ClaimPending({
       items={items}
       transactionHash={transactionHash}
       confirmingTitle="Claiming"
+      completedTitle="Claimed"
       buttonText="Claiming"
       quantityText={quantityText}
     />

--- a/packages/keychain/src/components/purchasenew/pending/index.tsx
+++ b/packages/keychain/src/components/purchasenew/pending/index.tsx
@@ -21,8 +21,14 @@ export type { TransactionPendingBaseProps } from "./base";
 export function Pending() {
   const { starterpackDetails, transactionHash, claimItems } =
     useStarterpackContext();
-  const { purchaseItems, explorer, selectedWallet, swapId, quantity } =
-    useOnchainPurchaseContext();
+  const {
+    purchaseItems,
+    explorer,
+    selectedWallet,
+    swapId,
+    quantity,
+    selectedPlatform,
+  } = useOnchainPurchaseContext();
 
   // Claim flow (merkle drop)
   if (starterpackDetails?.type === "claimed") {
@@ -36,8 +42,8 @@ export function Pending() {
     );
   }
 
-  // Bridge flow - detected by presence of swapId
-  if (swapId) {
+  // Bridge flow - detected by presence of swapId or if the platform is not Starknet
+  if (swapId || (selectedPlatform && selectedPlatform !== "starknet")) {
     return (
       <BridgePending
         name={starterpackDetails?.name || "Items"}
@@ -47,6 +53,7 @@ export function Pending() {
         paymentMethod="crypto"
         explorer={explorer}
         wallet={selectedWallet}
+        selectedPlatform={selectedPlatform}
       />
     );
   }

--- a/packages/keychain/src/components/purchasenew/pending/purchase.tsx
+++ b/packages/keychain/src/components/purchasenew/pending/purchase.tsx
@@ -21,6 +21,7 @@ export function PurchasePending({
       items={items}
       transactionHash={transactionHash}
       confirmingTitle="Confirming on Starknet"
+      completedTitle="Confirmed on Starknet"
       buttonText="Play"
     />
   );

--- a/packages/keychain/src/components/purchasenew/review/cost.tsx
+++ b/packages/keychain/src/components/purchasenew/review/cost.tsx
@@ -220,11 +220,7 @@ export function OnchainCostBreakdown({
               <Spinner />
             ) : (
               <div className="flex items-center gap-1.5">
-                {isPaymentTokenSameAsSelected ? (
-                  <span className="text-foreground-300">
-                    {formatAmount(paymentAmount)}
-                  </span>
-                ) : isUsingLayerswap ? (
+                {isUsingLayerswap ? (
                   feeEstimationError ? (
                     <span className="text-foreground-400">—</span>
                   ) : layerswapTotal !== null && displayToken ? (
@@ -234,6 +230,10 @@ export function OnchainCostBreakdown({
                   ) : (
                     <Spinner />
                   )
+                ) : isPaymentTokenSameAsSelected ? (
+                  <span className="text-foreground-300">
+                    {formatAmount(paymentAmount)}
+                  </span>
                 ) : (
                   convertedEquivalent !== null &&
                   displayToken && (

--- a/packages/keychain/src/components/purchasenew/review/onchain-tooltip.tsx
+++ b/packages/keychain/src/components/purchasenew/review/onchain-tooltip.tsx
@@ -93,7 +93,8 @@ export const OnchainFeesTooltip = ({
             <span>Total:</span>
             <span>
               {formatTokenAmount(
-                quote.totalCost * BigInt(quantity),
+                quote.totalCost * BigInt(quantity) +
+                  (layerswapFees ? BigInt(layerswapFees) : 0n),
                 decimals,
                 symbol,
               )}


### PR DESCRIPTION
## Summary

This PR improves the user experience for purchasing onchain starterpacks when bridging from other networks (e.g., Arbitrum, Optimism).

## Changes

-   **Auto-Purchase**: Automatically triggers the Starknet purchase transaction once the bridge deposit is confirmed on L2.
-   **Robust Fee Fetching**: Added retry logic with exponential backoff for fetching Layerswap fees to prevent "Fees not loaded" errors.
-   **UI Improvements**:
    -   Added a "Purchasing on Starknet" step to the pending view.
    -   Renamed "Buy [quantity]" to just "Buy".
    -   Added loading state to the "Bridge" button while fetching fees.
    -   The "Play" button now correctly dismisses the modal and resets navigation.
-   **Routing Fixes**: Improved detection of the bridge flow in the Pending router to prevent premature navigation or incorrect states.
-   **Explorer Support**: Added support for Optimism block explorers.
-   **Bug Fixes**:
    -   Fixed an issue where the pending screen would show up before the user signed the transaction.
    -   Fixed an issue where the wrong provider (external vs controller) was used to wait for transactions.
    -   Fixed incorrect error handling for deposit failures.

## Testing

-   Tested bridging from Arbitrum and Optimism.
-   Verified fee retry logic by simulating network delays.
-   Verified UI transitions and button states.