### PR TITLE
fix: extend Coinbase onramp confirmation timeout to 90s

### DIFF
--- a/packages/keychain/src/hooks/starterpack/coinbase.ts
+++ b/packages/keychain/src/hooks/starterpack/coinbase.ts
@@ -50,8 +50,8 @@ export interface CoinbaseQuoteInput {
 const FALLBACK_POLL_INTERVAL_MS = 15_000;
 /** Fast poll interval after popup signals success (1 second) */
 const CONFIRMATION_POLL_INTERVAL_MS = 1_000;
-/** Timeout for the fast confirmation poll after popup reports success (15 seconds) */
-const CONFIRMATION_TIMEOUT_MS = 15_000;
+/** Timeout for the fast confirmation poll after popup reports success (90 seconds) */
+const CONFIRMATION_TIMEOUT_MS = 90_000;
 
 export interface UseCoinbaseOptions {
   onError?: (error: Error) => void;


### PR DESCRIPTION
## Summary
Extends the Coinbase onramp confirmation poll timeout from 15s to 90s so the frontend waits long enough for the backend to flip EIP-3009 orders from `SUBMITTED` to `COMPLETED` (that transition depends on an async webhook/worker that often lands after 15s).

Previously: after the Apple Pay popup closed and payment succeeded, the frontend would show "Coinbase payment failed. Please try again." even though the backend had processed the payment.

## Test plan
- [ ] Complete a starterpack purchase with Coinbase Apple Pay and confirm the success state appears without error
