### PR TITLE
feat: accept expires_at param on session page

### DIFF
--- a/packages/keychain/src/components/connect/CreateSession.tsx
+++ b/packages/keychain/src/components/connect/CreateSession.tsx
@@ -32,11 +32,13 @@ export function CreateSession({
   onConnect,
   onSkip,
   isUpdate,
+  expiresAt: expiresAtOverride,
 }: {
   policies: ParsedSessionPolicies;
   onConnect: () => void;
   onSkip?: () => void;
   isUpdate?: boolean;
+  expiresAt?: bigint;
 }) {
   return (
     <CreateSessionProvider
@@ -47,6 +49,7 @@ export function CreateSession({
         isUpdate={isUpdate}
         onConnect={onConnect}
         onSkip={onSkip}
+        expiresAtOverride={expiresAtOverride}
       />
     </CreateSessionProvider>
   );
@@ -56,10 +59,12 @@ const CreateSessionLayout = ({
   isUpdate,
   onConnect,
   onSkip,
+  expiresAtOverride,
 }: {
   isUpdate?: boolean;
   onConnect: () => void;
   onSkip?: () => void;
+  expiresAtOverride?: bigint;
 }) => {
   const [isConsent, setIsConsent] = useState(false);
   const [isConnecting, setIsConnecting] = useState(false);
@@ -102,8 +107,8 @@ const CreateSessionLayout = ({
   }, [step, setOnBackCallback]);
 
   const expiresAt = useMemo(() => {
-    return duration + now();
-  }, [duration]);
+    return expiresAtOverride ?? duration + now();
+  }, [expiresAtOverride, duration]);
 
   const createSession = useCallback(
     async ({

--- a/packages/keychain/src/components/connect/RegisterSession.tsx
+++ b/packages/keychain/src/components/connect/RegisterSession.tsx
@@ -25,17 +25,23 @@ export function RegisterSession({
   policies,
   onConnect,
   publicKey,
+  expiresAt: expiresAtOverride,
 }: {
   policies: ParsedSessionPolicies;
   onConnect: (transaction_hash: string, expiresAt: bigint) => void;
   publicKey?: string;
+  expiresAt?: bigint;
 }) {
   return (
     <CreateSessionProvider
       initialPolicies={policies}
       requiredPolicies={requiredPolicies}
     >
-      <RegisterSessionLayout onConnect={onConnect} publicKey={publicKey} />
+      <RegisterSessionLayout
+        onConnect={onConnect}
+        publicKey={publicKey}
+        expiresAtOverride={expiresAtOverride}
+      />
     </CreateSessionProvider>
   );
 }
@@ -43,9 +49,11 @@ export function RegisterSession({
 const RegisterSessionLayout = ({
   onConnect,
   publicKey,
+  expiresAtOverride,
 }: {
   onConnect: (transaction_hash: string, expiresAt: bigint) => void;
   publicKey?: string;
+  expiresAtOverride?: bigint;
 }) => {
   const { policies } = useCreateSession();
   const { controller, theme, origin } = useConnection();
@@ -56,8 +64,8 @@ const RegisterSessionLayout = ({
   const { duration, isEditable, onToggleEditable } = useCreateSession();
 
   const expiresAt = useMemo(() => {
-    return duration + now();
-  }, [duration]);
+    return expiresAtOverride ?? duration + now();
+  }, [expiresAtOverride, duration]);
 
   useEffect(() => {
     if (!publicKey || !controller) {

--- a/packages/keychain/src/components/session.tsx
+++ b/packages/keychain/src/components/session.tsx
@@ -32,6 +32,7 @@ type SessionQueryParams = {
   redirect_uri: string | null;
   redirect_query_name: string | null;
   account: string | null;
+  expires_at: string | null;
 };
 
 /**
@@ -46,9 +47,19 @@ export function Session() {
       redirect_uri: searchParams.get("redirect_uri"),
       redirect_query_name: searchParams.get("redirect_query_name"),
       account: searchParams.get("account"),
+      expires_at: searchParams.get("expires_at"),
     }),
     [searchParams],
   );
+
+  const expiresAt = useMemo(() => {
+    if (!queries.expires_at) return undefined;
+    try {
+      return BigInt(queries.expires_at);
+    } catch {
+      return undefined;
+    }
+  }, [queries.expires_at]);
 
   const { controller, setController, policies } = useConnection();
   const [isLoading, setIsLoading] = useState<boolean>(true);
@@ -234,9 +245,14 @@ export function Session() {
           policies={policies}
           onConnect={onConnect}
           publicKey={queries.public_key}
+          expiresAt={expiresAt}
         />
       ) : (
-        <CreateSession policies={policies} onConnect={onConnect} />
+        <CreateSession
+          policies={policies}
+          onConnect={onConnect}
+          expiresAt={expiresAt}
+        />
       )}
     </>
   );


### PR DESCRIPTION
Adds an optional `expires_at` query parameter to the session page. When provided (as a Unix timestamp in seconds), it is used directly as the session expiration instead of computing it from the duration picker.

**Changes:**
- Parse `expires_at` from URL search params in the Session component
- Pass it through to `CreateSession` and `RegisterSession` as an optional `expiresAt` prop
- Use the override when present (`expiresAtOverride ?? duration + now()`), falling back to existing behavior otherwise