### PR TITLE
Add ApprovalPolicy support to controller toWasmPolicies

### DIFF
--- a/packages/controller/src/policies.ts
+++ b/packages/controller/src/policies.ts
@@ -1,4 +1,5 @@
 import {
+  Approval,
   ContractPolicy,
   Method,
   SessionPolicies,
@@ -14,7 +15,7 @@ export type ParsedSessionPolicies = {
 export type SessionContracts = Record<
   string,
   Omit<ContractPolicy, "methods"> & {
-    methods: (Method & { authorized?: boolean })[];
+    methods: ((Method | Approval) & { authorized?: boolean })[];
   }
 >;
 


### PR DESCRIPTION
## Summary

The controller SDK's `toWasmPolicies` function was missing `ApprovalPolicy` handling that exists in the keychain implementation. This caused merkle root mismatches for:
- `SessionConnector` (native/Capacitor apps)
- `NodeProvider` (Node.js server-side)
- `TelegramProvider` (Telegram mini-apps)

When these connectors are used with approve policies that include `spender` and `amount` fields, the session registration (via keychain) would create `ApprovalPolicy` objects, while session usage (via controller SDK) would create `CallPolicy` objects. This resulted in different merkle roots and "session/not-registered" errors.

## Changes

- Add `ApprovalPolicy` handling to `packages/controller/src/utils.ts` to match keychain implementation
- Update `SessionContracts` type in `packages/controller/src/policies.ts` to properly include `Approval` methods
- Add comprehensive tests for ApprovalPolicy handling

## Test plan

- [x] New tests verify ApprovalPolicy is created for approve methods with spender/amount
- [x] Tests verify fallback to CallPolicy (with deprecation warning) for legacy approve policies
- [x] Tests verify correct sorting behavior with mixed approve/non-approve methods
- [x] Existing canonical ordering tests continue to pass

## Fixes

Closes #2370

🤖 Generated with [Claude Code](https://claude.com/claude-code)