### PR TITLE
fix: social session register + harden provider lifecycle

### DIFF
--- a/packages/keychain/src/components/provider/index.test.tsx
+++ b/packages/keychain/src/components/provider/index.test.tsx
@@ -14,7 +14,9 @@ vi.mock("@/components/provider/upgrade", () => ({
 }));
 
 vi.mock("@/hooks/wallets", () => ({
-  WalletsProvider: ({ children }: PropsWithChildren) => <>{children}</>,
+  WalletsProvider: ({ children }: PropsWithChildren) => (
+    <div data-testid="wallets-provider">{children}</div>
+  ),
 }));
 
 vi.mock("@/utils/graphql", () => ({
@@ -184,5 +186,36 @@ describe("Provider", () => {
 
     expect(screen.getByText("child content")).toBeInTheDocument();
     expect(screen.queryByTestId("loading-spinner")).not.toBeInTheDocument();
+  });
+
+  it("keeps the provider tree mounted while config is loading", () => {
+    // Regression guard: if the loading branch short-circuits above the
+    // provider tree, it unmounts child providers mid-flight. OAuth redirect
+    // flows register embedded wallets on window.keychain_wallets before
+    // triggering a preset reload; those registrations must survive the
+    // loading state.
+    const { rerender } = render(
+      <Provider>
+        <div>child content</div>
+      </Provider>,
+    );
+
+    expect(screen.getByTestId("wallets-provider")).toBeInTheDocument();
+    const walletsProviderBefore = screen.getByTestId("wallets-provider");
+
+    mockUseConnectionValue.mockReturnValue({
+      ...baseConnection,
+      isConfigLoading: true,
+    });
+    rerender(
+      <Provider>
+        <div>child content</div>
+      </Provider>,
+    );
+
+    // Spinner replaces children, but WalletsProvider is still mounted
+    // (same DOM node instance — React kept it alive across the rerender).
+    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(screen.getByTestId("wallets-provider")).toBe(walletsProviderBefore);
   });
 });

--- a/packages/keychain/src/components/provider/index.tsx
+++ b/packages/keychain/src/components/provider/index.tsx
@@ -59,13 +59,20 @@ export function Provider({ children }: PropsWithChildren) {
     [connection.controller, connection.project],
   );
 
-  if (connection.isConfigLoading) {
-    return (
-      <div className="flex h-screen w-screen items-center justify-center bg-background">
-        <SpinnerIcon className="animate-spin text-muted-foreground" size="lg" />
-      </div>
-    );
-  }
+  // Keep the provider tree mounted while preset config is (re)loading.
+  // Previously this branch short-circuited with a spinner, which unmounted
+  // every child provider — orphaning in-flight async work and wiping
+  // globals like window.keychain_wallets. Any new flow that touches state
+  // across this boundary (e.g. OAuth redirect restoring searchParams)
+  // would hit the same class of bug. Rendering the spinner inside the
+  // tree preserves provider lifetimes across config reloads.
+  const body = connection.isConfigLoading ? (
+    <div className="flex h-screen w-screen items-center justify-center bg-background">
+      <SpinnerIcon className="animate-spin text-muted-foreground" size="lg" />
+    </div>
+  ) : (
+    children
+  );
 
   return (
     <FeatureProvider>
@@ -94,7 +101,7 @@ export function Provider({ children }: PropsWithChildren) {
                                     >
                                       <ProfileDataProvider>
                                         <StarterpackProviders>
-                                          {children}
+                                          {body}
                                         </StarterpackProviders>
                                       </ProfileDataProvider>
                                     </MarketplaceClientProvider>

--- a/packages/keychain/src/hooks/wallets.test.tsx
+++ b/packages/keychain/src/hooks/wallets.test.tsx
@@ -1,0 +1,113 @@
+import { render } from "@testing-library/react";
+import { WalletAdapter } from "@cartridge/controller";
+import { PropsWithChildren } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WalletsProvider } from "./wallets";
+
+const mockParent = {
+  externalDetectWallets: vi.fn().mockResolvedValue([]),
+  externalConnectWallet: vi.fn(),
+  externalSignMessage: vi.fn(),
+  externalSignTypedData: vi.fn(),
+  externalSendTransaction: vi.fn(),
+  externalGetBalance: vi.fn(),
+  externalSwitchChain: vi.fn(),
+  externalWaitForTransaction: vi.fn(),
+  open: vi.fn(),
+  close: vi.fn(),
+  reload: vi.fn(),
+};
+
+vi.mock("./connection", () => ({
+  useConnection: () => ({ parent: mockParent }),
+}));
+
+const Wrapper = ({ children }: PropsWithChildren) => (
+  <WalletsProvider>{children}</WalletsProvider>
+);
+
+const makeWallet = (address: string): WalletAdapter =>
+  ({
+    type: "turnkey",
+    platform: "ethereum",
+    signMessage: vi.fn().mockResolvedValue({
+      success: true,
+      wallet: "turnkey",
+      result: `0xsig-for-${address}`,
+    }),
+    getConnectedAccounts: () => [address],
+    getInfo: () => ({
+      type: "turnkey",
+      platform: "ethereum",
+      available: true,
+      name: "Turnkey",
+      connectedAccounts: [address],
+    }),
+  }) as unknown as WalletAdapter;
+
+// Lowercase so ethers getAddress() normalizes rather than validating checksum.
+const ADDRESS = "0x708aec02b92f5895b74484f7c771beaf3a0dabe7";
+
+describe("WalletsProvider embedded wallet persistence", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    delete (window as { keychain_wallets?: unknown }).keychain_wallets;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete (window as { keychain_wallets?: unknown }).keychain_wallets;
+  });
+
+  it("initializes window.keychain_wallets when mounted", () => {
+    render(
+      <Wrapper>
+        <div />
+      </Wrapper>,
+    );
+
+    expect(window.keychain_wallets).toBeDefined();
+  });
+
+  it("preserves embedded wallets registered before unmount", async () => {
+    // This is the OAuth-redirect bug: the handler registers a social
+    // embedded wallet, then setSearchParams triggers a provider remount,
+    // then session registration needs to sign with that wallet. The map
+    // must survive the remount; otherwise signMessage falls through to
+    // the external bridge and fails with "No wallet found with connected
+    // address".
+    const { unmount } = render(
+      <Wrapper>
+        <div />
+      </Wrapper>,
+    );
+
+    const wallet = makeWallet(ADDRESS);
+    window.keychain_wallets!.addEmbeddedWallet(ADDRESS, wallet);
+    expect(window.keychain_wallets!.getEmbeddedWallet(ADDRESS)).toBe(wallet);
+
+    unmount();
+
+    // Wallet must still be resolvable after unmount so that a subsequent
+    // remount can use it without re-registration.
+    expect(window.keychain_wallets).toBeDefined();
+    expect(window.keychain_wallets!.getEmbeddedWallet(ADDRESS)).toBe(wallet);
+
+    render(
+      <Wrapper>
+        <div />
+      </Wrapper>,
+    );
+
+    const resolved = window.keychain_wallets!.getEmbeddedWallet(ADDRESS);
+    expect(resolved).toBe(wallet);
+
+    const response = await window.keychain_wallets!.signMessage(
+      ADDRESS,
+      "0xdeadbeef",
+    );
+    expect(response.success).toBe(true);
+    expect(wallet.signMessage).toHaveBeenCalledWith("0xdeadbeef");
+    expect(mockParent.externalSignMessage).not.toHaveBeenCalled();
+  });
+});

--- a/packages/keychain/src/hooks/wallets.tsx
+++ b/packages/keychain/src/hooks/wallets.tsx
@@ -55,15 +55,16 @@ export const WalletsProvider: React.FC<PropsWithChildren> = ({ children }) => {
   const [isConnecting, setIsConnecting] = useState<boolean>(false);
   const [error, setError] = useState<Error | null>(null);
 
-  // Instantiate KeychainWallets once parent is available
+  // Instantiate KeychainWallets once parent is available. Intentionally
+  // persist across unmount/remount: embedded wallets registered during an
+  // OAuth redirect (e.g. Turnkey social login) must survive the provider
+  // remount that runs when preset config loads after setSearchParams,
+  // otherwise session creation can't find the signer and falls through
+  // to the external bridge, which fails with "No wallet found with
+  // connected address".
   useEffect(() => {
     if (parent && !window.keychain_wallets) {
       window.keychain_wallets = new KeychainWallets(parent);
-
-      // Cleanup on unmount
-      return () => {
-        delete window.keychain_wallets;
-      };
     }
   }, [parent]);
 


### PR DESCRIPTION
## Summary

Follow-on to #2551. After OAuth social login, session registration was failing with `External bridge error: No wallet found with connected address 0x…`. This PR fixes the immediate bug and removes the architectural trap that caused it.

## The bug

The OAuth redirect handler in `useCreateController.ts` registers the Turnkey embedded wallet on `window.keychain_wallets`, then calls `setSearchParams` to restore the preset. That flips `isConfigLoading=true`, causing `Provider` to return a spinner — unmounting its subtree including `WalletsProvider`. Its cleanup ran `delete window.keychain_wallets`, wiping the embedded wallet registration.

On **Register Session** click, `controller.createSession` asks the keychain to sign with the social EOA. `KeychainWallets.signMessage` doesn't find the address, falls through to the parent's external wallet bridge, which doesn't have it either (Turnkey isn't a browser extension) → `No wallet found with connected address` from `bridge.ts:176`.

The existing recovery path in `connection.ts` (re-registering social embedded wallets from controller signers) is gated on `!window.keychain_wallets` at effect-run time and doesn't re-fire when the map is recreated, so it silently misses this flow.

## Fixes

1. **Don't wipe `window.keychain_wallets` on unmount** (`hooks/wallets.tsx`). Embedded wallet registrations survive any provider remount. Belt.

2. **Stop using `isConfigLoading` as a full-tree unmount switch** (`provider/index.tsx`). Render the spinner inside the provider tree instead of short-circuiting above it. Provider lifetimes now span config reloads, so no in-flight async work or module-level state gets orphaned. Suspenders — addresses the root cause of both this bug and #2551.

## Tests

- `provider/index.test.tsx` — assert `WalletsProvider` stays mounted across an `isConfigLoading` rerender (regression guard against re-introducing the short-circuit).
- `hooks/wallets.test.tsx` — assert embedded wallets registered before unmount are still resolvable after remount, and that `signMessage` on the registered address routes to the embedded wallet rather than the external bridge. This is the exact invariant the bug violated.

438 keychain tests pass locally.

## Risks

The architectural change trades a crisp unmount boundary for continuous provider lifetimes. Generally a safer default, but it broadens what can run during config loading.

**Medium:**
- Provider effects keep running during config reload — wallet-detection polling, posthog tracking, query-client retries, etc. Possible extra analytics events or network calls briefly firing against the wrong config. Worth watching telemetry after deploy.
- Child page state persists across preset reloads. If any flow re-triggers `isConfigLoading` mid-session, pages keep in-memory state instead of getting a fresh mount. Usually desirable, but a behavior delta.
- Downstream providers now mount with initial values and re-render when config arrives, rather than mounting once with final values. Effects keyed on `rpcUrl`/`controller`/`defaultChainId` fire an extra time. Likely fine, flagging.

**Low:**
- `KeychainWallets` captures `parent` once at construction. Stable today (ConnectionProvider doesn't unmount), but latent fragility if penpal ever gains a reconnect path.
- Wallet map is monotonic across a session. Bounded and reset by logout (full page reload).
- Provider test coverage is mock-heavy — asserts React kept the DOM node mounted, not that every real provider's internal state survives correctly. MSW-based auth E2E would close that gap; out of scope here.

## Test plan

- [ ] Google OAuth signup with preset + policies → Register Session succeeds (Android, iOS)
- [ ] Discord OAuth signup with preset + policies → Register Session succeeds
- [ ] OAuth login (existing account) with preset → Register Session succeeds
- [ ] Non-OAuth paths (passkey, password, external wallet) still work
- [ ] Auto-session creation path still works
- [ ] Preset config loading shows the spinner correctly (no visual regression)
- [ ] Repeated login attempts without full reload don't mis-route via stale wallet entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)