### PR TITLE
fix(keychain): align password login button with primary theme

### DIFF
--- a/packages/keychain/src/components/connect/buttons/auth-button.tsx
+++ b/packages/keychain/src/components/connect/buttons/auth-button.tsx
@@ -87,7 +87,6 @@ const OPTIONS: Partial<Record<string, LoginAuthConfig>> = {
   },
   password: {
     Icon: LockIcon,
-    bgColor: "bg-background-300",
     label: AUTH_METHODS_LABELS.password,
   },
 };


### PR DESCRIPTION
## Summary
- Remove the password-specific gray background override in the keychain auth button config.
- Let the password login CTA use the same primary theme styling as other main actions.

## Testing
- `pnpm --filter @cartridge/keychain exec eslint src/components/connect/buttons/auth-button.tsx`
- `pnpm --filter @cartridge/keychain test:ci src/components/connect/create/CreateController.test.tsx`