### PR TITLE
feat(analytics): track preset, restore DAU, fix super-prop casing

### DIFF
--- a/packages/keychain/src/components/provider/posthog.tsx
+++ b/packages/keychain/src/components/provider/posthog.tsx
@@ -23,7 +23,7 @@ export function PostHogProvider({ children }: PropsWithChildren) {
   useEffect(() => {
     if (!registered && controllerVersion) {
       posthog.registerForSession({
-        controllerVersion: controllerVersion.version,
+        controller_version: controllerVersion.version,
       });
       setRegistered(true);
     }

--- a/packages/keychain/src/components/provider/posthog.tsx
+++ b/packages/keychain/src/components/provider/posthog.tsx
@@ -2,6 +2,7 @@ import { useConnection } from "@/hooks/connection";
 import { useVersion } from "@/hooks/version";
 import { PostHogContext, PostHogWrapper } from "@cartridge/ui/utils";
 import { PropsWithChildren, useContext, useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
 
 export const posthog = new PostHogWrapper(
   import.meta.env.VITE_POSTHOG_KEY ?? "api key",
@@ -14,6 +15,7 @@ export const posthog = new PostHogWrapper(
 export function PostHogProvider({ children }: PropsWithChildren) {
   const { controller, origin, preset } = useConnection();
   const { controllerVersion } = useVersion();
+  const { pathname } = useLocation();
 
   // Track the last identified address
   const [lastIdentifiedAddress, setLastIdentifiedAddress] = useState<string>();
@@ -64,6 +66,12 @@ export function PostHogProvider({ children }: PropsWithChildren) {
       posthog.register({ preset });
     }
   }, [preset]);
+
+  // posthog-js-lite has no auto-pageview; fire explicitly on route change
+  // so DAU/weekly-active reflect real usage.
+  useEffect(() => {
+    posthog.capture("$pageview", { pathname });
+  }, [pathname]);
 
   return (
     <PostHogContext.Provider value={{ posthog }}>

--- a/packages/keychain/src/components/provider/posthog.tsx
+++ b/packages/keychain/src/components/provider/posthog.tsx
@@ -12,7 +12,7 @@ export const posthog = new PostHogWrapper(
 );
 
 export function PostHogProvider({ children }: PropsWithChildren) {
-  const { controller, origin } = useConnection();
+  const { controller, origin, preset } = useConnection();
   const { controllerVersion } = useVersion();
 
   // Track the last identified address
@@ -58,6 +58,12 @@ export function PostHogProvider({ children }: PropsWithChildren) {
       posthog.register({ chain_id: controller.chainId });
     }
   }, [controller]);
+
+  useEffect(() => {
+    if (preset) {
+      posthog.register({ preset });
+    }
+  }, [preset]);
 
   return (
     <PostHogContext.Provider value={{ posthog }}>


### PR DESCRIPTION
## Summary

Three small follow-ups to the keychain analytics instrumentation (#2512), in one PR because they all touch `packages/keychain/src/components/provider/posthog.tsx`.

- **Track `preset`** as a super-property. The `?preset=…` URL param drives config and theme — different dapps on one origin can use different presets, and conversely one preset can appear across origins. Without it we can't segment by game.
- **Rename `controllerVersion` → `controller_version`** super-property. Aligns with the other super-props (`origin`, `chain_id`) and the schema documented in `types/analytics.ts`. Cheap to do now, expensive once dashboards are built against the camelCase name.
- **Fire `$pageview` on route change.** `posthog-js-lite` has no autocapture, so `$pageview` was never firing — that's why DAU disappeared from the Controller project (last `$pageview` was Jan 2025, predating the lite-client switch). Capture it explicitly on every pathname change inside the iframe router.

## Test plan

- [x] `pnpm vitest run src/components/provider/` — 17/17 passing
- [ ] Deploy to staging and confirm `$pageview` events start arriving with `preset`, `controller_version`, `origin`, `chain_id` on them
- [ ] Confirm no duplicate `$pageview` firing per logical page load
- [ ] Rebuild Controller DAU insight from `$pageview` once data is flowing

🤖 Generated with [Claude Code](https://claude.com/claude-code)