### PR TITLE
feat: support Stripe checkout for non-USDC starterpacks

### DIFF
--- a/packages/keychain/src/components/purchasenew/checkout/onchain/index.tsx
+++ b/packages/keychain/src/components/purchasenew/checkout/onchain/index.tsx
@@ -31,9 +31,7 @@ import { WalletSelector } from "./selector";
 import { QuantityControls } from "./quantity";
 import { WalletSelectionDrawer } from "./wallet-drawer";
 import { SocialClaimCheckout } from "./social-claim";
-import { USDC_ADDRESSES } from "@/utils/ekubo";
 import { getIpLocation } from "@/utils/ip";
-import { num } from "starknet";
 
 export function OnchainCheckout() {
   const { navigate } = useNavigation();
@@ -138,17 +136,6 @@ export function OnchainCheckout() {
     return quote ? quote.totalCost === BigInt(0) : undefined;
   }, [quote]);
 
-  const isStripeStarterpackSupported = useMemo(() => {
-    if (!controller || !quote) {
-      return true;
-    }
-
-    const usdcAddress = USDC_ADDRESSES[controller.chainId()];
-    return (
-      !!usdcAddress && num.toHex(quote.paymentToken) === num.toHex(usdcAddress)
-    );
-  }, [controller, quote]);
-
   const {
     balanceError,
     bridgeFrom,
@@ -197,7 +184,7 @@ export function OnchainCheckout() {
 
   const globalDisabled = useMemo(() => {
     if (isStripeSelected) {
-      return !isStripeStarterpackSupported || isStripeLoading;
+      return isStripeLoading;
     }
 
     // Disable if there's a fee estimation error (e.g., bridge amount too low)
@@ -231,7 +218,6 @@ export function OnchainCheckout() {
     isApplePaySelected,
     isApplePayAmountTooLow,
     isStripeSelected,
-    isStripeStarterpackSupported,
     isStripeLoading,
   ]);
 
@@ -260,9 +246,12 @@ export function OnchainCheckout() {
 
   const handlePurchase = useCallback(async () => {
     if (isApplePayAmountTooLow) return;
-    if (isStripeSelected) {
-      if (!isStripeStarterpackSupported) return;
-    } else if (!hasSufficientBalance && !isFree && !isApplePaySelected) {
+    if (
+      !isStripeSelected &&
+      !hasSufficientBalance &&
+      !isFree &&
+      !isApplePaySelected
+    ) {
       console.warn("no means to pay");
       return;
     }
@@ -313,7 +302,6 @@ export function OnchainCheckout() {
     hasSufficientBalance,
     isFree,
     isStripeSelected,
-    isStripeStarterpackSupported,
     isApplePaySelected,
     onCreditCardPurchase,
     refetchMe,
@@ -345,23 +333,13 @@ export function OnchainCheckout() {
       const lastMethod = localStorage.getItem(
         `@cartridge/lastPaymentMethod:${controller.chainId()}`,
       );
-      if (
-        lastMethod === "stripe" &&
-        isStripeStarterpackSupported &&
-        countryCode === "US"
-      ) {
+      if (lastMethod === "stripe" && countryCode === "US") {
         onStripeSelect();
       }
     } catch {
       // localStorage may be unavailable
     }
-  }, [
-    controller,
-    quote,
-    isStripeStarterpackSupported,
-    onStripeSelect,
-    countryCode,
-  ]);
+  }, [controller, quote, onStripeSelect, countryCode]);
 
   useEffect(() => {
     clearError();
@@ -454,14 +432,6 @@ export function OnchainCheckout() {
                 variant="warning"
                 title="Amount Too Low"
                 message="Bridge amount is too low for this network. Try increasing quantity or selecting a different network."
-              />
-            )}
-
-            {isStripeSelected && !isStripeStarterpackSupported && (
-              <ErrorCard
-                variant="error"
-                title="Stripe Checkout Unavailable"
-                message="Stripe checkout is only available for starterpacks priced in USDC."
               />
             )}
 

--- a/packages/keychain/src/components/purchasenew/review/cost.tsx
+++ b/packages/keychain/src/components/purchasenew/review/cost.tsx
@@ -28,7 +28,7 @@ import type { Quote } from "@/context";
 import { useCallback, useMemo, useEffect } from "react";
 import { useOnchainPurchaseContext } from "@/context";
 import { num } from "starknet";
-import { getStarterpackStripeCostDetails } from "./stripe-pricing";
+import { useStripeStarterpackQuote } from "@/hooks/payments/stripe-quote";
 
 type PaymentRails = "stripe" | "crypto";
 type PaymentUnit = "usdc" | "credits";
@@ -131,13 +131,8 @@ export function OnchainCostBreakdown({
     isFetchingCoinbaseQuote,
   } = useOnchainPurchaseContext();
   const { decimals } = quote.paymentTokenMetadata;
-  const stripeCostDetails = useMemo(() => {
-    if (!isStripeSelected) {
-      return undefined;
-    }
-
-    return getStarterpackStripeCostDetails(quote, quantity);
-  }, [isStripeSelected, quantity, quote]);
+  const { costDetails: stripeCostDetails, isLoading: isStripePriceLoading } =
+    useStripeStarterpackQuote({ enabled: isStripeSelected });
 
   // Get default token (matching quote if available) or fallback to the first available token
   const defaultToken =
@@ -234,16 +229,19 @@ export function OnchainCostBreakdown({
                 layerswapFees={isUsingLayerswap ? layerswapFees : undefined}
                 coinbaseQuote={isApplePaySelected ? coinbaseQuote : undefined}
                 stripeFeeInCents={stripeCostDetails?.processingFeeInCents}
+                stripeTotalInCents={stripeCostDetails?.totalInCents}
               />
             </div>
-            {isFetchingConversion || isFetchingCoinbaseQuote ? (
+            {isFetchingConversion ||
+            isFetchingCoinbaseQuote ||
+            isStripePriceLoading ? (
               <Spinner />
             ) : (
               <div className="flex items-center gap-1.5">
                 {isStripeSelected ? (
                   stripeCostDetails ? (
                     <span className="text-foreground-100">
-                      {formatAmount(stripeCostDetails.totalInCents / 100)}
+                      {`$${formatAmount(stripeCostDetails.totalInCents / 100)}`}
                     </span>
                   ) : (
                     <span className="text-foreground-400">—</span>

--- a/packages/keychain/src/components/purchasenew/review/onchain-tooltip.tsx
+++ b/packages/keychain/src/components/purchasenew/review/onchain-tooltip.tsx
@@ -28,6 +28,7 @@ export const OnchainFeesTooltip = ({
   layerswapFees,
   coinbaseQuote,
   stripeFeeInCents,
+  stripeTotalInCents,
 }: {
   trigger: React.ReactNode;
   defaultOpen?: boolean;
@@ -36,10 +37,9 @@ export const OnchainFeesTooltip = ({
   layerswapFees?: string;
   coinbaseQuote?: CoinbaseQuoteResult;
   stripeFeeInCents?: number;
+  stripeTotalInCents?: number;
 }) => {
   const { decimals, symbol } = quote.paymentTokenMetadata;
-  const baseTotal =
-    Number(quote.totalCost * BigInt(quantity)) / Math.pow(10, decimals);
 
   // Format layerswap fees in USDC (6 decimals)
   const formattedBridgeFee = layerswapFees
@@ -54,12 +54,12 @@ export const OnchainFeesTooltip = ({
 
   const formattedStripeFee =
     stripeFeeInCents !== undefined
-      ? `${(stripeFeeInCents / 100).toFixed(2)} ${symbol}`
+      ? `$${(stripeFeeInCents / 100).toFixed(2)}`
       : null;
 
   const totalWithStripeFee =
-    stripeFeeInCents !== undefined
-      ? `${(baseTotal + stripeFeeInCents / 100).toFixed(2)} ${symbol}`
+    stripeTotalInCents !== undefined
+      ? `$${(stripeTotalInCents / 100).toFixed(2)}`
       : null;
 
   return (

--- a/packages/keychain/src/components/purchasenew/review/stripe-pricing.test.ts
+++ b/packages/keychain/src/components/purchasenew/review/stripe-pricing.test.ts
@@ -1,57 +1,8 @@
 import { describe, expect, it } from "vitest";
-import {
-  getStarterpackStripeCostDetails,
-  getStripeFeeInCents,
-} from "./stripe-pricing";
+import { getStripeFeeInCents } from "./stripe-pricing";
 
 describe("starterpack stripe pricing", () => {
   it("calculates the Stripe fee from the starterpack total", () => {
     expect(getStripeFeeInCents(10750)).toBe(449);
-  });
-
-  it("builds starterpack checkout totals without a Cartridge fee", () => {
-    const pricing = getStarterpackStripeCostDetails(
-      {
-        basePrice: 100000000n,
-        protocolFee: 2500000n,
-        referralFee: 5000000n,
-        totalCost: 107500000n,
-        paymentToken: "0x1",
-        paymentTokenMetadata: {
-          symbol: "USDC",
-          decimals: 6,
-        },
-      },
-      1,
-    );
-
-    expect(pricing).toEqual({
-      baseCostInCents: 10750,
-      processingFeeInCents: 449,
-      totalInCents: 11199,
-    });
-  });
-
-  it("multiplies the starterpack total before applying the Stripe fee", () => {
-    const pricing = getStarterpackStripeCostDetails(
-      {
-        basePrice: 25000000n,
-        protocolFee: 625000n,
-        referralFee: 1250000n,
-        totalCost: 26875000n,
-        paymentToken: "0x1",
-        paymentTokenMetadata: {
-          symbol: "USDC",
-          decimals: 6,
-        },
-      },
-      2,
-    );
-
-    expect(pricing).toEqual({
-      baseCostInCents: 5375,
-      processingFeeInCents: 240,
-      totalInCents: 5615,
-    });
   });
 });

--- a/packages/keychain/src/components/purchasenew/review/stripe-pricing.ts
+++ b/packages/keychain/src/components/purchasenew/review/stripe-pricing.ts
@@ -1,33 +1,6 @@
-import type { Quote } from "@/context";
-import type { CostDetails } from "../types";
-
 const STRIPE_FIXED_FEE_CENTS = 30;
 
 export const getStripeFeeInCents = (baseCostInCents: number): number => {
   const percentFeeInCents = Math.round(baseCostInCents * 0.039);
   return percentFeeInCents + STRIPE_FIXED_FEE_CENTS;
-};
-
-export const getStarterpackStripeCostDetails = (
-  quote: Quote,
-  quantity: number,
-): CostDetails => {
-  const totalCost = quote.totalCost * BigInt(quantity);
-  const decimalsOffset = quote.paymentTokenMetadata.decimals - 2;
-
-  const baseCostInCents =
-    decimalsOffset >= 0
-      ? Number(
-          (totalCost + 10n ** BigInt(decimalsOffset) / 2n) /
-            10n ** BigInt(decimalsOffset),
-        )
-      : Number(totalCost * 10n ** BigInt(Math.abs(decimalsOffset)));
-
-  const processingFeeInCents = getStripeFeeInCents(baseCostInCents);
-
-  return {
-    baseCostInCents,
-    processingFeeInCents,
-    totalInCents: baseCostInCents + processingFeeInCents,
-  };
 };

--- a/packages/keychain/src/context/starterpack/credit-purchase.tsx
+++ b/packages/keychain/src/context/starterpack/credit-purchase.tsx
@@ -15,9 +15,6 @@ import { useStarterpackContext } from "./starterpack";
 import { useOnchainPurchaseContext } from "./onchain-purchase";
 import { getCurrentReferral } from "@/utils/referral";
 import { isOnchainStarterpack } from "./types";
-import { USDC_ADDRESSES } from "@/utils/ekubo";
-import { num } from "starknet";
-import { getStarterpackStripeCostDetails } from "@/components/purchasenew/review/stripe-pricing";
 
 export interface CostDetails {
   baseCostInCents: number;
@@ -100,16 +97,6 @@ export const CreditPurchaseProvider = ({
           throw new Error("Quote not loaded yet");
         }
 
-        const usdcAddress = USDC_ADDRESSES[controller.chainId()];
-        if (
-          !usdcAddress ||
-          num.toHex(starterpackQuote.paymentToken) !== num.toHex(usdcAddress)
-        ) {
-          throw new Error(
-            "Stripe checkout is only available for starterpacks priced in USDC.",
-          );
-        }
-
         const referralData = getCurrentReferral(origin);
 
         paymentIntent = await createStarterpackPaymentIntent({
@@ -133,11 +120,7 @@ export const CreditPurchaseProvider = ({
       setCustomerSessionClientSecret(
         paymentIntent.customerSessionClientSecret ?? undefined,
       );
-      setCostDetails(
-        starterpackDetails && isOnchainStarterpack(starterpackDetails)
-          ? getStarterpackStripeCostDetails(starterpackDetails.quote!, quantity)
-          : paymentIntent.pricing,
-      );
+      setCostDetails(paymentIntent.pricing);
     } catch (e) {
       setDisplayError(e as Error);
       throw e;

--- a/packages/keychain/src/hooks/payments/stripe-quote.ts
+++ b/packages/keychain/src/hooks/payments/stripe-quote.ts
@@ -1,0 +1,66 @@
+import { useMemo } from "react";
+import { useConnection } from "../connection";
+import { constants } from "starknet";
+import {
+  useStripeStarterpackQuoteQuery,
+  StripeStarterpackQuoteInput,
+} from "@/utils/api";
+import { useStarterpackContext } from "@/context";
+import { useOnchainPurchaseContext } from "@/context";
+import { isOnchainStarterpack } from "@/context/starterpack/types";
+import { getCurrentReferral } from "@/utils/referral";
+import type { CostDetails } from "@/components/purchasenew/types";
+
+export function useStripeStarterpackQuote({ enabled }: { enabled: boolean }) {
+  const { controller, origin } = useConnection();
+  const { registryAddress, bundleId, starterpackDetails } =
+    useStarterpackContext();
+  const { quantity } = useOnchainPurchaseContext();
+
+  const isMainnet = useMemo(
+    () => controller?.chainId() === constants.StarknetChainId.SN_MAIN,
+    [controller],
+  );
+
+  const input = useMemo((): StripeStarterpackQuoteInput | null => {
+    if (!starterpackDetails || !isOnchainStarterpack(starterpackDetails))
+      return null;
+    if (!registryAddress) return null;
+
+    const referralData = getCurrentReferral(origin);
+
+    return {
+      starterpackId: starterpackDetails.id.toString(),
+      quantity,
+      referral: referralData?.refAddress || referralData?.ref,
+      referralGroup: referralData?.refGroup,
+      registryAddress,
+      ...(bundleId !== undefined && { clientPercentage: 0 }),
+      isMainnet,
+    };
+  }, [
+    starterpackDetails,
+    registryAddress,
+    quantity,
+    origin,
+    bundleId,
+    isMainnet,
+  ]);
+
+  const { data, isLoading } = useStripeStarterpackQuoteQuery(
+    { input: input! },
+    { enabled: enabled && input !== null },
+  );
+
+  const costDetails = useMemo((): CostDetails | undefined => {
+    if (!data) return undefined;
+    const { pricing } = data.stripeStarterpackQuote;
+    return {
+      baseCostInCents: pricing.baseCostInCents,
+      processingFeeInCents: pricing.processingFeeInCents,
+      totalInCents: pricing.totalInCents,
+    };
+  }, [data]);
+
+  return { costDetails, isLoading };
+}

--- a/packages/keychain/src/hooks/starterpack/token-fallback.ts
+++ b/packages/keychain/src/hooks/starterpack/token-fallback.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { num, uint256 } from "starknet";
-import { fetchSwapQuote, USDC_ADDRESSES } from "@/utils/ekubo";
+import { fetchSwapQuote } from "@/utils/ekubo";
 import { isOnchainStarterpack } from "@/context/starterpack/types";
 import type { OnchainStarterpackDetails } from "@/context/starterpack/types";
 import type { TokenOption } from "./token-selection";
@@ -162,14 +162,8 @@ export function useTokenFallback({
 
       if (abortController.signal.aborted) return;
 
-      // No fallback token found - default to Stripe if priced in USDC
-      const usdcAddress = USDC_ADDRESSES[controller.chainId()];
-      if (
-        usdcAddress &&
-        num.toHex(quote.paymentToken) === num.toHex(usdcAddress)
-      ) {
-        onStripeSelect();
-      }
+      // No fallback token found - default to Stripe
+      onStripeSelect();
 
       setIsCheckingFallback(false);
     };

--- a/packages/keychain/src/utils/api/generated.ts
+++ b/packages/keychain/src/utils/api/generated.ts
@@ -7234,6 +7234,25 @@ export type StripePaymentQuery = {
   };
 };
 
+export type StripeStarterpackQuoteQueryVariables = Exact<{
+  input: StripeStarterpackQuoteInput;
+}>;
+
+export type StripeStarterpackQuoteQuery = {
+  __typename?: "Query";
+  stripeStarterpackQuote: {
+    __typename?: "StripeStarterpackQuote";
+    paymentToken: string;
+    needsSwap: boolean;
+    pricing: {
+      __typename?: "StripePricingDetails";
+      baseCostInCents: number;
+      processingFeeInCents: number;
+      totalInCents: number;
+    };
+  };
+};
+
 export type LayerswapSourcesQueryVariables = Exact<{
   token: Scalars["String"];
   isMainnet?: InputMaybe<Scalars["Boolean"]>;
@@ -7969,6 +7988,34 @@ export const useStripePaymentQuery = <
     useFetchData<StripePaymentQuery, StripePaymentQueryVariables>(
       StripePaymentDocument,
     ).bind(null, variables),
+    options,
+  );
+export const StripeStarterpackQuoteDocument = `
+    query StripeStarterpackQuote($input: StripeStarterpackQuoteInput!) {
+  stripeStarterpackQuote(input: $input) {
+    pricing {
+      baseCostInCents
+      processingFeeInCents
+      totalInCents
+    }
+    paymentToken
+    needsSwap
+  }
+}
+    `;
+export const useStripeStarterpackQuoteQuery = <
+  TData = StripeStarterpackQuoteQuery,
+  TError = unknown,
+>(
+  variables: StripeStarterpackQuoteQueryVariables,
+  options?: UseQueryOptions<StripeStarterpackQuoteQuery, TError, TData>,
+) =>
+  useQuery<StripeStarterpackQuoteQuery, TError, TData>(
+    ["StripeStarterpackQuote", variables],
+    useFetchData<
+      StripeStarterpackQuoteQuery,
+      StripeStarterpackQuoteQueryVariables
+    >(StripeStarterpackQuoteDocument).bind(null, variables),
     options,
   );
 export const LayerswapSourcesDocument = `

--- a/packages/keychain/src/utils/api/payment.graphql
+++ b/packages/keychain/src/utils/api/payment.graphql
@@ -17,6 +17,18 @@ query StripePayment($id: ID!) {
   }
 }
 
+query StripeStarterpackQuote($input: StripeStarterpackQuoteInput!) {
+  stripeStarterpackQuote(input: $input) {
+    pricing {
+      baseCostInCents
+      processingFeeInCents
+      totalInCents
+    }
+    paymentToken
+    needsSwap
+  }
+}
+
 query LayerswapSources($token: String!, $isMainnet: Boolean) {
   layerswapSources(token: $token, isMainnet: $isMainnet) {
     name


### PR DESCRIPTION
## Summary
- Remove the USDC-only restriction for Stripe starterpack purchases, allowing any payment token
- Use the new `stripeStarterpackQuote` server-side query for pricing instead of client-side calculation (backend handles Ekubo swap quotes)
- Stripe fees and totals in the tooltip now display in USD (`$X.XX`) instead of the payment token symbol
- Auto-fallback to Stripe now works for all payment tokens, not just USDC

## Test plan
- [ ] USDC starterpack via Stripe works identically to before (regression)
- [ ] Non-USDC starterpack (e.g. STRK) shows Stripe option with correct USD pricing
- [ ] Tooltip displays fees in USD when Stripe is selected
- [ ] Token fallback auto-selects Stripe when no token has sufficient balance
- [ ] Restore last payment method from localStorage works without USDC check

🤖 Generated with [Claude Code](https://claude.com/claude-code)