### PR TITLE
feat: capture WebAuthn options via PostHog for iOS debugging

### DIFF
--- a/packages/keychain/src/components/provider/posthog.tsx
+++ b/packages/keychain/src/components/provider/posthog.tsx
@@ -3,7 +3,7 @@ import { useVersion } from "@/hooks/version";
 import { PostHogContext, PostHogWrapper } from "@cartridge/ui/utils";
 import { PropsWithChildren, useContext, useEffect, useState } from "react";
 
-const posthog = new PostHogWrapper(
+export const posthog = new PostHogWrapper(
   import.meta.env.VITE_POSTHOG_KEY ?? "api key",
   {
     host: import.meta.env.VITE_POSTHOG_HOST,


### PR DESCRIPTION
## Summary
- Adds a PostHog `capture` call for WebAuthn credential creation options alongside the existing `console.log` debug statements
- Enables remote debugging of iOS Chrome passkey issues (e.g. Google Password Manager showing "Sign in" instead of "Create Passkey") without needing direct console access
- Exports the PostHog singleton from `posthog.tsx` so it can be used in non-React utility code

## Test plan
- [ ] Verify PostHog "WebAuthn Create Options" events appear in the PostHog dashboard when creating a passkey
- [ ] Confirm existing console.log debug output is unchanged
- [ ] Test on iOS Chrome to validate event properties (userAgent, isIOS, hasPlatformAuthenticator, options)

🤖 Generated with [Claude Code](https://claude.com/claude-code)