### PR TITLE
fix: defer URL param restore until after OAuth signup/login completes

### DIFF
--- a/packages/keychain/src/components/connect/create/useCreateController.ts
+++ b/packages/keychain/src/components/connect/create/useCreateController.ts
@@ -288,13 +288,20 @@ export function useCreateController({
       rpcUrl,
       signupResponse,
       signer,
+      overrideOrigin,
+      skipSessionCreation,
     }: {
       username: string;
       chainId: string;
       rpcUrl: string;
       signupResponse: SignupResponse;
       signer: SignerInput;
+      /** Explicit origin for OAuth redirect paths where closure value may be stale. */
+      overrideOrigin?: string;
+      /** Skip session creation (e.g. during OAuth redirect when policies aren't loaded yet). */
+      skipSessionCreation?: boolean;
     }) => {
+      const effectiveOrigin = overrideOrigin ?? origin;
       const classHash = STABLE_CONTROLLER.hash;
       const owner = {
         signer: signupResponse.signer,
@@ -303,7 +310,7 @@ export function useCreateController({
       const address = computeAccountAddress(classHash, owner, salt);
 
       const { controller, session } = await Controller.login({
-        appId: origin,
+        appId: effectiveOrigin,
         classHash,
         rpcUrl,
         address,
@@ -325,13 +332,21 @@ export function useCreateController({
           sessionKeyGuid: session.sessionKeyGuid,
           allowedPoliciesRoot: session.allowedPoliciesRoot,
           authorization: session.authorization ?? [],
-          appId: origin,
+          appId: effectiveOrigin,
         },
       });
 
       if (registerRet.register.username) {
         window.controller = controller;
         setController(controller);
+
+        // When called from the OAuth redirect path, skip session creation and
+        // post-login navigation. The restored URL params will trigger preset
+        // config loading, which remounts the tree and lets the normal connect
+        // flow handle session creation with fully-loaded policies.
+        if (skipSessionCreation) {
+          return;
+        }
 
         // Check if this is a standalone redirect flow
         const urlSearchParams = new URLSearchParams(window.location.search);
@@ -366,7 +381,7 @@ export function useCreateController({
         if (shouldAutoCreateSession) {
           await createSession({
             controller,
-            origin,
+            origin: effectiveOrigin,
             policies,
             params,
             handleCompletion,
@@ -596,12 +611,20 @@ export function useCreateController({
       rpcUrl,
       loginResponse,
       authenticationMethod,
+      overrideOrigin,
+      skipSessionCreation,
     }: {
       controller: NonNullable<ControllerQuery["controller"]>;
       rpcUrl: string;
       loginResponse: LoginResponse;
       authenticationMethod: AuthOption;
+      /** Explicit origin for OAuth redirect paths where closure value may be stale. */
+      overrideOrigin?: string;
+      /** Skip session creation (e.g. during OAuth redirect when policies aren't loaded yet). */
+      skipSessionCreation?: boolean;
     }) => {
+      const effectiveOrigin = overrideOrigin ?? origin;
+
       // Verify correct EVM wallet account is selected
       if (authenticationMethod !== "password") {
         const normalizeAddress = (address?: string) => {
@@ -644,7 +667,7 @@ export function useCreateController({
       }
 
       const loginRet = await Controller.login({
-        appId: origin,
+        appId: effectiveOrigin,
         rpcUrl,
         username: controller.accountID,
         classHash: controller.constructorCalldata[0],
@@ -659,6 +682,14 @@ export function useCreateController({
 
       window.controller = loginRet.controller;
       setController(loginRet.controller);
+
+      // When called from the OAuth redirect path, skip session creation and
+      // post-login navigation. The restored URL params will trigger preset
+      // config loading, which remounts the tree and lets the normal connect
+      // flow handle session creation with fully-loaded policies.
+      if (skipSessionCreation) {
+        return;
+      }
 
       // Check if this is a standalone redirect flow
       const urlSearchParams = new URLSearchParams(window.location.search);
@@ -693,7 +724,7 @@ export function useCreateController({
       if (shouldAutoCreateSession) {
         await createSession({
           controller: loginRet.controller,
-          origin,
+          origin: effectiveOrigin,
           policies,
           params,
           handleCompletion,
@@ -1002,6 +1033,12 @@ export function useCreateController({
             turnkeyWallet as unknown as WalletAdapter,
           );
 
+          // Extract origin from the saved searchParams so registration uses
+          // the correct appId, rather than relying on the (possibly stale)
+          // closure value which may not have loaded yet due to preset config.
+          const savedOrigin =
+            searchParams?.get("origin") || window.location.origin;
+
           if (isSignup) {
             await finishSignup({
               username,
@@ -1023,6 +1060,8 @@ export function useCreateController({
                   eth_address: account,
                 }),
               },
+              overrideOrigin: savedOrigin,
+              skipSessionCreation: true,
             });
           } else {
             const controller = await fetchController(chainId, username);
@@ -1041,6 +1080,8 @@ export function useCreateController({
               },
               authenticationMethod: socialProvider as AuthOption,
               rpcUrl,
+              overrideOrigin: savedOrigin,
+              skipSessionCreation: true,
             });
           }
 

--- a/packages/keychain/src/components/connect/create/useCreateController.ts
+++ b/packages/keychain/src/components/connect/create/useCreateController.ts
@@ -993,9 +993,6 @@ export function useCreateController({
           ) {
             return;
           }
-          if (searchParams) {
-            setSearchParams(searchParams);
-          }
 
           if (!window.keychain_wallets) {
             throw new Error("Keychain wallets isn't present");
@@ -1045,6 +1042,15 @@ export function useCreateController({
               authenticationMethod: socialProvider as AuthOption,
               rpcUrl,
             });
+          }
+
+          // Restore the original URL params (including preset) AFTER
+          // signup/login completes. Restoring earlier triggers preset config
+          // loading (isConfigLoading=true), which unmounts the entire
+          // component tree via the provider's loading guard, orphaning
+          // the in-flight signup/login async operation.
+          if (searchParams) {
+            setSearchParams(searchParams);
           }
         } catch (e) {
           setError(e as Error);


### PR DESCRIPTION
## Summary

Fixes Google/Discord OAuth signup failing when a preset environment is active.

## Bug

When a preset is configured, OAuth signup (Google/Discord) redirects back to the initial login screen instead of completing account creation. Passkey and password signup work fine with presets. OAuth signup works fine without presets.

## Root cause

After OAuth redirect, the handler restores saved URL params (including `preset`) via `setSearchParams`. This triggers `isConfigLoading=true` in the connection hook, which causes the Provider component to unmount the entire component tree (replacing it with a loading spinner). The in-flight async signup/login operation is orphaned — React 18 silently no-ops state updates on unmounted components, so the signup never completes and no account is created.

Additionally, `finishSignup`/`finishLogin` read `origin` and `policies` from React closure values, which may be stale or uninitialized during the OAuth redirect (before preset config has loaded).

## Fix

1. **Extract `origin` from saved searchParams** and pass it explicitly to `finishSignup`/`finishLogin` via a new `overrideOrigin` parameter, avoiding reliance on stale closure values.
2. **Skip session creation** during the OAuth redirect handler via a new `skipSessionCreation` flag — policies aren't loaded yet, so the normal connect flow handles session creation after the tree remounts with fully-loaded config.
3. **Defer `setSearchParams`** to after signup/login completes, preventing the premature unmount.

Non-OAuth callers are unaffected — they don't pass the new optional parameters, so existing closure-based behavior is preserved.

## Test plan

- [ ] OAuth signup (Google/Discord) with preset environment creates account and completes flow
- [ ] OAuth login with preset environment works
- [ ] OAuth signup/login without preset still works
- [ ] Passkey and password signup with preset still work
- [ ] Session creation still works after remount in preset flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)