### PR TITLE
fix(keychain): add Stripe.js to CSP script-src

### DIFF
--- a/packages/keychain/index.html
+++ b/packages/keychain/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data: https:; connect-src 'self' https: wss: http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*; frame-src 'self' https:; worker-src 'self' blob:; manifest-src 'self'; object-src 'none'; base-uri 'none'; form-action 'self' https:"
+      content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://js.stripe.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data: https:; connect-src 'self' https: wss: http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*; frame-src 'self' https:; worker-src 'self' blob:; manifest-src 'self'; object-src 'none'; base-uri 'none'; form-action 'self' https:"
     />
 
     <link rel="icon" type="image/png" href="/favicon-48x48.png" sizes="48x48" />

--- a/packages/keychain/vercel.json
+++ b/packages/keychain/vercel.json
@@ -5,7 +5,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data: https:; connect-src 'self' https: wss: http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*; frame-src 'self' https:; worker-src 'self' blob:; manifest-src 'self'; object-src 'none'; base-uri 'none'; form-action 'self' https:; frame-ancestors 'self' https: http://localhost:* http://127.0.0.1:* capacitor:;"
+          "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://js.stripe.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data: https:; connect-src 'self' https: wss: http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*; frame-src 'self' https:; worker-src 'self' blob:; manifest-src 'self'; object-src 'none'; base-uri 'none'; form-action 'self' https:; frame-ancestors 'self' https: http://localhost:* http://127.0.0.1:* capacitor:;"
         },
         {
           "key": "X-Content-Type-Options",


### PR DESCRIPTION
## Summary

The CSP hardening in #2384 introduced a `script-src` directive that only allowed `'self' 'wasm-unsafe-eval'`. This blocked `@stripe/stripe-js` from dynamically injecting its `<script src="https://js.stripe.com/v3/">` tag, causing the Slot fund page (and any Stripe checkout flow) to fail with:

```
Uncaught (in promise) Error: Failed to load Stripe.js
```

## Changes

Add `https://js.stripe.com` to the `script-src` CSP directive in both:

- **`packages/keychain/index.html`** — the `<meta>` CSP tag (dev + fallback)
- **`packages/keychain/vercel.json`** — the HTTP response header (production)

No other CSP directives need changes — `connect-src` and `frame-src` already include `https:` which covers `api.stripe.com` and Stripe's payment element iframes.

## Testing

- Verified Stripe.js loads successfully on the Slot fund page after the change.