### PR TITLE
ci: auto-merge docs-sync PRs after checks pass

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -170,6 +170,7 @@ jobs:
               - Trigger: Manual documentation sync
 
               Please review the documentation changes to ensure they accurately reflect the controller updates."
+              gh pr merge --auto --squash
             else
               gh pr create \
                 --title "docs: Update documentation for controller PR #${{ github.event.pull_request.number }}" \
@@ -180,6 +181,7 @@ jobs:
               - Files changed: ${{ steps.changed-files.outputs.changed_files }}
 
               Please review the documentation changes to ensure they accurately reflect the controller updates."
+              gh pr merge --auto --squash
             fi
           else
             echo "No documentation changes were made by Claude"


### PR DESCRIPTION
## Summary
- Adds `gh pr merge --auto --squash` after each `gh pr create` call in the docs-sync workflow
- Once Vercel status checks pass on the docs repo, the PR will merge automatically

## Prerequisites
- Auto-merge must be enabled in the docs repo settings (Settings > General > "Allow auto-merge")

🤖 Generated with [Claude Code](https://claude.com/claude-code)