### PR TITLE
fix(keychain): theme copy button in ErrorAlert

### DIFF
--- a/packages/keychain/src/components/ErrorAlert.tsx
+++ b/packages/keychain/src/components/ErrorAlert.tsx
@@ -115,16 +115,16 @@ export function ErrorAlert({
             <Button
               size="icon"
               variant="icon"
-              className="absolute right-5 w-5 h-5 bg-[rgba(0,0,0,0.1)]"
+              className="absolute right-5 w-5 h-5 bg-background/10"
               onClick={() => {
                 setCopied(true);
                 navigator.clipboard.writeText(copyText);
               }}
             >
               {copied ? (
-                <CheckIcon size="xs" className="text-[black]" />
+                <CheckIcon size="xs" className={styles.text} />
               ) : (
-                <CopyIcon size="xs" className="text-[black]" />
+                <CopyIcon size="xs" className={styles.text} />
               )}
             </Button>
           )}


### PR DESCRIPTION
## Problem
The copy button in the ErrorAlert component was hardcoded to use black icons (`text-[black]`), making them invisible on dark error alert backgrounds.

## Solution
- Use `styles.text` to inherit the correct color per variant (e.g., `text-destructive` for errors)
- Use `bg-background/10` for consistent themed background

## Before/After
The copy button icon is now visible and matches the alert text color.

Closes: camouflaged button issue mentioned in Discord