### PR TITLE
fix: coinbase popup polling fallback, retry reset, and animated alerts

### DIFF
--- a/packages/keychain/src/components/coinbase-popup.tsx
+++ b/packages/keychain/src/components/coinbase-popup.tsx
@@ -188,14 +188,20 @@ export function CoinbasePopup() {
 
         case "onramp_api.pending_payment_auth":
           setCommitted(true);
+          setError(undefined);
+          setFailed(false);
           break;
 
         case "onramp_api.payment_authorized":
           setCommitted(true);
+          setError(undefined);
+          setFailed(false);
           break;
 
         case "onramp_api.apple_pay_button_pressed":
           setCommitted(true);
+          setError(undefined);
+          setFailed(false);
           break;
 
         case "onramp_api.commit_error":
@@ -270,41 +276,37 @@ export function CoinbasePopup() {
     );
   }
 
+  const showStatusBar =
+    completed || failed || (committed && !completed && !failed);
+
   return (
-    <div className="flex flex-col h-screen bg-[#0F1410]">
-      {/* Status bar */}
-      {(completed || failed) && (
-        <div
-          className={`flex items-center justify-center gap-2 px-4 py-3 text-sm font-medium ${
-            completed
-              ? "bg-[#1a2e1a] text-[#4ade80]"
-              : "bg-[#2e1a1a] text-[#f87171]"
-          }`}
-        >
-          {completed ? (
-            <>
-              <span>✓</span>
-              <span>Payment successful! This window will close shortly.</span>
-            </>
-          ) : (
-            <>
-              <TimesIcon size="sm" />
-              <span>{error}</span>
-            </>
-          )}
-        </div>
-      )}
+    <div className="relative h-screen bg-[#0F1410]">
+      {/* Status bar — overlays top of iframe with slide-down animation */}
+      <div
+        className={`absolute top-0 left-0 right-0 z-20 transition-transform duration-300 ease-out ${
+          showStatusBar ? "translate-y-0" : "-translate-y-full"
+        }`}
+      >
+        {completed ? (
+          <div className="flex items-center justify-center gap-2 px-4 py-3 text-sm font-medium bg-[#1a2e1a] text-[#4ade80]">
+            <span>✓</span>
+            <span>Payment successful! This window will close shortly.</span>
+          </div>
+        ) : failed ? (
+          <div className="flex items-center justify-center gap-2 px-4 py-3 text-sm font-medium bg-[#2e1a1a] text-[#f87171]">
+            <TimesIcon size="sm" />
+            <span>{error}</span>
+          </div>
+        ) : committed ? (
+          <div className="flex items-center justify-center gap-2 px-4 py-3 text-sm font-medium bg-[#1a2a2e] text-[#60a5fa]">
+            <SpinnerIcon className="animate-spin" size="sm" />
+            <span>Payment processing...</span>
+          </div>
+        ) : null}
+      </div>
 
-      {/* Committed indicator (payment in progress) */}
-      {committed && !completed && !failed && (
-        <div className="flex items-center justify-center gap-2 px-4 py-3 text-sm font-medium bg-[#1a2a2e] text-[#60a5fa]">
-          <SpinnerIcon className="animate-spin" size="sm" />
-          <span>Payment processing...</span>
-        </div>
-      )}
-
-      {/* Iframe */}
-      <div className="flex-1 relative">
+      {/* Iframe — fills the full screen, status bar overlays on top */}
+      <div className="h-full relative">
         {!iframeReady && (
           <div className="absolute inset-0 flex items-center justify-center bg-[#0F1410] z-10">
             <SpinnerIcon className="animate-spin" size="lg" />

--- a/packages/keychain/src/components/purchasenew/checkout/coinbase/index.tsx
+++ b/packages/keychain/src/components/purchasenew/checkout/coinbase/index.tsx
@@ -71,12 +71,8 @@ export function CoinbaseCheckout() {
       {/* Policies Screen */}
       <div className={cn("flex flex-col h-full", !showPolicies && "hidden")}>
         <HeaderInner
-          title={
-            <div className="flex flex-col">
-              <span className="text-lg font-bold">Coinbase</span>
-              <span className="text-xs text-foreground-300">Policies</span>
-            </div>
-          }
+          title="Coinbase"
+          description="Policies"
           icon={<CoinbaseWalletColorIcon size="lg" />}
         />
         <LayoutContent className="p-4 flex flex-col gap-4">
@@ -119,12 +115,8 @@ export function CoinbaseCheckout() {
         )}
       >
         <HeaderInner
-          title={
-            <div className="flex flex-col">
-              <span className="text-lg font-bold">Apple Pay</span>
-              <span className="text-xs text-foreground-300">via Coinbase</span>
-            </div>
-          }
+          title="Apple Pay"
+          description="via Coinbase"
           icon={<CoinbaseWalletColorIcon size="lg" />}
         />
         <LayoutContent className="p-4 flex flex-col items-center justify-center gap-6 pb-24">


### PR DESCRIPTION
## Summary

Three fixes for the Coinbase payment popup flow, plus a UX polish.

### 1. Fallback polling prevents stuck 'Complete in Popup'

**Problem:** If the BroadcastChannel signal from the popup was lost (e.g. browser restrictions, timing), the keychain would stay stuck on 'Complete in Popup' forever.

**Fix:** Start a slow **5s fallback poll** as soon as the popup opens. This detects payment completion on the backend even without the popup signal. When `polling_success` arrives from the popup, the poll upgrades to **1s fast poll** with a 15s timeout (same as before).

### 2. Terminal ref set on polling_success (race condition fix)

**Problem:** After successful payment, the popup closes after 1.5s. The popup-close watcher would detect this and set `popupClosed=true` before the backend confirmation poll completed, causing the UI to show 'Payment Window Closed' instead of progressing.

**Fix:** Set `terminalReachedRef.current = true` immediately on `polling_success`, not just when the backend confirms `Completed`.

### 3. Retry clears cancelled state in popup

**Problem:** After cancelling a payment and retrying within the same popup, the 'Payment Cancelled' alert stayed visible because `pending_payment_auth`, `payment_authorized`, and `apple_pay_button_pressed` events only set `committed=true` without clearing `failed` and `error`.

**Fix:** Clear `failed` and `error` on all active-payment events.

### 4. Animated status bar alerts

**Problem:** Status bar alerts popped in abruptly and shifted the Coinbase iframe down.

**Fix:** Status bar now overlays the top of the iframe with a `translate-y` slide-down animation (300ms ease-out). The iframe always fills the full screen.

## Polling Strategy

```
Popup opens → 5s fallback poll (backend)
                    ↓ (if BroadcastChannel polling_success received)
              1s fast poll (15s timeout)
                    ↓ (on Completed/Failed)
              Stop all polls → navigate
```
