### PR TITLE
fix: bypass preset verification for direct keychain access

### DIFF
--- a/packages/keychain/src/hooks/connection.ts
+++ b/packages/keychain/src/hooks/connection.ts
@@ -429,11 +429,6 @@ export function useConnectionValue() {
       return;
     }
 
-    if (!configData.origin) {
-      setVerified(false);
-      return;
-    }
-
     const allowedOrigins = toArray(configData.origin as string | string[]);
 
     // In standalone mode (not iframe), verify preset if redirect_url matches preset whitelist
@@ -442,6 +437,11 @@ export function useConnectionValue() {
       const redirectUrl = searchParams.get("redirect_url");
 
       if (redirectUrl) {
+        if (!configData.origin) {
+          setVerified(false);
+          return;
+        }
+
         try {
           const redirectUrlObj = new URL(redirectUrl);
           const redirectOrigin = redirectUrlObj.origin;
@@ -462,6 +462,11 @@ export function useConnectionValue() {
       }
 
       // No redirect_url or invalid redirect_url - don't verify preset in standalone mode
+      setVerified(true);
+      return;
+    }
+
+    if (!configData.origin) {
       setVerified(false);
       return;
     }


### PR DESCRIPTION
## Summary
- Fixed an issue where direct access to the keychain with a preset (e.g., `https://x.cartridge.gg/?preset=...`) would incorrectly show an "Application domain does not match" warning.
- Updated the verification logic in `useConnectionValue` to skip domain enforcement in standalone mode when no `redirect_url` is provided.
- Refactored `allowedOrigins` calculation to reduce redundancy.

## Test plan
- Visit the keychain directly with a preset and verify no "Application domain does not match" warning is shown.
- Verify that the warning still appears if accessing via a `redirect_url` that does not match the preset's configured origins.
- Verify that verification still works correctly in embedded (iframe) mode.