### PR TITLE
fix(keychain): hide 'proceed with caution' warning for slot login

### DIFF
--- a/packages/keychain/src/components/connect/create/CreateController.test.tsx
+++ b/packages/keychain/src/components/connect/create/CreateController.test.tsx
@@ -239,6 +239,18 @@ describe("CreateController", () => {
       ),
     ).toBeInTheDocument();
   });
+  it("does not show warning for unverified theme when isSlot is true", async () => {
+    mockUseControllerTheme.mockReturnValue({
+      name: "cartridge",
+      verified: false,
+      icon: "icon-url",
+      cover: "cover-url",
+    });
+    renderWithProviders(<CreateController {...defaultProps} isSlot />);
+    expect(
+      screen.queryByText("Please proceed with caution"),
+    ).not.toBeInTheDocument();
+  });
   it("calls onCreated callback after successful creation", async () => {
     const handleSubmit = vi.fn().mockImplementation(() => {
       return Promise.resolve();

--- a/packages/keychain/src/components/connect/create/CreateController.tsx
+++ b/packages/keychain/src/components/connect/create/CreateController.tsx
@@ -92,6 +92,7 @@ function CreateControllerForm({
   isDropdownOpen,
   onDropdownOpenChange,
   authOptions,
+  isSlot,
 }: CreateControllerFormProps) {
   const [{ isInApp, appKey, appName }] = useState(() => InAppSpy());
   const { isOpen: keyboardIsOpen, viewportHeight } = useDetectKeyboardOpen();
@@ -239,7 +240,7 @@ function CreateControllerForm({
             />
           )}
 
-          {!theme.verified && (
+          {!theme.verified && !isSlot && (
             <ErrorAlert
               title="Please proceed with caution"
               isExpanded={false}
@@ -305,6 +306,7 @@ export function CreateControllerView({
   submitButtonRef,
   isDropdownOpen,
   onDropdownOpenChange,
+  isSlot,
 }: CreateControllerViewProps) {
   const handleOpenChange = (isOpen: boolean) => {
     if (!isOpen) {
@@ -351,6 +353,7 @@ export function CreateControllerView({
           isDropdownOpen={isDropdownOpen}
           onDropdownOpenChange={onDropdownOpenChange}
           authOptions={authOptions}
+          isSlot={isSlot}
         />
         <ChooseSignupMethodForm
           isLoading={isLoading}


### PR DESCRIPTION
## Summary
- Hide the "Please proceed with caution" warning when logging into slot (Cartridge's own site)
- The warning is intended for external sites embedding the keychain wallet with unverified domains
- Slot login at `https://x.cartridge.gg` should not display this error alert

## Changes
- Updated `CreateController` to check `!isSlot` before showing the unverified theme warning
- Added `isSlot` prop to `CreateControllerForm` and `CreateControllerView` components
- Added test case to verify the warning is hidden when `isSlot` is true

## Testing
- [x] Ran `pnpm lint:check`
- [x] Added unit test for the new behavior