### PR TITLE
Ensure canonical sorting of policies before hashing

### DIFF
--- a/packages/controller/src/__tests__/toWasmPolicies.test.ts
+++ b/packages/controller/src/__tests__/toWasmPolicies.test.ts
@@ -1,0 +1,180 @@
+import { toWasmPolicies } from "../utils";
+import { ParsedSessionPolicies } from "../policies";
+
+describe("toWasmPolicies", () => {
+  describe("canonical ordering", () => {
+    test("sorts contracts by address regardless of input order", () => {
+      const policies1: ParsedSessionPolicies = {
+        verified: false,
+        contracts: {
+          "0xAAA": {
+            methods: [{ entrypoint: "foo", authorized: true }],
+          },
+          "0xBBB": {
+            methods: [{ entrypoint: "bar", authorized: true }],
+          },
+        },
+      };
+
+      const policies2: ParsedSessionPolicies = {
+        verified: false,
+        contracts: {
+          "0xBBB": {
+            methods: [{ entrypoint: "bar", authorized: true }],
+          },
+          "0xAAA": {
+            methods: [{ entrypoint: "foo", authorized: true }],
+          },
+        },
+      };
+
+      const result1 = toWasmPolicies(policies1);
+      const result2 = toWasmPolicies(policies2);
+
+      expect(result1).toEqual(result2);
+      // First policy should be for 0xAAA (sorted alphabetically)
+      expect(result1[0]).toHaveProperty("target", "0xAAA");
+      expect(result1[1]).toHaveProperty("target", "0xBBB");
+    });
+
+    test("sorts methods within contracts by entrypoint", () => {
+      const policies1: ParsedSessionPolicies = {
+        verified: false,
+        contracts: {
+          "0xAAA": {
+            methods: [
+              { entrypoint: "zebra", authorized: true },
+              { entrypoint: "apple", authorized: true },
+              { entrypoint: "mango", authorized: true },
+            ],
+          },
+        },
+      };
+
+      const policies2: ParsedSessionPolicies = {
+        verified: false,
+        contracts: {
+          "0xAAA": {
+            methods: [
+              { entrypoint: "mango", authorized: true },
+              { entrypoint: "zebra", authorized: true },
+              { entrypoint: "apple", authorized: true },
+            ],
+          },
+        },
+      };
+
+      const result1 = toWasmPolicies(policies1);
+      const result2 = toWasmPolicies(policies2);
+
+      expect(result1).toEqual(result2);
+    });
+
+    test("produces consistent output for complex policies", () => {
+      const policies1: ParsedSessionPolicies = {
+        verified: false,
+        contracts: {
+          "0xCCC": {
+            methods: [
+              { entrypoint: "c_method", authorized: true },
+              { entrypoint: "a_method", authorized: true },
+            ],
+          },
+          "0xAAA": {
+            methods: [
+              { entrypoint: "z_method", authorized: true },
+              { entrypoint: "a_method", authorized: true },
+            ],
+          },
+          "0xBBB": {
+            methods: [{ entrypoint: "b_method", authorized: true }],
+          },
+        },
+      };
+
+      // Same policies in different order
+      const policies2: ParsedSessionPolicies = {
+        verified: false,
+        contracts: {
+          "0xBBB": {
+            methods: [{ entrypoint: "b_method", authorized: true }],
+          },
+          "0xAAA": {
+            methods: [
+              { entrypoint: "a_method", authorized: true },
+              { entrypoint: "z_method", authorized: true },
+            ],
+          },
+          "0xCCC": {
+            methods: [
+              { entrypoint: "a_method", authorized: true },
+              { entrypoint: "c_method", authorized: true },
+            ],
+          },
+        },
+      };
+
+      const result1 = toWasmPolicies(policies1);
+      const result2 = toWasmPolicies(policies2);
+
+      expect(result1).toEqual(result2);
+
+      // Verify order: 0xAAA first, then 0xBBB, then 0xCCC
+      // Within 0xAAA: a_method before z_method
+      expect(result1[0]).toHaveProperty("target", "0xAAA");
+      expect(result1[2]).toHaveProperty("target", "0xBBB");
+      expect(result1[3]).toHaveProperty("target", "0xCCC");
+    });
+
+    test("handles case-insensitive address sorting", () => {
+      const policies1: ParsedSessionPolicies = {
+        verified: false,
+        contracts: {
+          "0xaaa": {
+            methods: [{ entrypoint: "foo", authorized: true }],
+          },
+          "0xAAB": {
+            methods: [{ entrypoint: "bar", authorized: true }],
+          },
+        },
+      };
+
+      const policies2: ParsedSessionPolicies = {
+        verified: false,
+        contracts: {
+          "0xAAB": {
+            methods: [{ entrypoint: "bar", authorized: true }],
+          },
+          "0xaaa": {
+            methods: [{ entrypoint: "foo", authorized: true }],
+          },
+        },
+      };
+
+      const result1 = toWasmPolicies(policies1);
+      const result2 = toWasmPolicies(policies2);
+
+      expect(result1).toEqual(result2);
+    });
+
+    test("handles empty policies", () => {
+      const policies: ParsedSessionPolicies = {
+        verified: false,
+        contracts: {},
+        messages: [],
+      };
+
+      const result = toWasmPolicies(policies);
+      expect(result).toEqual([]);
+    });
+
+    test("handles undefined contracts and messages", () => {
+      const policies: ParsedSessionPolicies = {
+        verified: false,
+      };
+
+      const result = toWasmPolicies(policies);
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/packages/keychain/src/hooks/session.ts
+++ b/packages/keychain/src/hooks/session.ts
@@ -153,59 +153,74 @@ export function parseSessionPolicies({
   return summary;
 }
 
+/**
+ * Converts parsed session policies to WASM-compatible Policy objects.
+ *
+ * IMPORTANT: Policies are sorted canonically before hashing. Without this,
+ * Object.keys/entries reordering can cause identical policies to produce
+ * different merkle roots, leading to "session/not-registered" errors.
+ * See: https://github.com/cartridge-gg/controller/issues/2357
+ */
 export function toWasmPolicies(policies: ParsedSessionPolicies): Policy[] {
   return [
-    ...Object.entries(policies.contracts ?? {}).flatMap(
-      ([target, { methods }]) => {
+    ...Object.entries(policies.contracts ?? {})
+      .sort(([a], [b]) => a.toLowerCase().localeCompare(b.toLowerCase()))
+      .flatMap(([target, { methods }]) => {
         const methodsArr = Array.isArray(methods) ? methods : [methods];
-        return methodsArr.map((m): Policy => {
-          // Check if this is an approve entrypoint
-          if (m.entrypoint === "approve") {
-            // Only create ApprovalPolicy if both spender and amount are defined
-            if ("spender" in m && "amount" in m && m.spender && m.amount) {
-              const approvalPolicy: ApprovalPolicy = {
-                target,
-                spender: m.spender,
-                amount: String(m.amount), // Convert to string as ApprovalPolicy expects string
-              };
-              return approvalPolicy;
+        return methodsArr
+          .slice()
+          .sort((a, b) => a.entrypoint.localeCompare(b.entrypoint))
+          .map((m): Policy => {
+            // Check if this is an approve entrypoint
+            if (m.entrypoint === "approve") {
+              // Only create ApprovalPolicy if both spender and amount are defined
+              if ("spender" in m && "amount" in m && m.spender && m.amount) {
+                const approvalPolicy: ApprovalPolicy = {
+                  target,
+                  spender: m.spender,
+                  amount: String(m.amount), // Convert to string as ApprovalPolicy expects string
+                };
+                return approvalPolicy;
+              }
+
+              // Fall back to CallPolicy with deprecation warning
+              console.warn(
+                `[DEPRECATED] Approve method without spender and amount fields will be rejected in future versions. ` +
+                  `Please update your preset or policies to include both 'spender' and 'amount' fields for approve calls on contract ${target}. ` +
+                  `Example: { entrypoint: "approve", spender: "0x...", amount: "0x..." }`,
+              );
             }
 
-            // Fall back to CallPolicy with deprecation warning
-            console.warn(
-              `[DEPRECATED] Approve method without spender and amount fields will be rejected in future versions. ` +
-                `Please update your preset or policies to include both 'spender' and 'amount' fields for approve calls on contract ${target}. ` +
-                `Example: { entrypoint: "approve", spender: "0x...", amount: "0x..." }`,
-            );
-          }
+            // For non-approve methods and legacy approve, create a regular CallPolicy
+            return {
+              target,
+              method: hash.getSelectorFromName(m.entrypoint),
+              authorized: !!m.authorized,
+            };
+          });
+      }),
+    ...(policies.messages ?? [])
+      .map((p) => {
+        const domainHash = typedData.getStructHash(
+          p.types,
+          "StarknetDomain",
+          p.domain,
+          TypedDataRevision.ACTIVE,
+        );
+        const typeHash = typedData.getTypeHash(
+          p.types,
+          p.primaryType,
+          TypedDataRevision.ACTIVE,
+        );
 
-          // For non-approve methods and legacy approve, create a regular CallPolicy
-          return {
-            target,
-            method: hash.getSelectorFromName(m.entrypoint),
-            authorized: !!m.authorized,
-          };
-        });
-      },
-    ),
-    ...(policies.messages ?? []).map((p) => {
-      const domainHash = typedData.getStructHash(
-        p.types,
-        "StarknetDomain",
-        p.domain,
-        TypedDataRevision.ACTIVE,
-      );
-      const typeHash = typedData.getTypeHash(
-        p.types,
-        p.primaryType,
-        TypedDataRevision.ACTIVE,
-      );
-
-      return {
-        scope_hash: hash.computePoseidonHash(domainHash, typeHash),
-        authorized: !!p.authorized,
-      };
-    }),
+        return {
+          scope_hash: hash.computePoseidonHash(domainHash, typeHash),
+          authorized: !!p.authorized,
+        };
+      })
+      .sort((a, b) =>
+        a.scope_hash.toString().localeCompare(b.scope_hash.toString()),
+      ),
   ];
 }
 


### PR DESCRIPTION
## Summary

Policies are now canonically sorted before hashing to prevent non-deterministic merkle root calculations.
When developers manipulated policies with `Object.keys()`, filtering, or other operations, it could non-deterministically reorder object attributes.
This caused identical policies to produce different merkle roots, leading to "session/not-registered" errors.

## Changes

- Sort contract entries by address (case-insensitive)
- Sort methods within each contract by entrypoint
- Sort message policies by computed scope_hash
- Add tests verifying consistent output regardless of input order

## Fixes

Closes #2357

🤖 Generated with [Claude Code](https://claude.com/claude-code)