### PR TITLE
fix(coinbase): lower Apple Pay min threshold to $1.86 pre-fee

### DIFF
--- a/packages/keychain/src/components/purchasenew/checkout/onchain/index.tsx
+++ b/packages/keychain/src/components/purchasenew/checkout/onchain/index.tsx
@@ -124,7 +124,7 @@ export function OnchainCheckout() {
   }, [usdAmount, quantity]);
 
   const isApplePayAmountTooLow = useMemo(() => {
-    return isApplePaySelected && totalUsdAmount < 2;
+    return isApplePaySelected && totalUsdAmount < 1.86;
   }, [isApplePaySelected, totalUsdAmount]);
 
   // Pre-fetch Coinbase limits as soon as Apple Pay is selected so we can gate


### PR DESCRIPTION
## Summary
Coinbase's \$2 minimum applies to the **total including fees**, but the Apple Pay gate was comparing pre-fee starterpack price against \$2. That rejected starterpacks priced between \$1.86–\$1.99 even though they would clear Coinbase's floor once fees were added.

Lowered the threshold to \$1.86 so those purchases go through; below \$1.86 the "Amount Too Low" warning still shows.

## Test plan
- [ ] Starterpack priced at \$1.98 with Apple Pay selected → no warning, Buy enabled
- [ ] Starterpack priced at \$1.50 with Apple Pay selected → "Amount Too Low" warning, Buy disabled
- [ ] Starterpack priced at \$5 with Apple Pay selected → unchanged behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)