### PR TITLE
fix: policies spending amount asterisk

### DIFF
--- a/packages/keychain/src/components/connect/SpendingLimitCard.tsx
+++ b/packages/keychain/src/components/connect/SpendingLimitCard.tsx
@@ -46,7 +46,10 @@ export function SpendingLimitCard({
 
         if (!approveMethod) return null;
 
-        const amount = approveMethod.amount ?? "0";
+        const amount =
+          approveMethod.amount === "*"
+            ? UNLIMITED_VALUE
+            : (approveMethod.amount ?? "0");
         const checksumAddress = getChecksumAddress(address);
         const token = tokens[checksumAddress];
 


### PR DESCRIPTION
* support for `*` as an unlimited amount in policies

https://github.com/cartridge-gg/presets/blob/2043204e187498078e433d37a5b4bfc8710f877d/configs/zkube/config.json#L61

```
{
  "name": "Approve NFT Transfer",
  "description": "Approve another address to transfer your zKube game NFT",
  "entrypoint": "approve",
  "amount": "*",
  "spender": "*"
},
```

reported by Runelabs on zKube

<img width="1271" height="758" alt="image" src="https://github.com/user-attachments/assets/0c7af158-d434-464b-8a41-0302e4866cd2" />
