### PR TITLE
chore: remove WebAuthn debug logging

### DIFF
--- a/packages/keychain/src/components/ConnectRoute.tsx
+++ b/packages/keychain/src/components/ConnectRoute.tsx
@@ -17,7 +17,6 @@ import {
 import { isIframe } from "@cartridge/ui/utils";
 import { safeRedirect } from "@/utils/url-validator";
 import { requestStorageAccess } from "@/utils/connection/storage-access";
-import { posthog } from "@/components/provider/posthog";
 import {
   Button,
   HeaderInner,
@@ -271,13 +270,6 @@ export function ConnectRoute() {
           handleCompletion();
         } catch (e) {
           console.error("Failed to create verified session:", e);
-          posthog.capture("Verified Session Creation Failed", {
-            error: e instanceof Error ? e.message : String(e),
-            errorName: e instanceof Error ? e.name : undefined,
-            userAgent: navigator.userAgent,
-            isIOS: /iPad|iPhone|iPod/.test(navigator.userAgent),
-            isChromeIOS,
-          });
 
           if (isChromeIOS) {
             // Chrome iOS requires a user gesture for navigator.credentials.get().
@@ -336,12 +328,6 @@ export function ConnectRoute() {
           handleCompletion();
         } catch (e) {
           console.error("Failed to create verified session:", e);
-          posthog.capture("Verified Session Creation Failed (Continue)", {
-            error: e instanceof Error ? e.message : String(e),
-            errorName: e instanceof Error ? e.name : undefined,
-            userAgent: navigator.userAgent,
-            isChromeIOS: true,
-          });
           setSessionError(e instanceof Error ? e : new Error(String(e)));
         } finally {
           setIsSessionCreating(false);

--- a/packages/keychain/src/hooks/account.ts
+++ b/packages/keychain/src/hooks/account.ts
@@ -17,7 +17,7 @@ import { constants, getChecksumAddress } from "starknet";
 import { useConnection } from "./connection";
 import { useStarkAddress } from "./starknetid";
 import { useWallet } from "./wallet";
-import { posthog } from "@/components/provider/posthog";
+
 import { useAccountSearchQuery } from "@/utils/api";
 
 type RawAssertion = PublicKeyCredential & {
@@ -70,34 +70,6 @@ const createCredentials = async (
     { alg: -7, type: "public-key" },
   ];
   beginRegistration.publicKey.rp.id = import.meta.env.VITE_RP_ID;
-
-  // Debug: log the full options to compare Chrome iOS vs Safari behavior
-  console.log(
-    "[WebAuthn] navigator.credentials.create options:",
-    JSON.stringify(beginRegistration, (_, v) =>
-      v instanceof ArrayBuffer
-        ? `ArrayBuffer(${v.byteLength})`
-        : v instanceof Uint8Array
-          ? `Uint8Array(${v.length})`
-          : v,
-    ),
-  );
-  console.log("[WebAuthn] userAgent:", navigator.userAgent);
-  console.log("[WebAuthn] hasPlatformAuthenticator:", hasPlatformAuthenticator);
-
-  // Also capture via PostHog for remote debugging (iOS Chrome)
-  posthog.capture("WebAuthn Create Options", {
-    options: JSON.stringify(beginRegistration, (_, v) =>
-      v instanceof ArrayBuffer
-        ? `ArrayBuffer(${v.byteLength})`
-        : v instanceof Uint8Array
-          ? `Uint8Array(${v.length})`
-          : v,
-    ),
-    userAgent: navigator.userAgent,
-    hasPlatformAuthenticator,
-    isIOS: /iPad|iPhone|iPod/.test(navigator.userAgent),
-  });
 
   const credentials = (await navigator.credentials.create(
     beginRegistration,


### PR DESCRIPTION
Remove temporary PostHog and console.log debug logging that was added during the Chrome iOS passkey investigation.

**Changes:**
- Remove PostHog `Verified Session Creation Failed` captures from `ConnectRoute.tsx`
- Remove `console.log` and PostHog `WebAuthn Create Options` captures from `account.ts`
- Remove unused `posthog` imports from both files