### PR TITLE
Always show quantity in starterpack purchase button

### DIFF
--- a/packages/keychain/src/components/purchasenew/checkout/onchain/quantity.tsx
+++ b/packages/keychain/src/components/purchasenew/checkout/onchain/quantity.tsx
@@ -29,8 +29,7 @@ export function QuantityControls({
   purchaseLabel: customPurchaseLabel,
   isApplePayAmountTooLow,
 }: QuantityControlsProps) {
-  const purchaseLabel =
-    customPurchaseLabel || (quantity > 1 ? `Buy ${quantity}` : "Buy");
+  const purchaseLabel = customPurchaseLabel || `Buy ${quantity}`;
   const isQuantityDisabled =
     (globalDisabled && hasSufficientBalance && !isApplePayAmountTooLow) ||
     isSendingDeposit;


### PR DESCRIPTION
## Summary
- Updates the purchase button to always display quantity, even for single items
- Changes "Buy" to "Buy 1" for consistency

## Changes
- Modified `QuantityControls` component to always show quantity in button label
- Removed conditional logic that hid quantity when it was 1

## Test plan
- [ ] Verify starterpack purchase shows "Buy 1" for single items
- [ ] Verify multiple items still show "Buy N" correctly
- [ ] Check all purchase flows display quantity consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)