### PR TITLE
feat(coinflow): use verified account email for card checkout

### DIFF
--- a/packages/keychain/src/components/purchasenew/checkout/coinflow/index.tsx
+++ b/packages/keychain/src/components/purchasenew/checkout/coinflow/index.tsx
@@ -25,7 +25,6 @@ export function CoinflowCheckout() {
   const cardFormRef = useRef<{ tokenize: () => Promise<{ token: string }> }>(
     null,
   );
-  const [email, setEmail] = useState("");
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
   const [expMonth, setExpMonth] = useState("");
@@ -60,7 +59,6 @@ export function CoinflowCheckout() {
           cardToken: token,
           expMonth,
           expYear,
-          email,
           firstName,
           lastName,
           country,
@@ -82,7 +80,6 @@ export function CoinflowCheckout() {
     cardCheckout,
     expMonth,
     expYear,
-    email,
     firstName,
     lastName,
     country,
@@ -98,7 +95,6 @@ export function CoinflowCheckout() {
   }
 
   const isFormValid =
-    email &&
     firstName &&
     lastName &&
     expMonth &&
@@ -128,13 +124,6 @@ export function CoinflowCheckout() {
               onChange={(e) => setLastName(e.target.value)}
             />
           </div>
-
-          <Input
-            placeholder="Email"
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-          />
 
           <CoinflowCardForm
             ref={cardFormRef}

--- a/packages/keychain/src/components/purchasenew/checkout/coinflow/index.tsx
+++ b/packages/keychain/src/components/purchasenew/checkout/coinflow/index.tsx
@@ -1,5 +1,10 @@
-import { CoinflowCardForm } from "@coinflowlabs/react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  CoinflowCardForm,
+  MerchantStyle,
+  type CardFormRef,
+  type MerchantTheme,
+} from "@coinflowlabs/react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   useNavigation,
   useStarterpackContext,
@@ -12,28 +17,56 @@ import {
   Input,
   LayoutContent,
   LayoutFooter,
+  Skeleton,
   Spinner,
 } from "@cartridge/ui";
 import { ControllerErrorAlert } from "@/components/ErrorAlert";
+import { useControllerTheme } from "@/hooks/connection";
 import { useCoinflowCardCheckoutMutation } from "@/utils/api";
+
+const COINFLOW_PRIMARY_FALLBACK = "#fbcb4a";
+
+// Match Coinflow's iframe to the keychain Input component so the card
+// fields read as a single form with the surrounding inputs. Pulled from
+// @cartridge/ui's default theme + primitives/input.js variants.
+const COINFLOW_THEME_BASE = {
+  background: "#1e221f",
+  backgroundAccent: "#242824",
+  backgroundAccent2: "#242824",
+  textColor: "#ffffff",
+  textColorAccent: "#505050",
+  textColorAction: "#ffffff",
+  style: MerchantStyle.Sharp,
+  fontSize: "12px",
+  cardNumberPlaceholder: "Card number",
+  expirationPlaceholder: "MM / YY",
+  cvvPlaceholder: "CVV",
+  showCardIcon: true,
+} as const;
 
 export function CoinflowCheckout() {
   const { clearError } = useStarterpackContext();
   const { coinflowIntent, coinflowEnv } = useCreditPurchaseContext();
   const { navigate } = useNavigation();
+  const controllerTheme = useControllerTheme();
+  const coinflowTheme = useMemo<MerchantTheme>(() => {
+    const primary = controllerTheme?.colors?.primary;
+    return {
+      ...COINFLOW_THEME_BASE,
+      primary:
+        typeof primary === "string" ? primary : COINFLOW_PRIMARY_FALLBACK,
+    };
+  }, [controllerTheme]);
 
-  const cardFormRef = useRef<{ tokenize: () => Promise<{ token: string }> }>(
-    null,
-  );
+  const cardFormRef = useRef<CardFormRef>(null);
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
-  const [expMonth, setExpMonth] = useState("");
-  const [expYear, setExpYear] = useState("");
   const [country, setCountry] = useState("US");
   const [zip, setZip] = useState("");
   const [address1, setAddress1] = useState("");
   const [city, setCity] = useState("");
   const [state, setState] = useState("");
+  const [isFormReady, setIsFormReady] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
@@ -51,7 +84,11 @@ export function CoinflowCheckout() {
     setIsSubmitting(true);
 
     try {
-      const { token } = await cardFormRef.current.tokenize();
+      const { token, expMonth, expYear } = await cardFormRef.current.tokenize();
+
+      if (!expMonth || !expYear) {
+        throw new Error("Card expiration is required");
+      }
 
       await cardCheckout({
         input: {
@@ -78,8 +115,6 @@ export function CoinflowCheckout() {
   }, [
     coinflowIntent,
     cardCheckout,
-    expMonth,
-    expYear,
     firstName,
     lastName,
     country,
@@ -90,19 +125,23 @@ export function CoinflowCheckout() {
     navigate,
   ]);
 
+  const onCardFormLoad = useCallback(() => setIsFormReady(true), []);
+
+  const isFormValid = useMemo(
+    () =>
+      isFormReady &&
+      !!firstName &&
+      !!lastName &&
+      !!address1 &&
+      !!city &&
+      !!country &&
+      !isSubmitting,
+    [isFormReady, firstName, lastName, address1, city, country, isSubmitting],
+  );
+
   if (!coinflowIntent) {
     return null;
   }
-
-  const isFormValid =
-    firstName &&
-    lastName &&
-    expMonth &&
-    expYear &&
-    address1 &&
-    city &&
-    country &&
-    !isSubmitting;
 
   return (
     <>
@@ -111,72 +150,107 @@ export function CoinflowCheckout() {
         icon={<CreditCardIcon variant="solid" size="lg" />}
       />
       <LayoutContent>
-        <div className="flex flex-col gap-3">
-          <div className="flex gap-3">
-            <Input
-              placeholder="First name"
-              value={firstName}
-              onChange={(e) => setFirstName(e.target.value)}
-            />
-            <Input
-              placeholder="Last name"
-              value={lastName}
-              onChange={(e) => setLastName(e.target.value)}
+        {/* Keep skeletons in the tree while Coinflow's iframe boots so the
+            layout is stable and the user has immediate feedback. The
+            CoinflowCardForm is always mounted (just visually hidden) so its
+            onLoad can fire. */}
+        {!isFormReady && (
+          <div className="flex flex-col gap-3">
+            <div className="flex gap-3">
+              <Skeleton className="h-10 flex-1 rounded" />
+              <Skeleton className="h-10 flex-1 rounded" />
+            </div>
+            <Skeleton className="h-10 w-full rounded" />
+            <Skeleton className="h-10 w-full rounded" />
+            <Skeleton className="h-10 w-full rounded" />
+            <div className="flex gap-3">
+              <Skeleton className="h-10 flex-1 rounded" />
+              <Skeleton className="h-10 flex-1 rounded" />
+            </div>
+            <div className="flex gap-3">
+              <Skeleton className="h-10 flex-1 rounded" />
+              <Skeleton className="h-10 flex-1 rounded" />
+            </div>
+          </div>
+        )}
+
+        <div
+          className={`flex flex-col gap-5 ${isFormReady ? "" : "hidden"}`}
+          aria-hidden={!isFormReady}
+        >
+          <div className="flex flex-col gap-2">
+            <label className="text-xs text-foreground-300 font-medium">
+              Name on card
+            </label>
+            <div className="flex gap-3">
+              <Input
+                placeholder="First name"
+                value={firstName}
+                onChange={(e) => setFirstName(e.target.value)}
+              />
+              <Input
+                placeholder="Last name"
+                value={lastName}
+                onChange={(e) => setLastName(e.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-xs text-foreground-300 font-medium">
+              Card information
+            </label>
+            <CoinflowCardForm
+              ref={cardFormRef}
+              merchantId={coinflowIntent.merchantId}
+              env={coinflowEnv}
+              theme={coinflowTheme}
+              onLoad={onCardFormLoad}
             />
           </div>
 
-          <CoinflowCardForm
-            ref={cardFormRef}
-            merchantId={coinflowIntent.merchantId}
-            env={coinflowEnv}
-          />
-
-          <div className="flex gap-3">
+          <div className="flex flex-col gap-3">
+            <label className="text-xs text-foreground-300 font-medium">
+              Billing address
+            </label>
             <Input
-              placeholder="MM"
-              value={expMonth}
-              onChange={(e) => setExpMonth(e.target.value.slice(0, 2))}
-              maxLength={2}
+              placeholder="Address"
+              value={address1}
+              onChange={(e) => setAddress1(e.target.value)}
             />
-            <Input
-              placeholder="YY"
-              value={expYear}
-              onChange={(e) => setExpYear(e.target.value.slice(0, 2))}
-              maxLength={2}
-            />
+            <div className="flex gap-3">
+              <Input
+                placeholder="City"
+                value={city}
+                onChange={(e) => setCity(e.target.value)}
+              />
+              <Input
+                placeholder="State"
+                value={state}
+                onChange={(e) => setState(e.target.value)}
+              />
+            </div>
           </div>
 
-          <Input
-            placeholder="Address"
-            value={address1}
-            onChange={(e) => setAddress1(e.target.value)}
-          />
-          <div className="flex gap-3">
-            <Input
-              placeholder="City"
-              value={city}
-              onChange={(e) => setCity(e.target.value)}
-            />
-            <Input
-              placeholder="State"
-              value={state}
-              onChange={(e) => setState(e.target.value)}
-            />
-          </div>
-          <div className="flex gap-3">
-            <Input
-              placeholder="Zip"
-              value={zip}
-              onChange={(e) => setZip(e.target.value)}
-            />
-            <Input
-              placeholder="Country (ISO 3166-1 alpha-2, e.g. US)"
-              value={country}
-              onChange={(e) =>
-                setCountry(e.target.value.toUpperCase().slice(0, 2))
-              }
-              maxLength={2}
-            />
+          <div className="flex flex-col gap-2">
+            <label className="text-xs text-foreground-300 font-medium">
+              Country or region
+            </label>
+            <div className="flex gap-3">
+              <Input
+                placeholder="Country (ISO 3166-1 alpha-2, e.g. US)"
+                value={country}
+                onChange={(e) =>
+                  setCountry(e.target.value.toUpperCase().slice(0, 2))
+                }
+                maxLength={2}
+              />
+              <Input
+                placeholder="Postal code"
+                value={zip}
+                onChange={(e) => setZip(e.target.value)}
+              />
+            </div>
           </div>
         </div>
       </LayoutContent>

--- a/packages/keychain/src/components/purchasenew/checkout/onchain/index.tsx
+++ b/packages/keychain/src/components/purchasenew/checkout/onchain/index.tsx
@@ -267,6 +267,12 @@ export function OnchainCheckout() {
 
     try {
       if (isCoinflowSelected) {
+        const { data: meData } = await refetchMe();
+        if (!meData?.me?.email) {
+          navigate("/purchase/verification?method=coinflow");
+          return;
+        }
+
         await onCreditCardPurchase();
         navigate("/purchase/checkout/coinflow");
       } else if (isApplePaySelected) {

--- a/packages/keychain/src/components/purchasenew/verification/index.tsx
+++ b/packages/keychain/src/components/purchasenew/verification/index.tsx
@@ -248,6 +248,8 @@ export function Verification() {
   const sendPhoneMutation = useSendPhoneVerificationMutation();
   const verifyPhoneMutation = useVerifyPhoneMutation();
 
+  const emailOnly = method === "coinflow";
+
   useEffect(() => {
     if (meData?.me && accountPrivateData && step === null) {
       const accountPrivate = accountPrivateData.accountPrivate;
@@ -255,8 +257,8 @@ export function Verification() {
       if (!meData.me.email) {
         setStep("EMAIL_INPUT");
       } else if (
-        !accountPrivate?.phoneNumber ||
-        !accountPrivate?.phoneNumberVerifiedAt
+        !emailOnly &&
+        (!accountPrivate?.phoneNumber || !accountPrivate?.phoneNumberVerifiedAt)
       ) {
         setStep("PHONE_INPUT");
         setPhone(accountPrivate?.phoneNumber || "");
@@ -264,7 +266,7 @@ export function Verification() {
         setStep("SUCCESS");
       }
     }
-  }, [meData, accountPrivateData, step]);
+  }, [meData, accountPrivateData, step, emailOnly]);
 
   useEffect(() => {
     if (resendCooldown > 0) {
@@ -277,15 +279,18 @@ export function Verification() {
   }, [resendCooldown]);
 
   useEffect(() => {
-    const isVerified =
-      meData?.me?.email &&
-      accountPrivateData?.accountPrivate?.phoneNumber &&
-      accountPrivateData?.accountPrivate?.phoneNumberVerifiedAt;
+    const hasEmail = !!meData?.me?.email;
+    const hasVerifiedPhone =
+      !!accountPrivateData?.accountPrivate?.phoneNumber &&
+      !!accountPrivateData?.accountPrivate?.phoneNumberVerifiedAt;
+    const isVerified = emailOnly ? hasEmail : hasEmail && hasVerifiedPhone;
 
     if (step === "SUCCESS" && method && isVerified && !isTransientSuccess) {
       const timer = setTimeout(() => {
         if (method === "apple-pay") {
           navigate("/purchase/checkout/coinbase");
+        } else if (method === "coinflow") {
+          navigate("/purchase/checkout/coinflow");
         } else {
           navigate(
             `/purchase/checkout/onchain${method ? `?method=${method}` : ""}`,
@@ -294,7 +299,15 @@ export function Verification() {
       }, 1500);
       return () => clearTimeout(timer);
     }
-  }, [step, method, navigate, meData, accountPrivateData, isTransientSuccess]);
+  }, [
+    step,
+    method,
+    navigate,
+    meData,
+    accountPrivateData,
+    isTransientSuccess,
+    emailOnly,
+  ]);
 
   const handleSendEmail = async () => {
     setError(null);
@@ -335,8 +348,9 @@ export function Verification() {
           ]);
 
           if (
-            !updatedAccountPrivate?.accountPrivate?.phoneNumber ||
-            !updatedAccountPrivate?.accountPrivate?.phoneNumberVerifiedAt
+            !emailOnly &&
+            (!updatedAccountPrivate?.accountPrivate?.phoneNumber ||
+              !updatedAccountPrivate?.accountPrivate?.phoneNumberVerifiedAt)
           ) {
             setStep("PHONE_INPUT");
             setPhone(updatedAccountPrivate?.accountPrivate?.phoneNumber || "");

--- a/packages/keychain/src/utils/api/generated.ts
+++ b/packages/keychain/src/utils/api/generated.ts
@@ -1211,7 +1211,6 @@ export type CoinflowCardCheckoutInput = {
   coinflowPaymentId: Scalars["ID"];
   /** ISO 3166-1 alpha-2 country code (e.g. "US"). Required by Coinflow address validation. */
   country: Scalars["String"];
-  email: Scalars["String"];
   expMonth: Scalars["String"];
   expYear: Scalars["String"];
   firstName: Scalars["String"];


### PR DESCRIPTION
## Summary
- Remove the email input from the Coinflow card form; the backend now reads the buyer's email from `Account.email` (only set via `verifyEmail`).
- Before entering the Coinflow card form, check `me.email`. If missing, route the user to `/purchase/verification?method=coinflow`.
- Teach the shared verification screen about `method=coinflow`: email-only (no phone step), and on success navigate back to `/purchase/checkout/coinflow`.
- Regenerate `generated.ts` against the newly deployed backend schema (drops `email` from `CoinflowCardCheckoutInput`).

Paired with cartridge-gg/internal#4314.

## Test plan
- [ ] New user (no verified email) selects Coinflow → lands on verification → email verify → lands on Coinflow card form (no email input).
- [ ] Existing user with verified email selects Coinflow → goes straight to the card form.
- [ ] Card form submits successfully and the purchase completes.
- [ ] Apple Pay path (`method=apple-pay`) still asks for both email and phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)