### PR TITLE
chore(skills): add controller development skill

### DIFF
--- a/.agents/skills/controller-development/SKILL.md
+++ b/.agents/skills/controller-development/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: controller-development
+description: Contributor workflow for cartridge-gg/controller. Use when implementing or reviewing changes across this pnpm/turbo monorepo, including SDK, keychain UI, examples, storybook snapshots, and test/lint pipelines.
+---
+
+# Controller Development
+
+Use this skill to implement changes in `cartridge-gg/controller` with monorepo-aware validation.
+
+## Core Workflow
+
+1. Install and bootstrap:
+   - `corepack enable pnpm`
+   - `pnpm i`
+2. Pick scope using package filters when possible:
+   - `pnpm --filter @cartridge/controller <command>`
+   - `pnpm --filter @cartridge/keychain <command>`
+   - `pnpm --filter @cartridge/connector <command>`
+3. Run targeted validation:
+   - `pnpm test`
+   - `pnpm test:ci` when changes cross packages
+   - `pnpm test:storybook` for component/UI changes
+4. Run quality checks:
+   - `pnpm lint`
+   - `pnpm format`
+5. Run full build before PR when changes affect published packages:
+   - `pnpm build`
+
+## UI And Snapshot Guidance
+
+- Run `pnpm storybook` when changing keychain UI components.
+- Update snapshots with `pnpm test:storybook:update` only when intentional visual diffs are confirmed.
+
+## PR Checklist
+
+- Keep workspace changes scoped and avoid unrelated package churn.
+- Report exact commands run and package filters used.
+- Mention snapshot updates explicitly when present.

--- a/.agents/skills/controller-development/agents/openai.yaml
+++ b/.agents/skills/controller-development/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Controller Development"
+  short_description: "Contributor workflow for cartridge-gg/controller"
+  default_prompt: "Use $controller-development to implement and validate changes in controller."


### PR DESCRIPTION
## Summary
- add a repository-specific development skill at `.agents/skills/controller-development`
- include `agents/openai.yaml` metadata for discoverability and default invocation

## Validation
- `/tmp/skillcreator-venv/bin/python /Users/nasr/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/controller-development`