### PR TITLE
fix: skip popup flow for Chrome iOS, use direct iframe passkey creation

### DIFF
--- a/packages/keychain/src/components/connect/create/webauthn/index.ts
+++ b/packages/keychain/src/components/connect/create/webauthn/index.ts
@@ -15,7 +15,10 @@ export function useWebauthnAuthentication() {
       if (!chainId) throw new Error("No chainId found");
 
       // Signup flow
-      const isSafari = /^((?!chrome|android).)*safari/i.test(
+      // Only Safari needs the popup flow for passkey creation in cross-origin iframes.
+      // Chrome iOS (CriOS) uses WebKit like Safari but handles popups differently,
+      // so we let it use the direct iframe path (which has publickey-credentials-create permission).
+      const isSafari = /^((?!chrome|android|crios).)*safari/i.test(
         navigator.userAgent,
       );
 


### PR DESCRIPTION
Chrome iOS (CriOS) was being routed through the popup flow due to the isSafari regex matching its user agent. However, passkey creation in Chrome iOS popups shows a 'Sign in' dialog instead of 'Create Passkey'.

By excluding CriOS from the Safari regex, Chrome iOS now uses the direct iframe path (which has publickey-credentials-create permission), same as Chrome desktop.