### PR TITLE
Add headless username lookup and auto-signup connect

### DIFF
--- a/packages/connector/src/controller.ts
+++ b/packages/connector/src/controller.ts
@@ -38,6 +38,10 @@ export default class ControllerConnector extends InjectedConnector {
     return this.controller.username();
   }
 
+  lookupUsername(username: string) {
+    return this.controller.lookupUsername(username);
+  }
+
   isReady(): boolean {
     return this.controller.isReady();
   }

--- a/packages/controller/HEADLESS_MODE.md
+++ b/packages/controller/HEADLESS_MODE.md
@@ -2,19 +2,36 @@
 
 ## Overview
 
-Headless mode enables programmatic authentication with the Cartridge Controller SDK without displaying any UI. You trigger headless mode by passing a `username` and `signer` to `connect(...)`.
+Headless mode enables programmatic authentication with the Cartridge Controller
+SDK without displaying any UI. You trigger headless mode by passing a `username`
+and `signer` to `connect(...)`.
 
 ```
 Controller SDK → Keychain iframe (hidden) → Backend API
 ```
 
 **Key Points**
+
 - The keychain iframe still exists, but the modal is not opened.
 - The SDK passes the connect request to keychain over Penpal.
 - Keychain executes the same authentication logic as the UI flow.
 - No duplicated auth logic in the SDK.
 
 ## Usage
+
+### Username Lookup (Recommended)
+
+Use lookup first so your app can decide whether to login or signup and show the
+available signer methods for existing accounts.
+
+```ts
+const lookup = await controller.lookupUsername("alice");
+
+if (lookup.exists) {
+  // e.g. ["webauthn", "google", "password"]
+  console.log(lookup.signers);
+}
+```
 
 ### Basic (Passkey / WebAuthn)
 
@@ -30,6 +47,9 @@ await controller.connect({
   signer: "webauthn",
 });
 ```
+
+If `alice` does not exist yet, headless connect will create a new account and
+continue.
 
 ### Password
 
@@ -60,6 +80,7 @@ await controller.connect({ username: "alice", signer: "walletconnect" });
 ## Supported Auth Options
 
 Headless mode supports all **implemented** auth options:
+
 - `webauthn`
 - `password`
 - `google`
@@ -72,8 +93,8 @@ Headless mode supports all **implemented** auth options:
 ## Handling Session Approval
 
 If policies are unverified or include approvals, Keychain will prompt for
-session approval **after** authentication. In that case, `connect` will open
-the approval UI and resolve once the session is approved.
+session approval **after** authentication. In that case, `connect` will open the
+approval UI and resolve once the session is approved.
 
 ```ts
 const account = await controller.connect({
@@ -83,6 +104,7 @@ const account = await controller.connect({
 
 console.log("Session approved:", account.address);
 ```
+
 If you want to react to connection state changes, subscribe to the standard
 wallet events (for example `accountsChanged`) or just await `connect(...)` and
 update your app state afterwards.
@@ -92,9 +114,7 @@ update your app state afterwards.
 The SDK provides specific error classes for headless mode:
 
 ```ts
-import {
-  HeadlessAuthenticationError,
-} from "@cartridge/controller";
+import { HeadlessAuthenticationError } from "@cartridge/controller";
 
 try {
   await controller.connect({ username: "alice", signer: "webauthn" });
@@ -107,7 +127,8 @@ try {
 
 ## Notes
 
-- Headless mode uses the **existing signers** on the controller for the given username.
+- Headless mode can create new accounts when the username does not exist.
+- For existing accounts, the requested signer must already be registered.
 - For passkeys, the account must already have a WebAuthn signer registered.
 - If policies are unverified or include approvals, Keychain will request
   explicit approval after authentication.

--- a/packages/controller/src/__tests__/lookupUsername.test.ts
+++ b/packages/controller/src/__tests__/lookupUsername.test.ts
@@ -1,0 +1,166 @@
+import { constants } from "starknet";
+import ControllerProvider from "../controller";
+import { IMPLEMENTED_AUTH_OPTIONS } from "../types";
+
+describe("lookupUsername", () => {
+  beforeEach(() => {
+    (global as any).fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test("returns normalized signer options in canonical order", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: {
+          account: {
+            username: "alice",
+            controllers: {
+              edges: [
+                {
+                  node: {
+                    signers: [
+                      {
+                        isOriginal: true,
+                        isRevoked: false,
+                        metadata: {
+                          __typename: "Eip191Credentials",
+                          eip191: [
+                            { provider: "metamask", ethAddress: "0x1" },
+                            { provider: "google", ethAddress: "0x2" },
+                            { provider: "unknown", ethAddress: "0x3" },
+                          ],
+                        },
+                      },
+                      {
+                        isOriginal: true,
+                        isRevoked: false,
+                        metadata: { __typename: "PasswordCredentials" },
+                      },
+                      {
+                        isOriginal: true,
+                        isRevoked: false,
+                        metadata: { __typename: "WebauthnCredentials" },
+                      },
+                      {
+                        isOriginal: true,
+                        isRevoked: true,
+                        metadata: { __typename: "WebauthnCredentials" },
+                      },
+                      {
+                        isOriginal: true,
+                        isRevoked: false,
+                        metadata: {
+                          __typename: "Eip191Credentials",
+                          eip191: [{ provider: "discord", ethAddress: "0x4" }],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        },
+      }),
+    });
+
+    const provider = new ControllerProvider({ lazyload: true });
+    const result = await provider.lookupUsername("alice");
+    const expectedOrder = IMPLEMENTED_AUTH_OPTIONS.filter((option) =>
+      ["google", "webauthn", "discord", "password", "metamask"].includes(
+        option,
+      ),
+    );
+
+    expect(result).toEqual({
+      username: "alice",
+      exists: true,
+      signers: expectedOrder,
+    });
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://api.cartridge.gg/query",
+      expect.any(Object),
+    );
+  });
+
+  test("filters non-original signers on non-mainnet chains", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: {
+          account: {
+            username: "alice",
+            controllers: {
+              edges: [
+                {
+                  node: {
+                    signers: [
+                      {
+                        isOriginal: false,
+                        isRevoked: false,
+                        metadata: {
+                          __typename: "Eip191Credentials",
+                          eip191: [{ provider: "google", ethAddress: "0x1" }],
+                        },
+                      },
+                      {
+                        isOriginal: true,
+                        isRevoked: false,
+                        metadata: { __typename: "PasswordCredentials" },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        },
+      }),
+    });
+
+    const provider = new ControllerProvider({
+      lazyload: true,
+      defaultChainId: constants.StarknetChainId.SN_SEPOLIA,
+    });
+    const result = await provider.lookupUsername("alice");
+
+    expect(result.signers).toEqual(["password"]);
+  });
+
+  test("returns exists=false for unknown usernames", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: {
+          account: null,
+        },
+      }),
+    });
+
+    const provider = new ControllerProvider({ lazyload: true });
+    const result = await provider.lookupUsername("missing-user");
+
+    expect(result).toEqual({
+      username: "missing-user",
+      exists: false,
+      signers: [],
+    });
+  });
+
+  test("throws on network failures", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 503,
+    });
+
+    const provider = new ControllerProvider({ lazyload: true });
+
+    await expect(provider.lookupUsername("alice")).rejects.toThrow(
+      "HTTP error! status: 503",
+    );
+  });
+});

--- a/packages/controller/src/controller.ts
+++ b/packages/controller/src/controller.ts
@@ -15,6 +15,7 @@ import { KEYCHAIN_URL } from "./constants";
 import { HeadlessAuthenticationError, NotReadyToConnect } from "./errors";
 import { KeychainIFrame } from "./iframe";
 import BaseProvider from "./provider";
+import { lookupUsername as lookupUsernameApi } from "./lookup";
 import {
   AuthOptions,
   Chain,
@@ -28,6 +29,7 @@ import {
   ProfileContextTypeVariant,
   ResponseCodes,
   OpenOptions,
+  HeadlessUsernameLookupResult,
   StarterpackOptions,
 } from "./types";
 import { validateRedirectUrl } from "./url-validator";
@@ -528,6 +530,17 @@ export default class ControllerProvider extends BaseProvider {
     }
 
     return this.keychain.username();
+  }
+
+  async lookupUsername(
+    username: string,
+  ): Promise<HeadlessUsernameLookupResult> {
+    const trimmed = username.trim();
+    if (!trimmed) {
+      throw new Error("Username is required");
+    }
+
+    return lookupUsernameApi(trimmed, this.selectedChain);
   }
 
   openPurchaseCredits() {

--- a/packages/controller/src/lookup.ts
+++ b/packages/controller/src/lookup.ts
@@ -1,8 +1,43 @@
-import { LookupRequest, LookupResponse } from "./types";
-import { num } from "starknet";
+import {
+  AuthOption,
+  HeadlessUsernameLookupResult,
+  IMPLEMENTED_AUTH_OPTIONS,
+  LookupRequest,
+  LookupResponse,
+} from "./types";
+import { constants, num } from "starknet";
 import { API_URL } from "./constants";
 
 const cache = new Map<string, string>();
+const QUERY_URL = `${API_URL}/query`;
+
+type LookupSigner = {
+  isOriginal: boolean;
+  isRevoked: boolean;
+  metadata: {
+    __typename: string;
+    eip191?: Array<{
+      provider: string;
+      ethAddress: string;
+    }> | null;
+  };
+};
+
+type LookupSignersQueryResponse = {
+  data?: {
+    account?: {
+      username: string;
+      controllers?: {
+        edges?: Array<{
+          node?: {
+            signers?: LookupSigner[] | null;
+          } | null;
+        } | null> | null;
+      } | null;
+    } | null;
+  };
+  errors?: Array<{ message?: string }>;
+};
 
 async function lookup(request: LookupRequest): Promise<LookupResponse> {
   if (!request.addresses?.length && !request.usernames?.length) {
@@ -22,6 +57,139 @@ async function lookup(request: LookupRequest): Promise<LookupResponse> {
   }
 
   return response.json();
+}
+
+async function queryLookupSigners(
+  username: string,
+): Promise<LookupSignersQueryResponse> {
+  const response = await fetch(QUERY_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      query: `
+        query LookupSigners($username: String!) {
+          account(username: $username) {
+            username
+            controllers(first: 1) {
+              edges {
+                node {
+                  signers {
+                    isOriginal
+                    isRevoked
+                    metadata {
+                      __typename
+                      ... on Eip191Credentials {
+                        eip191 {
+                          provider
+                          ethAddress
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `,
+      variables: { username },
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+function normalizeProvider(provider: string): AuthOption | undefined {
+  const normalized = provider.toLowerCase() as AuthOption;
+  if (!HEADLESS_AUTH_OPTIONS.includes(normalized)) {
+    return undefined;
+  }
+  return normalized;
+}
+
+const HEADLESS_AUTH_OPTIONS: AuthOption[] = [
+  "google",
+  "webauthn",
+  "discord",
+  "walletconnect",
+  "password",
+  "metamask",
+  "rabby",
+  "phantom-evm",
+].filter((option) => IMPLEMENTED_AUTH_OPTIONS.includes(option));
+
+function normalizeSignerOptions(
+  signers: LookupSigner[] | undefined,
+  chainId: string,
+): AuthOption[] {
+  if (!signers || signers.length === 0) {
+    return [];
+  }
+
+  const isMainnet = chainId === constants.StarknetChainId.SN_MAIN;
+  const available = signers.filter(
+    (signer) => !signer.isRevoked && (isMainnet || signer.isOriginal),
+  );
+
+  const signerSet = new Set<AuthOption>();
+  for (const signer of available) {
+    switch (signer.metadata.__typename) {
+      case "WebauthnCredentials":
+        signerSet.add("webauthn");
+        break;
+      case "PasswordCredentials":
+        signerSet.add("password");
+        break;
+      case "Eip191Credentials":
+        signer.metadata.eip191?.forEach((entry) => {
+          const provider = normalizeProvider(entry.provider);
+          if (provider) {
+            signerSet.add(provider);
+          }
+        });
+        break;
+      default:
+        break;
+    }
+  }
+
+  return HEADLESS_AUTH_OPTIONS.filter((option) => signerSet.has(option));
+}
+
+export async function lookupUsername(
+  username: string,
+  chainId: string,
+): Promise<HeadlessUsernameLookupResult> {
+  const response = await queryLookupSigners(username);
+  if (response.errors?.length) {
+    throw new Error(response.errors[0].message || "Lookup query failed");
+  }
+
+  const account = response.data?.account;
+  if (!account) {
+    return {
+      username,
+      exists: false,
+      signers: [],
+    };
+  }
+
+  const controller = account.controllers?.edges?.[0]?.node;
+  const signers = normalizeSignerOptions(
+    controller?.signers ?? undefined,
+    chainId,
+  );
+  return {
+    username: account.username,
+    exists: true,
+    signers,
+  };
 }
 
 export async function lookupUsernames(

--- a/packages/controller/src/types.ts
+++ b/packages/controller/src/types.ts
@@ -120,6 +120,12 @@ export interface LookupResponse {
   results: LookupResult[];
 }
 
+export interface HeadlessUsernameLookupResult {
+  username: string;
+  exists: boolean;
+  signers: AuthOption[];
+}
+
 export enum FeeSource {
   PAYMASTER = "PAYMASTER",
   CREDITS = "CREDITS",

--- a/packages/keychain/src/utils/connection/headless.test.ts
+++ b/packages/keychain/src/utils/connection/headless.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ResponseCodes } from "@cartridge/controller";
+
+const mockFetchController = vi.fn();
+const mockGenerateStarknetKeypair = vi.fn();
+const mockEncryptPrivateKey = vi.fn();
+const mockComputeAccountAddress = vi.fn();
+const mockControllerLogin = vi.fn();
+
+vi.mock("@/components/connect/create/utils", () => ({
+  fetchController: (...args: unknown[]) => mockFetchController(...args),
+}));
+
+vi.mock("@/components/connect/create/password/crypto", () => ({
+  decryptPrivateKey: vi.fn(),
+  encryptPrivateKey: (...args: unknown[]) => mockEncryptPrivateKey(...args),
+  generateStarknetKeypair: () => mockGenerateStarknetKeypair(),
+}));
+
+vi.mock("@/components/provider/upgrade", () => ({
+  STABLE_CONTROLLER: { hash: "0xclasshash" },
+}));
+
+vi.mock("@/hooks/account", () => ({
+  doSignup: vi.fn(),
+}));
+
+vi.mock("@cartridge/controller-wasm", () => ({
+  computeAccountAddress: (...args: unknown[]) =>
+    mockComputeAccountAddress(...args),
+}));
+
+vi.mock("./headless-requests", () => ({
+  createHeadlessApprovalRequest: vi.fn(),
+  hasPendingHeadlessApproval: vi.fn(() => false),
+}));
+
+vi.mock("./session-creation", () => ({
+  createVerifiedSession: vi.fn(),
+  requiresSessionApproval: vi.fn(() => false),
+}));
+
+vi.mock("@/utils/controller", () => ({
+  default: {
+    login: (...args: unknown[]) => mockControllerLogin(...args),
+    create: vi.fn(),
+  },
+}));
+
+describe("headless connect auto-signup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a new password account when username does not exist", async () => {
+    const mockController = {
+      address: vi.fn(() => "0xnew"),
+      register: vi.fn().mockResolvedValue({ register: { username: "alice" } }),
+    };
+
+    mockFetchController.mockRejectedValue(
+      new Error("ent: controller not found"),
+    );
+    mockGenerateStarknetKeypair.mockReturnValue({
+      privateKey: "0xpriv",
+      publicKey: "0xpub",
+    });
+    mockEncryptPrivateKey.mockResolvedValue("enc");
+    mockComputeAccountAddress.mockReturnValue("0xcomputed");
+    mockControllerLogin.mockResolvedValue({
+      controller: mockController,
+      session: {
+        expiresAt: "1",
+        guardianKeyGuid: "0x0",
+        metadataHash: "0x0",
+        sessionKeyGuid: "0x1",
+        allowedPoliciesRoot: "0x0",
+        authorization: [],
+      },
+    });
+
+    const { headlessConnect } = await import("./headless");
+    const setController = vi.fn();
+    const getParent = vi.fn(() => undefined);
+    const getConnectionState = () => ({
+      origin: "https://game.example",
+      chainId: "0x534e5f4d41494e",
+      rpcUrl: "https://rpc.example",
+      policies: undefined,
+      isPoliciesResolved: true,
+      isConfigLoading: false,
+    });
+
+    const connect = headlessConnect({
+      setController,
+      getParent,
+      getConnectionState,
+    })("https://game.example");
+
+    const result = await connect({
+      username: "alice",
+      signer: "password",
+      password: "pw",
+    });
+
+    expect(result).toEqual({
+      code: ResponseCodes.SUCCESS,
+      address: "0xnew",
+    });
+    expect(mockControllerLogin).toHaveBeenCalledWith(
+      expect.objectContaining({
+        username: "alice",
+        isControllerRegistered: false,
+      }),
+    );
+    expect(mockController.register).toHaveBeenCalled();
+    expect(setController).toHaveBeenCalledWith(mockController);
+  });
+});


### PR DESCRIPTION
This adds `controller.lookupUsername(username)` for headless flows, returning whether an account exists and normalized signer options for the controller’s configured chain. It also updates headless connect to auto-signup when a username is missing, while keeping strict signer matching for existing accounts. The connector now exposes the lookup helper, and docs were updated with the recommended lookup-first flow. Tests were added for lookup normalization/error handling and for password-based headless auto-signup.