### PR TITLE
feat: open Coinbase payment link in popup instead of iframe

### DIFF
--- a/packages/keychain/src/components/purchasenew/checkout/coinbase/index.tsx
+++ b/packages/keychain/src/components/purchasenew/checkout/coinbase/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import {
   HeaderInner,
   LayoutContent,
@@ -8,19 +8,62 @@ import {
   CoinbaseWalletColorIcon,
   ExternalIcon,
   cn,
+  TimesIcon,
 } from "@cartridge/ui";
 import { useOnchainPurchaseContext } from "@/context";
+import { useNavigation } from "@/context";
+import { CoinbaseOnrampStatus } from "@cartridge/ui/utils/api/cartridge";
 
 export function CoinbaseCheckout() {
-  const { paymentLink, onCreateCoinbaseOrder } = useOnchainPurchaseContext();
-  const [isLoaded, setIsLoaded] = useState(false);
+  const {
+    paymentLink,
+    orderStatus,
+    onCreateCoinbaseOrder,
+    openPaymentPopup,
+    stopPolling,
+  } = useOnchainPurchaseContext();
+  const { navigate } = useNavigation();
   const [showPolicies, setShowPolicies] = useState(true);
+  const [popupOpened, setPopupOpened] = useState(false);
 
+  // Create the order if we don't have a payment link yet
   useEffect(() => {
     if (!paymentLink) {
       onCreateCoinbaseOrder();
     }
   }, [paymentLink, onCreateCoinbaseOrder]);
+
+  // Navigate to pending when order is completed
+  useEffect(() => {
+    if (orderStatus === CoinbaseOnrampStatus.Completed) {
+      navigate("/purchase/pending", { reset: true });
+    }
+  }, [orderStatus, navigate]);
+
+  // Clean up polling on unmount
+  useEffect(() => {
+    return () => {
+      stopPolling();
+    };
+  }, [stopPolling]);
+
+  const handleContinue = useCallback(() => {
+    setShowPolicies(false);
+    // Open popup immediately after accepting policies
+    if (paymentLink && !popupOpened) {
+      openPaymentPopup();
+      setPopupOpened(true);
+    }
+  }, [paymentLink, popupOpened, openPaymentPopup]);
+
+  const handleRetryPopup = useCallback(() => {
+    if (paymentLink) {
+      openPaymentPopup();
+      setPopupOpened(true);
+    }
+  }, [paymentLink, openPaymentPopup]);
+
+  const isFailed = orderStatus === CoinbaseOnrampStatus.Failed;
 
   return (
     <>
@@ -37,7 +80,7 @@ export function CoinbaseCheckout() {
         />
         <LayoutContent className="p-4 flex flex-col gap-4">
           <div className="bg-[#181C19] border border-background-200 p-4 rounded-[4px] text-xs text-foreground-300">
-            By clicking ‘Continue’ you are agreeing to the following Coinbase
+            By clicking 'Continue' you are agreeing to the following Coinbase
             policies.
           </div>
 
@@ -57,40 +100,81 @@ export function CoinbaseCheckout() {
           </div>
         </LayoutContent>
         <LayoutFooter>
-          <Button className="w-full" onClick={() => setShowPolicies(false)}>
-            CONTINUE
+          <Button
+            className="w-full"
+            onClick={handleContinue}
+            disabled={!paymentLink}
+          >
+            {paymentLink ? "CONTINUE" : "LOADING..."}
           </Button>
         </LayoutFooter>
       </div>
 
+      {/* Payment Status Screen */}
       <div
         className={cn(
           "flex flex-col h-full",
           showPolicies && "invisible absolute inset-0 -z-10",
         )}
       >
-        <LayoutContent className="p-0 overflow-hidden relative bg-[#121212]">
-          {!isLoaded && (
-            <div className="absolute inset-0 flex items-center justify-center bg-[#0F1410] z-10">
-              <SpinnerIcon className="animate-spin" size="lg" />
+        <HeaderInner
+          title={
+            <div className="flex flex-col">
+              <span className="text-lg font-bold">Apple Pay</span>
+              <span className="text-xs text-foreground-300">via Coinbase</span>
             </div>
-          )}
-          {paymentLink ? (
-            <div className="h-full w-full px-10 flex justify-center">
-              <iframe
-                src={paymentLink}
-                className="h-full w-full max-w-[440px] border-none"
-                allow="payment"
-                title="Coinbase Onramp"
-                onLoad={() => setIsLoaded(true)}
-              />
+          }
+          icon={<CoinbaseWalletColorIcon size="lg" />}
+        />
+        <LayoutContent className="p-4 flex flex-col items-center justify-center gap-6">
+          {isFailed ? (
+            <div className="flex flex-col items-center gap-4 text-center">
+              <div className="w-12 h-12 rounded-full bg-destructive/10 flex items-center justify-center">
+                <TimesIcon size="lg" className="text-destructive" />
+              </div>
+              <div>
+                <p className="text-sm font-semibold text-foreground-100">
+                  Payment Failed
+                </p>
+                <p className="text-xs text-foreground-300 mt-1">
+                  The payment could not be completed. Please try again.
+                </p>
+              </div>
             </div>
           ) : (
-            <div className="flex items-center justify-center h-full">
+            <div className="flex flex-col items-center gap-4 text-center">
               <SpinnerIcon className="animate-spin" size="lg" />
+              <div>
+                <p className="text-sm font-semibold text-foreground-100">
+                  Waiting for Payment
+                </p>
+                <p className="text-xs text-foreground-300 mt-1">
+                  Complete the payment in the popup window that opened.
+                </p>
+                <p className="text-xs text-foreground-400 mt-2">
+                  If the popup didn't open or was closed, click below to reopen
+                  it.
+                </p>
+              </div>
             </div>
           )}
         </LayoutContent>
+        <LayoutFooter>
+          {isFailed ? (
+            <Button className="w-full" onClick={handleRetryPopup}>
+              TRY AGAIN
+            </Button>
+          ) : (
+            <Button
+              className="w-full"
+              variant="secondary"
+              onClick={handleRetryPopup}
+              disabled={!paymentLink}
+            >
+              REOPEN PAYMENT WINDOW
+            </Button>
+          )}
+        </LayoutFooter>
       </div>
     </>
   );

--- a/packages/keychain/src/components/purchasenew/review/onchain-cost.stories.tsx
+++ b/packages/keychain/src/components/purchasenew/review/onchain-cost.stories.tsx
@@ -61,6 +61,11 @@ const MockOnchainPurchaseProvider = ({ children }: { children: ReactNode }) => {
     isFetchingCoinbaseQuote: false,
     onApplePaySelect: () => {},
     onCreateCoinbaseOrder: async () => {},
+    openPaymentPopup: () => {},
+    stopPolling: () => {},
+    orderId: undefined,
+    orderStatus: undefined,
+    isPollingOrder: false,
     getTransactions: async () => [],
   };
 

--- a/packages/keychain/src/components/purchasenew/wallet/wallet.stories.tsx
+++ b/packages/keychain/src/components/purchasenew/wallet/wallet.stories.tsx
@@ -63,6 +63,11 @@ const mockOnchainPurchaseValue: OnchainPurchaseContextType = {
   isFetchingCoinbaseQuote: false,
   onApplePaySelect: () => {},
   onCreateCoinbaseOrder: async () => {},
+  openPaymentPopup: () => {},
+  stopPolling: () => {},
+  orderId: undefined,
+  orderStatus: undefined,
+  isPollingOrder: false,
   getTransactions: async () => [],
 };
 

--- a/packages/keychain/src/context/starterpack/onchain-purchase.tsx
+++ b/packages/keychain/src/context/starterpack/onchain-purchase.tsx
@@ -21,6 +21,7 @@ import {
 import { Item } from "./types";
 import { useStarterpackContext } from "./starterpack";
 import { ExternalWalletError } from "@/utils/errors";
+import { CoinbaseOnrampStatus } from "@cartridge/ui/utils/api/cartridge";
 import {
   useQuantity,
   useExternalWallet,
@@ -83,6 +84,9 @@ export interface OnchainPurchaseContextType {
   isCreatingOrder: boolean;
   coinbaseQuote: CoinbaseQuoteResult | undefined;
   isFetchingCoinbaseQuote: boolean;
+  orderId: string | undefined;
+  orderStatus: CoinbaseOnrampStatus | undefined;
+  isPollingOrder: boolean;
 
   // Actions
   onOnchainPurchase: () => Promise<void>;
@@ -95,6 +99,8 @@ export interface OnchainPurchaseContextType {
   waitForDeposit: (swapId: string) => Promise<boolean>;
   onApplePaySelect: () => void;
   onCreateCoinbaseOrder: () => Promise<void>;
+  openPaymentPopup: () => void;
+  stopPolling: () => void;
   getTransactions: (username: string) => Promise<CoinbaseTransactionResult[]>;
 }
 
@@ -200,6 +206,7 @@ export const OnchainPurchaseProvider = ({
 
   const [isApplePaySelected, setIsApplePaySelected] = useState(false);
   const {
+    orderId,
     paymentLink,
     isCreatingOrder,
     createOrder: createCoinbaseOrder,
@@ -207,6 +214,10 @@ export const OnchainPurchaseProvider = ({
     getQuote: getCoinbaseQuote,
     coinbaseQuote,
     isFetchingQuote: isFetchingCoinbaseQuote,
+    isPollingOrder,
+    orderStatus,
+    openPaymentPopup,
+    stopPolling,
   } = useCoinbase({
     onError: setDisplayError,
   });
@@ -526,12 +537,17 @@ export const OnchainPurchaseProvider = ({
     isCreatingOrder,
     coinbaseQuote,
     isFetchingCoinbaseQuote,
+    orderId,
+    orderStatus,
+    isPollingOrder,
     onOnchainPurchase,
     onExternalConnect,
     onSendDeposit,
     waitForDeposit,
     onApplePaySelect,
     onCreateCoinbaseOrder,
+    openPaymentPopup,
+    stopPolling,
     getTransactions,
   };
 

--- a/packages/keychain/src/hooks/starterpack/index.ts
+++ b/packages/keychain/src/hooks/starterpack/index.ts
@@ -41,6 +41,7 @@ export type {
   CoinbaseOrderResult,
   CoinbaseTransactionResult,
   CoinbaseQuoteResult,
+  CoinbaseOrderStatusResult,
 } from "./coinbase";
 
 export { useStarterpackPlayHandler } from "./play";


### PR DESCRIPTION
## Summary

Replace the embedded iframe for Coinbase payment link with a popup window + GraphQL order status polling. The iframe approach cannot work when the keychain is embedded in a parent app with a different top-level domain.

## Changes

- **`useCoinbase` hook**: Added `openPaymentPopup()` to open payment in a centered popup, `startPolling()`/`stopPolling()` to poll `coinbaseOnrampOrder` every 5s with a 10-minute timeout, and `getCoinbaseOrderStatus()` helper using the existing `CoinbaseOnRampOrderDocument` query.
- **`CoinbaseCheckout` component**: Replaced iframe with a waiting screen that opens a popup on policy acceptance, polls for completion, and auto-navigates to the pending page.
- **`BridgePending` component**: Replaced transaction-list polling with reactive `orderStatus` from context for the Apple Pay flow.
- **`OnchainPurchaseContext`**: Exposed `orderId`, `orderStatus`, `isPollingOrder`, `openPaymentPopup`, and `stopPolling`.