### PR TITLE
fix: reset navigation stack when showing execution prompt

### DIFF
--- a/packages/keychain/src/utils/connection/execute.test.ts
+++ b/packages/keychain/src/utils/connection/execute.test.ts
@@ -248,7 +248,7 @@ describe("execute utils", () => {
       // Should navigate to UI for session refresh
       expect(mockNavigate).toHaveBeenCalledWith(
         expect.stringMatching(/^\/execute\?/),
-        { replace: true },
+        { replace: true, reset: true },
       );
 
       // Parse the URL to verify error is included
@@ -292,7 +292,7 @@ describe("execute utils", () => {
       // Should navigate to UI for manual execution
       expect(mockNavigate).toHaveBeenCalledWith(
         expect.stringMatching(/^\/execute\?/),
-        { replace: true },
+        { replace: true, reset: true },
       );
 
       // Parse the URL to verify error is included
@@ -378,7 +378,7 @@ describe("execute utils", () => {
 
       expect(mockNavigate).toHaveBeenCalledWith(
         expect.stringMatching(/^\/execute\?/),
-        { replace: true },
+        { replace: true, reset: true },
       );
 
       // The promise should be pending since sync mode waits for navigation
@@ -434,7 +434,7 @@ describe("execute utils", () => {
 
       expect(mockNavigate).toHaveBeenCalledWith(
         expect.stringMatching(/^\/execute\?/),
-        { replace: true },
+        { replace: true, reset: true },
       );
 
       expect(result).toEqual({
@@ -466,7 +466,7 @@ describe("execute utils", () => {
 
       expect(mockNavigate).toHaveBeenCalledWith(
         expect.stringMatching(/^\/execute\?/),
-        { replace: true },
+        { replace: true, reset: true },
       );
 
       // When trySessionExecute fails, we return USER_INTERACTION_REQUIRED

--- a/packages/keychain/src/utils/connection/execute.ts
+++ b/packages/keychain/src/utils/connection/execute.ts
@@ -108,7 +108,7 @@ export function execute({
 }: {
   navigate: (
     to: string | number,
-    options?: { replace?: boolean; state?: unknown },
+    options?: { replace?: boolean; state?: unknown; reset?: boolean },
   ) => void;
   propagateError?: boolean;
   errorDisplayMode?: "modal" | "notification" | "silent"; // Available for potential future use
@@ -134,7 +134,7 @@ export function execute({
             reject,
           });
 
-          navigate(url, { replace: true });
+          navigate(url, { replace: true, reset: true });
         });
       }
 
@@ -184,7 +184,7 @@ export function execute({
               resolve,
               reject,
             });
-            navigate(url, { replace: true });
+            navigate(url, { replace: true, reset: true });
 
             return resolve({
               code: ResponseCodes.USER_INTERACTION_REQUIRED,

--- a/packages/keychain/src/utils/connection/index.ts
+++ b/packages/keychain/src/utils/connection/index.ts
@@ -25,7 +25,7 @@ export function connectToController<ParentMethods extends object>({
   setController: (controller?: Controller) => void;
   navigate: (
     to: string | number,
-    options?: { replace?: boolean; state?: unknown },
+    options?: { replace?: boolean; state?: unknown; reset?: boolean },
   ) => void;
   propagateError?: boolean;
   errorDisplayMode?: "modal" | "notification" | "silent";


### PR DESCRIPTION
## Summary

Fixes state issue where the execution prompt incorrectly showed a back button on the second display instead of the close button.

## Changes

- Added `reset: true` to execute route navigation to clear navigation history
- Updated type signatures to include the `reset` option
- Updated all relevant tests to expect the new behavior

## Testing

All 16 tests passing ✅