### PR TITLE
fix: prefer close over back in iframe header

### DIFF
--- a/packages/keychain/src/components/app.tsx
+++ b/packages/keychain/src/components/app.tsx
@@ -308,19 +308,19 @@ export function App() {
           element={
             <Purchase
               type={PurchaseType.Credits}
-            // onBack={() => {
-            //   const searchParams = new URLSearchParams(
-            //     window.location.search,
-            //   );
-            //   const returnTo = searchParams.get("returnTo");
-            //   if (returnTo) {
-            //     // returnTo is already decoded by URLSearchParams.get()
-            //     // Use replace navigation for execute URLs to ensure proper navigation stack handling
-            //     navigate(returnTo, { replace: true });
-            //   } else {
-            //     navigate("/funding");
-            //   }
-            // }}
+              // onBack={() => {
+              //   const searchParams = new URLSearchParams(
+              //     window.location.search,
+              //   );
+              //   const returnTo = searchParams.get("returnTo");
+              //   if (returnTo) {
+              //     // returnTo is already decoded by URLSearchParams.get()
+              //     // Use replace navigation for execute URLs to ensure proper navigation stack handling
+              //     navigate(returnTo, { replace: true });
+              //   } else {
+              //     navigate("/funding");
+              //   }
+              // }}
             />
           }
         />


### PR DESCRIPTION
## Summary
- make iframe/popup header default to close instead of back
- keep explicit force-back behavior unchanged for screens that opt in
- scope this PR to header navigation behavior only

## Test plan
- [x] Run repo hooks/tests via commit hook
- [ ] Open popup flows (connect/starterpack/update-session) and verify close icon is shown instead of back