### PR TITLE
Extract startapp query parameter into constant

### DIFF
--- a/packages/controller/src/constants.ts
+++ b/packages/controller/src/constants.ts
@@ -1,3 +1,7 @@
 export const KEYCHAIN_URL = "https://x.cartridge.gg";
 export const PROFILE_URL = "https://profile.cartridge.gg";
 export const API_URL = "https://api.cartridge.gg";
+
+// Query parameter name used to pass session data via URL redirects.
+// Borrowed from Telegram mini app convention, but the choice is arbitrary.
+export const REDIRECT_QUERY_NAME = "startapp";

--- a/packages/controller/src/node/server.ts
+++ b/packages/controller/src/node/server.ts
@@ -1,5 +1,6 @@
 import * as http from "http";
 import { AddressInfo } from "net";
+import { REDIRECT_QUERY_NAME } from "../constants";
 
 type ServerResponse = http.ServerResponse<http.IncomingMessage> & {
   req: http.IncomingMessage;
@@ -38,7 +39,7 @@ export class CallbackServer {
     }
 
     const params = new URLSearchParams(req.url.split("?")[1]);
-    const session = params.get("startapp");
+    const session = params.get(REDIRECT_QUERY_NAME);
 
     if (!session) {
       console.warn("Received callback without session data");

--- a/packages/controller/src/session/provider.ts
+++ b/packages/controller/src/session/provider.ts
@@ -7,7 +7,7 @@ import {
 import { loadConfig, SessionPolicies } from "@cartridge/presets";
 import { AddStarknetChainParameters } from "@starknet-io/types-js";
 import { encode } from "starknet";
-import { API_URL, KEYCHAIN_URL } from "../constants";
+import { API_URL, KEYCHAIN_URL, REDIRECT_QUERY_NAME } from "../constants";
 import { parsePolicies, ParsedSessionPolicies } from "../policies";
 import BaseProvider from "../provider";
 import { AuthOptions } from "../types";
@@ -388,9 +388,9 @@ export default class SessionProvider extends BaseProvider {
       }
     }
 
-    if (window.location.search.includes("startapp")) {
+    if (window.location.search.includes(REDIRECT_QUERY_NAME)) {
       const params = new URLSearchParams(window.location.search);
-      const session = params.get("startapp");
+      const session = params.get(REDIRECT_QUERY_NAME);
       if (session) {
         const normalizedSession = this.ingestSessionFromRedirect(session);
         if (
@@ -402,7 +402,7 @@ export default class SessionProvider extends BaseProvider {
         }
 
         // Remove the session query parameter
-        params.delete("startapp");
+        params.delete(REDIRECT_QUERY_NAME);
         const newUrl =
           window.location.pathname +
           (params.toString() ? `?${params.toString()}` : "") +

--- a/packages/keychain/src/utils/api/generated.ts
+++ b/packages/keychain/src/utils/api/generated.ts
@@ -5465,6 +5465,7 @@ export type Session = Node & {
   /** Whether the session has been revoked */
   isRevoked: Scalars["Boolean"];
   metadata?: Maybe<SessionMetadata>;
+  sessionKeyGUID?: Maybe<Scalars["String"]>;
   signer?: Maybe<Signer>;
   updatedAt: Scalars["Time"];
 };
@@ -5604,6 +5605,22 @@ export type SessionWhereInput = {
   isRevokedNEQ?: InputMaybe<Scalars["Boolean"]>;
   not?: InputMaybe<SessionWhereInput>;
   or?: InputMaybe<Array<SessionWhereInput>>;
+  /** session_key_guid field predicates */
+  sessionKeyGUID?: InputMaybe<Scalars["String"]>;
+  sessionKeyGUIDContains?: InputMaybe<Scalars["String"]>;
+  sessionKeyGUIDContainsFold?: InputMaybe<Scalars["String"]>;
+  sessionKeyGUIDEqualFold?: InputMaybe<Scalars["String"]>;
+  sessionKeyGUIDGT?: InputMaybe<Scalars["String"]>;
+  sessionKeyGUIDGTE?: InputMaybe<Scalars["String"]>;
+  sessionKeyGUIDHasPrefix?: InputMaybe<Scalars["String"]>;
+  sessionKeyGUIDHasSuffix?: InputMaybe<Scalars["String"]>;
+  sessionKeyGUIDIn?: InputMaybe<Array<Scalars["String"]>>;
+  sessionKeyGUIDIsNil?: InputMaybe<Scalars["Boolean"]>;
+  sessionKeyGUIDLT?: InputMaybe<Scalars["String"]>;
+  sessionKeyGUIDLTE?: InputMaybe<Scalars["String"]>;
+  sessionKeyGUIDNEQ?: InputMaybe<Scalars["String"]>;
+  sessionKeyGUIDNotIn?: InputMaybe<Array<Scalars["String"]>>;
+  sessionKeyGUIDNotNil?: InputMaybe<Scalars["Boolean"]>;
   /** updated_at field predicates */
   updatedAt?: InputMaybe<Scalars["Time"]>;
   updatedAtGT?: InputMaybe<Scalars["Time"]>;


### PR DESCRIPTION
Extract the hardcoded "startapp" string literal into `REDIRECT_QUERY_NAME` constant across the session provider and node server.

This improves maintainability and documents that the parameter name follows Telegram mini app convention, though the choice is arbitrary.