### PR TITLE
fix: scope close-only header behavior to update session flow

### DIFF
--- a/packages/keychain/src/components/NavigationHeader.tsx
+++ b/packages/keychain/src/components/NavigationHeader.tsx
@@ -24,11 +24,9 @@ export function NavigationHeader({
   // Check if we're in an iframe
   const isInIframe = window.self !== window.top;
 
-  // Determine which button to show based on navigation state.
-  // In iframe/popup context, prefer close over back by default.
+  // Determine which button to show based on navigation state
   const shouldShowBack =
-    forceShowBack ||
-    (!isInIframe && canGoBack && !forceShowClose && !showClose);
+    forceShowBack || (canGoBack && !forceShowClose && !showClose);
   const shouldShowClose =
     isInIframe && (forceShowClose || showClose || !shouldShowBack);
 

--- a/packages/keychain/src/components/layout.tsx
+++ b/packages/keychain/src/components/layout.tsx
@@ -8,6 +8,9 @@ import { Outlet, useLocation } from "react-router-dom";
 export function Layout({ children }: { children?: React.ReactNode }) {
   const { closeModal, onModalClose } = useConnection();
   const location = useLocation();
+  const isUpdateSessionRoute = useMemo(() => {
+    return location.pathname.startsWith("/update-session");
+  }, [location.pathname]);
   // Check if current page should have bottom navigation
   const hasBottomNav = useMemo(() => {
     return [
@@ -24,7 +27,7 @@ export function Layout({ children }: { children?: React.ReactNode }) {
       <LayoutContainer>
         <NavigationHeader
           variant="hidden"
-          forceShowClose={hasBottomNav}
+          forceShowClose={hasBottomNav || isUpdateSessionRoute}
           icon={<GearIcon />}
           onClose={hasBottomNav ? closeModal : onModalClose}
         />


### PR DESCRIPTION
## Summary
- restore default iframe header behavior so back/close is not globally overridden
- opt into close-only header behavior for the `/update-session` route only
- keep other flows (including `/connect`) on existing navigation behavior

## Test plan
- [ ] Open `/update-session` in popup/iframe and verify close is shown (no back)
- [ ] Open `/connect` and verify previous back/close behavior remains unchanged
- [ ] Sanity-check bottom-nav pages still show close as before