### PR TITLE
fix: onramp popup polling, retry state, and non-terminal commit errors

### DIFF
--- a/packages/keychain/src/components/coinbase-popup.tsx
+++ b/packages/keychain/src/components/coinbase-popup.tsx
@@ -205,13 +205,9 @@ export function CoinbasePopup() {
           break;
 
         case "onramp_api.commit_error":
-          setError(
-            data.data?.errorMessage ||
-              "Payment could not be processed. Please try again.",
-          );
+          // Don't treat as terminal — Coinbase falls back to QR code
+          // when Apple Pay is unsupported or fails.
           setCommitted(false);
-          setFailed(true);
-          setCompleted(false);
           break;
 
         case "onramp_api.cancel":


### PR DESCRIPTION
- Poll backend at 1s from popup open for immediate status detection
- Add 15s confirmation timeout when popup signals success
- Set terminal ref on success signal to prevent popup-closed race
- Clear failed/error state on retry events in popup (pending_payment_auth, payment_authorized, apple_pay_button_pressed)
- Treat commit_error as non-terminal (UI falls back to QR code)
- Animate status bar with slide-down transition instead of shifting iframe
- Use HeaderInner title/description props to fix text truncation