### PR TITLE
fix(coinbase): gate Buy on limits before order creation

### DIFF
--- a/packages/keychain/src/components/purchasenew/checkout/coinbase/index.tsx
+++ b/packages/keychain/src/components/purchasenew/checkout/coinbase/index.tsx
@@ -255,7 +255,10 @@ export function CoinbaseCheckout() {
 
       {/* Policies Screen */}
       <div
-        className={cn("flex flex-col h-full", mode !== "policies" && "hidden")}
+        className={cn(
+          "flex flex-col h-full",
+          (mode !== "policies" || waitingForLimits) && "hidden",
+        )}
       >
         <HeaderInner
           title="Coinbase"
@@ -378,7 +381,6 @@ export function CoinbaseCheckout() {
             }
             isSubmitting={isSubmittingLimitsUpgrade}
             onSubmit={handleVerifySubmit}
-            onBack={handleBackToMethod}
           />
         </div>
       )}

--- a/packages/keychain/src/components/purchasenew/checkout/coinbase/limits-verify-panels.tsx
+++ b/packages/keychain/src/components/purchasenew/checkout/coinbase/limits-verify-panels.tsx
@@ -16,7 +16,11 @@ import {
   TimesIcon,
 } from "@cartridge/ui";
 import type { SubmitCoinbaseLimitsUpgradeInput } from "@/utils/api";
-import { LIMIT_TYPE_WEEKLY_SPENDING } from "@/hooks/starterpack/coinbase";
+import {
+  LIMIT_TYPE_LIFETIME_TRANSACTIONS,
+  LIMIT_TYPE_WEEKLY_SPENDING,
+  UNLIMITED_SENTINEL,
+} from "@/hooks/starterpack/coinbase";
 import type { CoinbaseLimitsResult } from "@/hooks/starterpack";
 
 const MONTH_OPTIONS = [
@@ -86,7 +90,6 @@ export interface VerifyFormPanelProps {
   isResubmit: boolean;
   isSubmitting: boolean;
   onSubmit: (input: SubmitCoinbaseLimitsUpgradeInput) => void;
-  onBack: () => void;
 }
 
 export function VerifyFormPanel({
@@ -94,7 +97,6 @@ export function VerifyFormPanel({
   isResubmit,
   isSubmitting,
   onSubmit,
-  onBack,
 }: VerifyFormPanelProps) {
   const [ssn, setSsn] = useState("");
   const [month, setMonth] = useState("");
@@ -108,6 +110,28 @@ export function VerifyFormPanel({
       )?.maxUpgrade,
     [limits.maxUpgrades],
   );
+
+  /** Human-readable reason the user landed on this form. */
+  const reason = useMemo(() => {
+    const weekly = limits.limits.find(
+      (l) => l.limitType === LIMIT_TYPE_WEEKLY_SPENDING,
+    );
+    const lifetime = limits.limits.find(
+      (l) => l.limitType === LIMIT_TYPE_LIFETIME_TRANSACTIONS,
+    );
+    const lifetimeDepleted =
+      lifetime &&
+      lifetime.remaining !== UNLIMITED_SENTINEL &&
+      Number(lifetime.remaining) <= 0;
+    if (lifetimeDepleted) {
+      const cap = lifetime?.limit ?? "15";
+      return `You've reached Coinbase's ${cap}-transaction lifetime cap.`;
+    }
+    const weeklyCap = weekly?.limit;
+    return weeklyCap
+      ? `This purchase exceeds your $${weeklyCap} weekly Coinbase limit.`
+      : "You've reached your Coinbase purchase limit.";
+  }, [limits.limits]);
 
   const ssnValid = /^\d{4}$/.test(ssn);
   const dobValid = isValidCalendarDate(year, month, day);
@@ -129,17 +153,20 @@ export function VerifyFormPanel({
         icon={<CoinbaseWalletColorIcon size="lg" />}
       />
       <LayoutContent className="p-4 flex flex-col gap-4">
-        <div className="bg-[#181C19] border border-background-200 p-4 rounded-[4px] text-xs text-foreground-300">
+        <div className="bg-[#181C19] border border-background-200 p-4 rounded-[4px] text-xs text-foreground-300 flex flex-col gap-2">
           {isResubmit ? (
-            <span className="text-destructive-100">
+            <p className="text-destructive-100">
               We couldn&apos;t verify your details. Please double-check and try
               again.
-            </span>
+            </p>
           ) : (
             <>
-              Verify your identity to raise your weekly limit
-              {weeklyUpgrade ? ` to $${weeklyUpgrade}` : ""} and unlock
-              unlimited transactions. Takes about 2 minutes.
+              <p>{reason}</p>
+              <p>
+                Verify your identity to raise your weekly limit
+                {weeklyUpgrade ? ` to $${weeklyUpgrade}` : ""} and unlock
+                unlimited transactions.
+              </p>
             </>
           )}
         </div>
@@ -208,24 +235,14 @@ export function VerifyFormPanel({
         </div>
       </LayoutContent>
       <LayoutFooter>
-        <div className="flex gap-2 w-full">
-          <Button
-            variant="secondary"
-            className="flex-1"
-            onClick={onBack}
-            disabled={isSubmitting}
-          >
-            BACK
-          </Button>
-          <Button
-            className="flex-1"
-            onClick={handleSubmit}
-            disabled={!canSubmit}
-            isLoading={isSubmitting}
-          >
-            SUBMIT
-          </Button>
-        </div>
+        <Button
+          className="w-full"
+          onClick={handleSubmit}
+          disabled={!canSubmit}
+          isLoading={isSubmitting}
+        >
+          SUBMIT
+        </Button>
       </LayoutFooter>
     </>
   );

--- a/packages/keychain/src/components/purchasenew/checkout/onchain/index.tsx
+++ b/packages/keychain/src/components/purchasenew/checkout/onchain/index.tsx
@@ -20,7 +20,11 @@ import {
 } from "@/context";
 import { useConnection } from "@/hooks/connection";
 import { useFeature, useFeatures } from "@/hooks/features";
-import { useTokenBalance, useTokenFallback } from "@/hooks/starterpack";
+import {
+  exceedsLimit,
+  useTokenBalance,
+  useTokenFallback,
+} from "@/hooks/starterpack";
 import { ControllerErrorAlert } from "@/components/ErrorAlert";
 import { Receiving } from "../../receiving";
 import { OnchainCostBreakdown } from "../../review/cost";
@@ -74,6 +78,9 @@ export function OnchainCheckout() {
     onCreateCoinbaseOrder,
     isCreatingOrder,
     usdAmount,
+    coinbaseLimits,
+    isFetchingCoinbaseLimits,
+    fetchCoinbaseLimits,
   } = useOnchainPurchaseContext();
   const { onCreditCardPurchase, isStripeLoading, isCoinflowLoading } =
     useCreditPurchaseContext();
@@ -119,6 +126,26 @@ export function OnchainCheckout() {
   const isApplePayAmountTooLow = useMemo(() => {
     return isApplePaySelected && totalUsdAmount < 2;
   }, [isApplePaySelected, totalUsdAmount]);
+
+  // Pre-fetch Coinbase limits as soon as Apple Pay is selected so we can gate
+  // the Buy button and skip a doomed order-create for users over the cap.
+  useEffect(() => {
+    if (isApplePaySelected) {
+      fetchCoinbaseLimits();
+    }
+  }, [isApplePaySelected, fetchCoinbaseLimits]);
+
+  const applePayLimitsLoading = useMemo(
+    () => isApplePaySelected && !coinbaseLimits && isFetchingCoinbaseLimits,
+    [isApplePaySelected, coinbaseLimits, isFetchingCoinbaseLimits],
+  );
+  const applePayLimitExceeded = useMemo(
+    () =>
+      isApplePaySelected &&
+      !!coinbaseLimits &&
+      exceedsLimit(totalUsdAmount, coinbaseLimits),
+    [isApplePaySelected, coinbaseLimits, totalUsdAmount],
+  );
 
   const quote = useMemo(() => {
     if (!starterpackDetails || !isOnchainStarterpack(starterpackDetails)) {
@@ -292,7 +319,29 @@ export function OnchainCheckout() {
           return;
         }
 
-        await onCreateCoinbaseOrder();
+        // User is over the Coinbase cap — skip the order create entirely;
+        // CoinbaseCheckout will surface the verify flow.
+        if (applePayLimitExceeded) {
+          navigate("/purchase/checkout/coinbase");
+          return;
+        }
+
+        try {
+          await onCreateCoinbaseOrder();
+        } catch (err) {
+          // Safety net: Coinbase can still reject if /limits was stale.
+          // Navigate anyway so the verify flow takes over.
+          const message = err instanceof Error ? err.message : String(err);
+          if (
+            message.includes("guest_transaction_count") ||
+            message.includes("guest_transaction_limit")
+          ) {
+            await fetchCoinbaseLimits();
+            navigate("/purchase/checkout/coinbase");
+            return;
+          }
+          throw err;
+        }
         navigate("/purchase/checkout/coinbase");
       } else {
         await onOnchainPurchase();
@@ -309,6 +358,8 @@ export function OnchainCheckout() {
     isCoinflowSelected,
     isCoinflowStarterpackSupported,
     isApplePaySelected,
+    applePayLimitExceeded,
+    fetchCoinbaseLimits,
     onCreditCardPurchase,
     refetchMe,
     refetchAccountPrivate,
@@ -500,7 +551,8 @@ export function OnchainCheckout() {
                 (bridgeFrom !== null && isFetchingFees) ||
                 isCreatingOrder ||
                 isStripeLoading ||
-                isCoinflowLoading
+                isCoinflowLoading ||
+                applePayLimitsLoading
               }
               isSendingDeposit={isSendingDeposit}
               globalDisabled={globalDisabled}
@@ -513,7 +565,13 @@ export function OnchainCheckout() {
               onPurchase={handlePurchase}
               onBridge={handleBridge}
               isApplePayAmountTooLow={isApplePayAmountTooLow}
-              purchaseLabel={isCoinflowSelected ? "Continue" : undefined}
+              purchaseLabel={
+                isCoinflowSelected
+                  ? "Continue"
+                  : applePayLimitExceeded
+                    ? "Verify to continue"
+                    : undefined
+              }
             />
           </>
         )}


### PR DESCRIPTION
## Summary
- Pre-fetches Coinbase limits when user selects Apple Pay — Buy button shows spinner while loading and flips to **"Verify to continue"** when the purchase would exceed the weekly or lifetime cap
- Skips `onCreateCoinbaseOrder` entirely when exceeded, navigating straight to the verify flow (no wasted Coinbase order)
- Safety net: catches `guest_transaction_count` / `guest_transaction_limit` server errors from stale limits, re-fetches, and redirects
- Fixes layout shift where the limits spinner + policies panel both rendered `h-full`
- UX polish: removes redundant BACK button from verify form, adds contextual reason copy (e.g. "You've reached Coinbase's 15-transaction lifetime cap.")

## Test plan
- [x] `tsc -b --noEmit` clean
- [x] ESLint clean
- [x] Pre-commit hooks pass
- [ ] Select Apple Pay → Buy button shows spinner → resolves to "Verify to continue" for a user at 15/15 lifetime txns
- [ ] Clicking "Verify to continue" navigates to verify form (no Coinbase order error)
- [ ] For a user under the cap, Buy behaves normally (creates order + opens popup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)