### PR TITLE
fix(keychain): show connect socials button unless all connections exist

### DIFF
--- a/packages/keychain/src/components/settings/connections/connections-section.tsx
+++ b/packages/keychain/src/components/settings/connections/connections-section.tsx
@@ -9,6 +9,7 @@ import {
   type OAuthConnection,
   type OAuthConnectionsData,
   type DisconnectOAuthData,
+  type OAuthProvider,
   GET_OAUTH_CONNECTIONS,
   DISCONNECT_OAUTH,
 } from "@/utils/api/oauth-connections";
@@ -52,7 +53,11 @@ export const ConnectionsSection = () => {
     },
   );
 
-  const hasConnections = data && data.length > 0;
+  const ALL_PROVIDERS: OAuthProvider[] = ["TIKTOK", "INSTAGRAM", "TWITTER"];
+  const connectedProviders = data?.map((c) => c.provider) ?? [];
+  const hasAllConnections = ALL_PROVIDERS.every((p) =>
+    connectedProviders.includes(p),
+  );
 
   return (
     <section className="space-y-4">
@@ -81,7 +86,7 @@ export const ConnectionsSection = () => {
           </>
         )}
       </div>
-      {!hasConnections && (
+      {!hasAllConnections && (
         <Button
           type="button"
           variant="outline"


### PR DESCRIPTION
## Summary
- The "Connect Socials" button was incorrectly hidden when any social connection existed
- Now the button remains visible until all possible connections (TikTok, Instagram, Twitter) have been added
- Users can continue adding more social connections after connecting their first account

## Testing
- [ ] Ran `pnpm lint`
- [ ] Verified TypeScript compiles without errors
- [ ] Manual testing: button should appear when 0, 1, or 2 connections exist, and hide only when all 3 are connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)