### PR TITLE
refactor: consolidate toWasmPolicies into single source of truth

### DIFF
--- a/packages/controller/src/index.ts
+++ b/packages/controller/src/index.ts
@@ -3,6 +3,7 @@ export * from "./errors";
 export * from "./types";
 export * from "./lookup";
 export * from "./utils";
+export * from "./policies";
 export * from "./wallets";
 export * from "./toast";
 export * from "@cartridge/presets";

--- a/packages/controller/src/session/provider.ts
+++ b/packages/controller/src/session/provider.ts
@@ -23,6 +23,7 @@ interface SessionRegistration {
   guardianKeyGuid: string;
   metadataHash: string;
   sessionKeyGuid: string;
+  allowedPoliciesRoot?: string;
 }
 
 export type SessionOptions = {

--- a/packages/controller/src/utils.ts
+++ b/packages/controller/src/utils.ts
@@ -129,7 +129,7 @@ export function toWasmPolicies(policies: ParsedSessionPolicies): Policy[] {
             return {
               target,
               method: hash.getSelectorFromName(m.entrypoint),
-              authorized: m.authorized,
+              authorized: !!m.authorized,
             };
           }),
       ),
@@ -149,7 +149,7 @@ export function toWasmPolicies(policies: ParsedSessionPolicies): Policy[] {
 
         return {
           scope_hash: hash.computePoseidonHash(domainHash, typeHash),
-          authorized: p.authorized,
+          authorized: !!p.authorized,
         };
       })
       .sort((a, b) =>

--- a/packages/keychain/src/components/session.tsx
+++ b/packages/keychain/src/components/session.tsx
@@ -19,6 +19,7 @@ type SessionResponse = {
   expiresAt: string;
   transactionHash?: string;
   alreadyRegistered?: boolean;
+  allowedPoliciesRoot?: string;
 };
 
 type SessionQueryParams = {
@@ -160,6 +161,7 @@ export function Session() {
             ownerGuid: controller.ownerGuid(),
             alreadyRegistered: true,
             expiresAt: String(session.session.expiresAt),
+            allowedPoliciesRoot: session.allowedPoliciesRoot,
           });
 
           return;

--- a/packages/keychain/src/utils/controller.ts
+++ b/packages/keychain/src/utils/controller.ts
@@ -29,7 +29,8 @@ import {
 } from "@cartridge/controller-wasm/controller";
 
 import { credentialToAuth } from "@/components/connect/types";
-import { ParsedSessionPolicies, toWasmPolicies } from "@/hooks/session";
+import { ParsedSessionPolicies } from "@/hooks/session";
+import { toWasmPolicies } from "@cartridge/controller";
 import { CredentialMetadata } from "@cartridge/ui/utils/api/cartridge";
 import { DeployedAccountTransaction } from "@starknet-io/types-js";
 import { toJsFeeEstimate } from "./fee";


### PR DESCRIPTION
## Summary

Consolidates `toWasmPolicies` into a single implementation in the controller package to prevent session hash mismatches between registration and execution.

The root cause of `session/not-registered` errors was two independent implementations (controller and keychain) that could drift, producing different merkle roots and session hashes.

## Changes

- Fixed `authorized` field coercion in controller's `toWasmPolicies` (`m.authorized` → `!!m.authorized`)
- Exported `ParsedSessionPolicies` from `@cartridge/controller`
- Keychain now imports `toWasmPolicies` from `@cartridge/controller` instead of maintaining a duplicate
- Removed 70-line duplicate implementation from keychain
- Added `allowedPoliciesRoot` to SessionResponse for diagnostic verification

## Test plan

✅ Build: 8/8 tasks successful
✅ Lint: 6/6 tasks successful  
✅ Tests: 326/326 tests passed in keychain test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)