### PR TITLE
fix: reuse existing controller to prevent re-initialization issues

### DIFF
--- a/packages/connector/src/controller.ts
+++ b/packages/connector/src/controller.ts
@@ -11,15 +11,20 @@ export default class ControllerConnector extends InjectedConnector {
   public controller: ControllerProvider;
 
   constructor(options: ControllerOptions = {}) {
-    const controller = new ControllerProvider(options);
+    let controller: ControllerProvider;
 
-    super({
-      options: {
-        id: controller.id,
-        name: controller.name,
-      },
-    });
+    if (typeof window !== "undefined" && (window as any).starknet_controller) {
+      console.warn(
+        "ControllerConnector was instantiated multiple times. " +
+          "Reusing existing controller to prevent errors. " +
+          "To fix, create the connector at the module level instead of inside a React component.",
+      );
+      controller = (window as any).starknet_controller;
+    } else {
+      controller = new ControllerProvider(options);
+    }
 
+    super({ options: { id: controller.id, name: controller.name } });
     this.controller = controller;
   }
 


### PR DESCRIPTION
## Summary

- Reuse existing controller instance from `window.starknet_controller` when `ControllerConnector` is instantiated multiple times
- Prevents duplicate iframes and message channels that cause issues when React re-renders

## Context

When `ControllerConnector` is created inside a React component, React re-renders can cause multiple instantiations.
This creates duplicate penpal connections and orphaned message channels, breaking the controller.

The fix checks for an existing controller on `window.starknet_controller` and reuses it, with a warning to guide developers toward the correct pattern (creating the connector at module level).

Fixes #2093

## Test plan

- [ ] Verify controller works normally when created at module level (no warning)
- [ ] Verify controller works when created inside a React component (warning shown, but no errors)
- [ ] Verify existing functionality is not affected

🤖 Generated with [Claude Code](https://claude.ai/code)