### PR TITLE
fix: resolve chainId race condition in preset flow

### DIFF
--- a/packages/controller/src/controller.ts
+++ b/packages/controller/src/controller.ts
@@ -789,6 +789,7 @@ export default class ControllerProvider extends BaseProvider {
     const iframe = new KeychainIFrame({
       ...this.options,
       rpcUrl: this.rpcUrl(),
+      chainId: this.selectedChain,
       onClose: () => {
         this.keychain?.reset?.();
       },

--- a/packages/controller/src/iframe/keychain.ts
+++ b/packages/controller/src/iframe/keychain.ts
@@ -6,6 +6,7 @@ import { IFrame, IFrameOptions } from "./base";
 type KeychainIframeOptions = IFrameOptions<Keychain> &
   KeychainOptions & {
     version?: string;
+    chainId?: string;
     ref?: string;
     refGroup?: string;
     needsSessionCreation?: boolean;
@@ -31,6 +32,7 @@ export class KeychainIFrame extends IFrame<Keychain> {
     preset,
     shouldOverridePresetPolicies,
     rpcUrl,
+    chainId,
     ref,
     refGroup,
     needsSessionCreation,
@@ -75,6 +77,10 @@ export class KeychainIFrame extends IFrame<Keychain> {
 
     if (rpcUrl) {
       _url.searchParams.set("rpc_url", encodeURIComponent(rpcUrl));
+    }
+
+    if (chainId) {
+      _url.searchParams.set("chain_id", chainId);
     }
 
     if (ref) {

--- a/packages/controller/src/node/provider.ts
+++ b/packages/controller/src/node/provider.ts
@@ -146,7 +146,7 @@ export default class SessionProvider extends BaseProvider {
       redirectUri,
     )}&redirect_query_name=startapp&policies=${encodeURIComponent(
       JSON.stringify(this._policies),
-    )}&rpc_url=${encodeURIComponent(this._rpcUrl)}`;
+    )}&rpc_url=${encodeURIComponent(this._rpcUrl)}&chain_id=${encodeURIComponent(this._chainId)}`;
 
     this._backend.openLink(url);
 

--- a/packages/controller/src/session/provider.ts
+++ b/packages/controller/src/session/provider.ts
@@ -295,7 +295,8 @@ export default class SessionProvider extends BaseProvider {
           `/session?public_key=${this._publicKey}` +
           `&redirect_uri=${this._redirectUrl}` +
           `&redirect_query_name=startapp` +
-          `&rpc_url=${this._rpcUrl}`;
+          `&rpc_url=${this._rpcUrl}` +
+          `&chain_id=${this._chainId}`;
 
         if (this._preset) {
           url += `&preset=${encodeURIComponent(this._preset)}`;

--- a/packages/controller/src/telegram/provider.ts
+++ b/packages/controller/src/telegram/provider.ts
@@ -82,7 +82,7 @@ export default class TelegramProvider extends BaseProvider {
       this._tmaUrl
     }&redirect_query_name=startapp&policies=${JSON.stringify(
       this._policies,
-    )}&rpc_url=${this._rpcUrl}`;
+    )}&rpc_url=${this._rpcUrl}&chain_id=${this._chainId}`;
 
     localStorage.setItem("lastUsedConnector", this.id);
     openLink(url);


### PR DESCRIPTION
## Problem

Users upgrading from v0.13.4 to v0.13.9 with preset-based configurations experience an indefinite loading screen — authentication and session registration are non-functional.

**Root cause:** v0.13.9 introduced `isPoliciesResolved` as a UI gate in `app.tsx`. For preset users, `resolvePolicies` returns `isPoliciesResolved: false` when either `isConfigLoading` is true or `chainId` is undefined. The `chainId` in the keychain is derived asynchronously (via RPC call), creating a race condition where the UI blocks on a value that hasn't resolved yet.

A secondary issue compounds this: the disconnect `useEffect` compares RPC URL strings (`controller.rpcUrl() === urlRpcUrl`). URL normalization differences (encoding, trailing slashes, different providers for the same chain) cause false-positive mismatches, triggering unnecessary disconnect loops that prevent recovery.

## Fix

**1. Pass `chain_id` as a URL parameter from all providers to the keychain.**
The controller already knows the `chainId` synchronously at construction time. This passes it through the URL to the keychain iframe (and session/telegram/node redirect URLs), eliminating the need for an async RPC derivation on initial load.

**2. Initialize `chainId` synchronously from the URL param in `useConnectionValue`.**
The `useState` initializer reads `chain_id` from `window.location.search`, so `chainId` is immediately available when `resolvePolicies` runs — no more race condition.

**3. Replace RPC URL string comparison with chain ID comparison in disconnect logic.**
Comparing `controller.chainId() === chainId` instead of `controller.rpcUrl() === urlRpcUrl` avoids false-positive disconnects from URL normalization differences. Two different RPC endpoints for the same chain no longer trigger a disconnect.

## Files changed

- `packages/controller/src/iframe/keychain.ts` — Accept and forward `chainId` option as URL param
- `packages/controller/src/controller.ts` — Pass `selectedChain` to KeychainIFrame
- `packages/controller/src/session/provider.ts` — Add `chain_id` to session redirect URL
- `packages/controller/src/telegram/provider.ts` — Add `chain_id` to telegram redirect URL
- `packages/controller/src/node/provider.ts` — Add `chain_id` to node redirect URL
- `packages/keychain/src/hooks/connection.ts` — Sync chainId init + chain ID disconnect comparison
- `packages/keychain/src/hooks/connection.test.ts` — Updated disconnect tests for chain ID logic