### PR TITLE
fix: prioritize iOS check before hasPlatformAuthenticator for WebAuthn

### DIFF
--- a/packages/keychain/src/hooks/account.ts
+++ b/packages/keychain/src/hooks/account.ts
@@ -43,19 +43,10 @@ const createCredentials = async (
     if (isIOS) {
       // iOS check must come first: Chrome iOS reports hasPlatformAuthenticator
       // as false even though the device supports passkeys via iCloud Keychain.
-      // Force all authenticatorSelection properties so Chrome iOS shows
-      // "Create Passkey" instead of "Sign in".
+      // Explicitly set "platform" so Chrome iOS shows "Create Passkey"
+      // instead of "Sign in".
       beginRegistration.publicKey.authenticatorSelection.authenticatorAttachment =
         "platform";
-      beginRegistration.publicKey.authenticatorSelection.residentKey =
-        "required";
-      beginRegistration.publicKey.authenticatorSelection.requireResidentKey =
-        true;
-      beginRegistration.publicKey.authenticatorSelection.userVerification =
-        "required";
-      // Clear excludeCredentials to prevent existing passkeys from
-      // triggering a sign-in flow instead of creation
-      beginRegistration.publicKey.excludeCredentials = [];
     } else if (
       !hasPlatformAuthenticator ||
       navigator.userAgent.indexOf("Win") != -1


### PR DESCRIPTION
## Problem

Chrome iOS reports \`hasPlatformAuthenticator\` as \`false\` even though the device supports passkeys via iCloud Keychain. This caused the code to enter the \`!hasPlatformAuthenticator\` branch first, setting \`authenticatorAttachment: \"cross-platform\"\` — which triggers a **\"Sign in with passkey\"** dialog instead of **\"Create Passkey\"**.

## Root Cause

The condition order was:
1. \`!hasPlatformAuthenticator\` → set \`cross-platform\` ← **Chrome iOS always hit this**
2. \`isIOS\` → set \`platform\` ← **never reached**

Chrome iOS uses iCloud Keychain for passkey storage (Apple does not allow third-party passkey providers on iOS), but incorrectly reports that no platform authenticator is available.

## Fix

Move the iOS check **before** the \`hasPlatformAuthenticator\` check. On iOS devices we now always set \`authenticatorAttachment: \"platform\"\`, regardless of what \`hasPlatformAuthenticator\` reports. This ensures Chrome iOS correctly shows the \"Create Passkey\" flow via iCloud Keychain. All other authenticatorSelection properties (residentKey, userVerification, etc.) are already correctly set by the backend.