### PR TITLE
Request storage access in iframe connect flow

### DIFF
--- a/packages/keychain/src/components/ConnectRoute.tsx
+++ b/packages/keychain/src/components/ConnectRoute.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/hooks/route";
 import { isIframe } from "@cartridge/ui/utils";
 import { safeRedirect } from "@/utils/url-validator";
+import { requestStorageAccess } from "@/utils/connection/storage-access";
 
 const CANCEL_RESPONSE = {
   code: ResponseCodes.CANCELED,
@@ -52,6 +53,16 @@ export function ConnectRoute() {
   const handleConnect = useCallback(async () => {
     if (!params || !controller) {
       return;
+    }
+
+    // In iframe context, request storage access on user gesture so
+    // third-party storage can persist across app restarts.
+    if (!isStandalone) {
+      try {
+        await requestStorageAccess();
+      } catch (error) {
+        console.error("[ConnectRoute] Storage access request failed:", error);
+      }
     }
 
     params.resolve?.({
@@ -98,6 +109,14 @@ export function ConnectRoute() {
   const handleSkip = useCallback(async () => {
     if (!params || !controller) {
       return;
+    }
+
+    if (!isStandalone) {
+      try {
+        await requestStorageAccess();
+      } catch (error) {
+        console.error("[ConnectRoute] Storage access request failed:", error);
+      }
     }
 
     params.resolve?.({


### PR DESCRIPTION
## Summary\n- Request Storage Access API in iframe connect flow before completing connect/skip\n- Allows third-party storage (cookies/localStorage) to persist across restarts in WKWebView\n\n## Testing\n- Not run (requires device/WebView testing)