### PR TITLE
fix: call close() in disconnect to reset iframe state

### DIFF
--- a/packages/controller/src/__tests__/disconnect.test.ts
+++ b/packages/controller/src/__tests__/disconnect.test.ts
@@ -98,6 +98,24 @@ describe("ControllerProvider.disconnect", () => {
     expect(keychainDisconnect).toHaveBeenCalledTimes(1);
   });
 
+  test("closes iframe to reset keychain state for subsequent connect", async () => {
+    const controller = new ControllerProvider({});
+    const keychainDisconnect = jest.fn().mockResolvedValue(undefined);
+    (controller as any).keychain = {
+      disconnect: keychainDisconnect,
+    };
+
+    const mockClose = jest.fn();
+    (controller as any).iframes = {
+      keychain: { close: mockClose },
+    };
+
+    await controller.disconnect();
+
+    expect(keychainDisconnect).toHaveBeenCalledTimes(1);
+    expect(mockClose).toHaveBeenCalledTimes(1);
+  });
+
   test("does not throw when localStorage is unavailable", async () => {
     delete (global as any).localStorage;
     const controller = new ControllerProvider({});

--- a/packages/controller/src/controller.ts
+++ b/packages/controller/src/controller.ts
@@ -412,7 +412,8 @@ export default class ControllerProvider extends BaseProvider {
       return;
     }
 
-    return this.keychain.disconnect();
+    await this.keychain.disconnect();
+    return this.close();
   }
 
   async openProfile(tab: ProfileContextTypeVariant = "inventory") {


### PR DESCRIPTION
## Summary

When `disconnect()` is called, the iframe is left in a stale post-disconnect state. On the next `connect()`, the existing iframe is reused (by design since v0.13.3) but the keychain doesn't render the login UI, showing a blank screen instead.

This fix calls `close()` after keychain disconnect, which triggers `keychain.reset()` via the iframe's onClose callback. This ensures the keychain is in a clean state for the next connect.

## Root Cause

In v0.13.3, iframe reuse was introduced to prevent re-initialization issues when `ControllerConnector` is instantiated multiple times. However, `disconnect()` was never updated to account for the iframe now persisting across connect/disconnect cycles. The method still only cleared auth state but left the iframe's internal state stale.

## Changes

- Call `this.close()` in `ControllerProvider.disconnect()` after keychain disconnect
- Add test verifying iframe close is called during disconnect