### PR TITLE
fix: harden Coinbase popup handling and refresh checkout order

### DIFF
--- a/packages/keychain/src/components/purchasenew/review/onchain-cost.stories.tsx
+++ b/packages/keychain/src/components/purchasenew/review/onchain-cost.stories.tsx
@@ -60,7 +60,7 @@ const MockOnchainPurchaseProvider = ({ children }: { children: ReactNode }) => {
     coinbaseQuote: undefined,
     isFetchingCoinbaseQuote: false,
     onApplePaySelect: () => {},
-    onCreateCoinbaseOrder: async () => {},
+    onCreateCoinbaseOrder: async () => undefined,
     openPaymentPopup: () => {},
     stopPolling: () => {},
     orderId: undefined,

--- a/packages/keychain/src/components/purchasenew/wallet/wallet.stories.tsx
+++ b/packages/keychain/src/components/purchasenew/wallet/wallet.stories.tsx
@@ -62,7 +62,7 @@ const mockOnchainPurchaseValue: OnchainPurchaseContextType = {
   coinbaseQuote: undefined,
   isFetchingCoinbaseQuote: false,
   onApplePaySelect: () => {},
-  onCreateCoinbaseOrder: async () => {},
+  onCreateCoinbaseOrder: async () => undefined,
   openPaymentPopup: () => {},
   stopPolling: () => {},
   orderId: undefined,


### PR DESCRIPTION
## Summary
- parse Coinbase popup `postMessage` payloads more robustly (string/object/nested payload variants) and handle additional Coinbase event names without incorrectly ignoring valid events
- keep the Coinbase popup loading state tied to Coinbase load events instead of iframe load
- force creation of a fresh Coinbase order/payment link when the user retries checkout after canceling, to avoid reusing stale links

## Test plan
- [x] Run `pnpm format`
- [ ] In checkout, cancel Coinbase popup, go back, click Buy/Continue again, verify a new order/payment link is used
- [ ] Confirm popup handles `onramp_api.polling_success`, `onramp_api.polling_error`, and `onramp_api.cancel` events without being ignored
- [ ] Confirm popup shows loading until Coinbase `load_success` event arrives