### PR TITLE
fix(starterpack): quote Coinbase Apple Pay against USDC equivalent for non-USDC payment tokens

### DIFF
--- a/packages/keychain/src/components/purchasenew/checkout/onchain/index.tsx
+++ b/packages/keychain/src/components/purchasenew/checkout/onchain/index.tsx
@@ -24,6 +24,7 @@ import {
   exceedsLimit,
   useTokenBalance,
   useTokenFallback,
+  COINBASE_APPLE_PAY_MIN_USD,
 } from "@/hooks/starterpack";
 import { ControllerErrorAlert } from "@/components/ErrorAlert";
 import { Receiving } from "../../receiving";
@@ -81,6 +82,7 @@ export function OnchainCheckout() {
     coinbaseLimits,
     isFetchingCoinbaseLimits,
     fetchCoinbaseLimits,
+    applePayMinQuantity,
   } = useOnchainPurchaseContext();
   const { onCreditCardPurchase, isCoinflowLoading } =
     useCreditPurchaseContext();
@@ -123,9 +125,31 @@ export function OnchainCheckout() {
     return usdAmount * quantity;
   }, [usdAmount, quantity]);
 
+  // Derive the actual USDC the user will onramp. For non-USDC payment tokens
+  // convertedPrice.amount is the USDC equivalent from useTokenSelection's Ekubo
+  // quote, which usdAmount/totalUsdAmount (computed from totalCost/1e6) does not
+  // reflect. Fall back to totalUsdAmount when no converted price is available.
+  const totalUsdcAmount = useMemo(() => {
+    if (
+      isApplePaySelected &&
+      convertedPrice &&
+      convertedPrice.quantity === quantity
+    ) {
+      return (
+        Number(convertedPrice.amount) /
+        10 ** convertedPrice.tokenMetadata.decimals
+      );
+    }
+    return totalUsdAmount;
+  }, [isApplePaySelected, convertedPrice, quantity, totalUsdAmount]);
+
   const isApplePayAmountTooLow = useMemo(() => {
-    return isApplePaySelected && totalUsdAmount < 1.86;
-  }, [isApplePaySelected, totalUsdAmount]);
+    return (
+      isApplePaySelected &&
+      applePayMinQuantity === undefined &&
+      totalUsdcAmount < COINBASE_APPLE_PAY_MIN_USD
+    );
+  }, [isApplePaySelected, applePayMinQuantity, totalUsdcAmount]);
 
   // Pre-fetch Coinbase limits as soon as Apple Pay is selected so we can gate
   // the Buy button and skip a doomed order-create for users over the cap.
@@ -143,8 +167,8 @@ export function OnchainCheckout() {
     () =>
       isApplePaySelected &&
       !!coinbaseLimits &&
-      exceedsLimit(totalUsdAmount, coinbaseLimits),
-    [isApplePaySelected, coinbaseLimits, totalUsdAmount],
+      exceedsLimit(totalUsdcAmount, coinbaseLimits),
+    [isApplePaySelected, coinbaseLimits, totalUsdcAmount],
   );
 
   const quote = useMemo(() => {
@@ -514,6 +538,14 @@ export function OnchainCheckout() {
                 variant="warning"
                 title="Amount Too Low"
                 message="Minimum purchase amount is $2.00 for Apple Pay."
+              />
+            )}
+
+            {isApplePaySelected && applePayMinQuantity !== undefined && (
+              <ErrorCard
+                variant="warning"
+                title="Quantity Adjusted"
+                message={`Quantity set to ${applePayMinQuantity} to meet the $2.00 Apple Pay minimum.`}
               />
             )}
 

--- a/packages/keychain/src/components/purchasenew/review/onchain-cost.stories.tsx
+++ b/packages/keychain/src/components/purchasenew/review/onchain-cost.stories.tsx
@@ -72,6 +72,7 @@ const MockOnchainPurchaseProvider = ({ children }: { children: ReactNode }) => {
     popupClosed: false,
     paymentSuccess: false,
     coinbaseLsSwapId: undefined,
+    applePayMinQuantity: undefined,
     getTransactions: async () => [],
     coinbaseLimits: undefined,
     isFetchingCoinbaseLimits: false,

--- a/packages/keychain/src/components/purchasenew/wallet/wallet.stories.tsx
+++ b/packages/keychain/src/components/purchasenew/wallet/wallet.stories.tsx
@@ -79,6 +79,7 @@ const mockOnchainPurchaseValue: OnchainPurchaseContextType = {
   popupClosed: false,
   paymentSuccess: false,
   coinbaseLsSwapId: undefined,
+  applePayMinQuantity: undefined,
   getTransactions: async () => [],
   coinbaseLimits: undefined,
   isFetchingCoinbaseLimits: false,

--- a/packages/keychain/src/context/starterpack/onchain-purchase.tsx
+++ b/packages/keychain/src/context/starterpack/onchain-purchase.tsx
@@ -433,7 +433,14 @@ export const OnchainPurchaseProvider = ({
     if (quantity < requiredQuantity) {
       setQuantity(requiredQuantity);
       setApplePayMinQuantity(requiredQuantity);
-    } else if (applePayMinQuantity !== undefined) {
+    } else if (
+      applePayMinQuantity !== undefined &&
+      quantity !== applePayMinQuantity
+    ) {
+      // User manually moved quantity away from the bumped value, so the
+      // notice is no longer relevant. (Keep it while quantity matches the
+      // bumped value — otherwise the warning would flicker off the moment
+      // convertedPrice catches up after the bump.)
       setApplePayMinQuantity(undefined);
     }
   }, [

--- a/packages/keychain/src/context/starterpack/onchain-purchase.tsx
+++ b/packages/keychain/src/context/starterpack/onchain-purchase.tsx
@@ -32,6 +32,7 @@ import {
   useLayerswap,
   useTokenSelection,
   useCoinbase,
+  COINBASE_APPLE_PAY_MIN_USD,
   type TokenOption,
   type CoinbaseOrderResult,
   type CoinbaseTransactionResult,
@@ -68,6 +69,7 @@ export interface OnchainPurchaseContextType {
   setSelectedToken: (token: TokenOption | undefined) => void;
   convertedPrice: {
     amount: bigint;
+    quantity: number;
     tokenMetadata: { symbol: string; decimals: number };
   } | null;
   swapQuote: SwapQuote | null;
@@ -102,6 +104,8 @@ export interface OnchainPurchaseContextType {
   popupClosed: boolean;
   paymentSuccess: boolean;
   coinbaseLsSwapId: string | undefined;
+  /** Quantity we auto-bumped to so Apple Pay's per-transaction minimum is met. Undefined when no bump is active. */
+  applePayMinQuantity: number | undefined;
 
   // Coinbase limits-upgrade state
   coinbaseLimits: CoinbaseLimitsResult | undefined;
@@ -170,8 +174,13 @@ export const OnchainPurchaseProvider = ({
   );
 
   // Compose hooks
-  const { quantity, incrementQuantity, decrementQuantity, resetQuantity } =
-    useQuantity();
+  const {
+    quantity,
+    setQuantity,
+    incrementQuantity,
+    decrementQuantity,
+    resetQuantity,
+  } = useQuantity();
 
   const {
     selectedWallet,
@@ -278,6 +287,9 @@ export const OnchainPurchaseProvider = ({
   const [isCoinflowSelected, setIsCoinflowSelected] = useState(false);
   const [coinbaseLsSwapId, setCoinbaseLsSwapId] = useState<
     string | undefined
+  >();
+  const [applePayMinQuantity, setApplePayMinQuantity] = useState<
+    number | undefined
   >();
   const {
     orderId,
@@ -400,6 +412,37 @@ export const OnchainPurchaseProvider = ({
 
     setRequestedAmount(Number(convertedPrice.amount));
   }, [selectedPlatform, convertedPrice, setRequestedAmount]);
+
+  // Apple Pay has a per-transaction minimum ($1.86). If the starterpack's
+  // unit cost in USDC is below that, bump the quantity so the total clears
+  // the minimum and surface it to the user via applePayMinQuantity.
+  useEffect(() => {
+    if (!isApplePaySelected) {
+      if (applePayMinQuantity !== undefined) setApplePayMinQuantity(undefined);
+      return;
+    }
+    if (!convertedPrice || convertedPrice.quantity !== quantity) return;
+
+    const totalUsdc =
+      Number(convertedPrice.amount) /
+      10 ** convertedPrice.tokenMetadata.decimals;
+    const unitUsdc = totalUsdc / quantity;
+    if (!Number.isFinite(unitUsdc) || unitUsdc <= 0) return;
+
+    const requiredQuantity = Math.ceil(COINBASE_APPLE_PAY_MIN_USD / unitUsdc);
+    if (quantity < requiredQuantity) {
+      setQuantity(requiredQuantity);
+      setApplePayMinQuantity(requiredQuantity);
+    } else if (applePayMinQuantity !== undefined) {
+      setApplePayMinQuantity(undefined);
+    }
+  }, [
+    isApplePaySelected,
+    convertedPrice,
+    quantity,
+    setQuantity,
+    applePayMinQuantity,
+  ]);
 
   // USDC amount to onramp via Coinbase Apple Pay.
   //
@@ -714,6 +757,7 @@ export const OnchainPurchaseProvider = ({
     popupClosed,
     paymentSuccess,
     coinbaseLsSwapId,
+    applePayMinQuantity,
     onOnchainPurchase,
     onExternalConnect,
     onSendDeposit,

--- a/packages/keychain/src/context/starterpack/onchain-purchase.tsx
+++ b/packages/keychain/src/context/starterpack/onchain-purchase.tsx
@@ -4,6 +4,7 @@ import {
   useState,
   useCallback,
   useEffect,
+  useMemo,
   ReactNode,
 } from "react";
 import { useLocation } from "react-router-dom";
@@ -400,26 +401,41 @@ export const OnchainPurchaseProvider = ({
     setRequestedAmount(Number(convertedPrice.amount));
   }, [selectedPlatform, convertedPrice, setRequestedAmount]);
 
-  // Fetch Coinbase quote when Apple Pay is selected or quantity changes
+  // USDC amount to onramp via Coinbase Apple Pay.
+  //
+  // For Apple Pay the token selector auto-picks USDC, so convertedPrice.amount is
+  // the USDC equivalent of the starterpack (from a live Ekubo quote when the
+  // registry's paymentToken is not USDC, otherwise it's just the USDC totalCost).
+  // When a swap is required we add a 2% buffer so the on-chain swap — which runs
+  // minutes later against a fresh quote — has enough USDC after price drift.
+  const applePayUsdcAmount = useMemo<string | undefined>(() => {
+    if (!onchainDetails?.quote || !selectedToken || !convertedPrice) {
+      return undefined;
+    }
+    if (convertedPrice.quantity !== quantity) {
+      return undefined;
+    }
+
+    const needsSwap =
+      num.toHex(selectedToken.address) !==
+      num.toHex(onchainDetails.quote.paymentToken);
+    const usdcBaseUnits = needsSwap
+      ? (convertedPrice.amount * 102n) / 100n
+      : convertedPrice.amount;
+    return (Number(usdcBaseUnits) / 1_000_000).toFixed(6);
+  }, [onchainDetails, selectedToken, convertedPrice, quantity]);
+
+  // Fetch Coinbase quote when Apple Pay is selected or USDC amount changes
   useEffect(() => {
-    if (!isApplePaySelected || !onchainDetails?.quote) {
+    if (!isApplePaySelected || !applePayUsdcAmount) {
       return;
     }
 
-    const purchaseAmount = onchainDetails.quote.totalCost * BigInt(quantity);
-    const purchaseUSDCAmount = (Number(purchaseAmount) / 1_000_000).toFixed(6);
-
     getCoinbaseQuote({
-      purchaseUSDCAmount,
+      purchaseUSDCAmount: applePayUsdcAmount,
       sandbox: !isMainnet,
     });
-  }, [
-    isApplePaySelected,
-    onchainDetails,
-    quantity,
-    isMainnet,
-    getCoinbaseQuote,
-  ]);
+  }, [isApplePaySelected, applePayUsdcAmount, isMainnet, getCoinbaseQuote]);
 
   const onOnchainPurchase = useCallback(async () => {
     if (!controller || !starterpackDetails || !registryAddress) return;
@@ -630,14 +646,15 @@ export const OnchainPurchaseProvider = ({
       if (!onchainDetails?.quote) {
         throw new Error("Quote not loaded yet");
       }
+      if (!applePayUsdcAmount) {
+        throw new Error("USDC pricing not ready");
+      }
 
       const force = opts?.force ?? false;
       if (isCreatingOrder || (paymentLink && !force)) return;
 
-      const purchaseAmount = onchainDetails.quote.totalCost * BigInt(quantity);
-
       const order = await createCoinbaseOrder({
-        purchaseUSDCAmount: (Number(purchaseAmount) / 1_000_000).toString(),
+        purchaseUSDCAmount: applePayUsdcAmount,
       });
 
       if (order?.layerswapPayment?.swapId) {
@@ -648,7 +665,7 @@ export const OnchainPurchaseProvider = ({
     },
     [
       onchainDetails,
-      quantity,
+      applePayUsdcAmount,
       isCreatingOrder,
       paymentLink,
       createCoinbaseOrder,

--- a/packages/keychain/src/context/starterpack/onchain-purchase.tsx
+++ b/packages/keychain/src/context/starterpack/onchain-purchase.tsx
@@ -468,9 +468,15 @@ export const OnchainPurchaseProvider = ({
     return (Number(usdcBaseUnits) / 1_000_000).toFixed(6);
   }, [onchainDetails, selectedToken, convertedPrice, quantity]);
 
-  // Fetch Coinbase quote when Apple Pay is selected or USDC amount changes
+  // Fetch Coinbase quote when Apple Pay is selected or USDC amount changes.
+  // Skip when below Coinbase's Apple Pay minimum — the auto-bump effect will
+  // raise the quantity shortly and we'll retrigger with a valid amount.
+  // Firing the doomed request here only produces a lingering error toast.
   useEffect(() => {
     if (!isApplePaySelected || !applePayUsdcAmount) {
+      return;
+    }
+    if (Number(applePayUsdcAmount) < COINBASE_APPLE_PAY_MIN_USD) {
       return;
     }
 

--- a/packages/keychain/src/hooks/starterpack/coinbase.ts
+++ b/packages/keychain/src/hooks/starterpack/coinbase.ts
@@ -37,6 +37,9 @@ export const LIMIT_TYPE_LIFETIME_TRANSACTIONS = "lifetime_transactions";
 /** Sentinel for unlimited limit / remaining values. */
 export const UNLIMITED_SENTINEL = "-1";
 
+/** Coinbase's minimum USD amount for an Apple Pay onramp purchase. */
+export const COINBASE_APPLE_PAY_MIN_USD = 1.86;
+
 export interface CreateOrderInput {
   purchaseUSDCAmount: string;
 }

--- a/packages/keychain/src/hooks/starterpack/index.ts
+++ b/packages/keychain/src/hooks/starterpack/index.ts
@@ -39,7 +39,11 @@ export type {
   UseTokenFallbackReturn,
 } from "./token-fallback";
 
-export { useCoinbase, exceedsLimit } from "./coinbase";
+export {
+  useCoinbase,
+  exceedsLimit,
+  COINBASE_APPLE_PAY_MIN_USD,
+} from "./coinbase";
 export type {
   CreateOrderInput,
   UseCoinbaseOptions,

--- a/packages/keychain/src/hooks/starterpack/token-fallback.ts
+++ b/packages/keychain/src/hooks/starterpack/token-fallback.ts
@@ -1,11 +1,24 @@
 import { useState, useEffect, useRef } from "react";
 import { num, uint256 } from "starknet";
-import { fetchSwapQuote } from "@/utils/ekubo";
+import { fetchSwapQuote, USDC_ADDRESSES, USDCE_ADDRESSES } from "@/utils/ekubo";
 import { isOnchainStarterpack } from "@/context/starterpack/types";
 import type { OnchainStarterpackDetails } from "@/context/starterpack/types";
 import type { TokenOption } from "./token-selection";
 import type { ExternalPlatform } from "@cartridge/controller";
 import Controller from "@/utils/controller";
+
+/**
+ * USDC and USDC.e are 1:1 pegged stablecoins with the same decimals, so swap
+ * quotes between them are wasted Ekubo requests. Treat the pair as equivalent
+ * when estimating how much of a fallback candidate the user would need.
+ */
+function isUsdcVariantPair(a: string, b: string, chainId: string): boolean {
+  const usdc = USDC_ADDRESSES[chainId];
+  const usdce = USDCE_ADDRESSES[chainId];
+  if (!usdc || !usdce) return false;
+  const variants = new Set([num.toHex(usdc), num.toHex(usdce)]);
+  return variants.has(num.toHex(a)) && variants.has(num.toHex(b));
+}
 
 export interface UseTokenFallbackOptions {
   controller: Controller | undefined;
@@ -107,60 +120,68 @@ export function useTokenFallback({
 
     const checkFallbacks = async () => {
       setIsCheckingFallback(true);
+      try {
+        const candidates = availableTokens.filter(
+          (token) => token.address !== selectedToken.address,
+        );
 
-      const candidates = availableTokens.filter(
-        (token) => token.address !== selectedToken.address,
-      );
+        const ownerAddress = controller.address();
+        const chainId = controller.chainId();
+        const totalCost = quote.totalCost * BigInt(quantity);
 
-      const ownerAddress = controller.address();
-      const totalCost = quote.totalCost * BigInt(quantity);
+        for (const candidate of candidates) {
+          if (abortController.signal.aborted) return;
 
-      for (const candidate of candidates) {
-        if (abortController.signal.aborted) return;
+          try {
+            const isPaymentToken =
+              num.toHex(candidate.address) === num.toHex(quote.paymentToken);
 
-        try {
-          const isPaymentToken =
-            num.toHex(candidate.address) === num.toHex(quote.paymentToken);
+            let requiredAmount: bigint;
 
-          let requiredAmount: bigint;
+            if (
+              isPaymentToken ||
+              isUsdcVariantPair(candidate.address, quote.paymentToken, chainId)
+            ) {
+              // Same token or USDC ↔ USDC.e (1:1 pegged); no Ekubo quote needed.
+              requiredAmount = totalCost;
+            } else {
+              const swapResult = await fetchSwapQuote(
+                totalCost,
+                quote.paymentToken,
+                candidate.address,
+                chainId,
+                abortController.signal,
+              );
+              requiredAmount = swapResult.total;
+            }
 
-          if (isPaymentToken) {
-            requiredAmount = totalCost;
-          } else {
-            const swapResult = await fetchSwapQuote(
-              totalCost,
-              quote.paymentToken,
+            if (abortController.signal.aborted) return;
+
+            const balance = await fetchBalance(
+              controller,
               candidate.address,
-              controller.chainId(),
-              abortController.signal,
+              ownerAddress,
             );
-            requiredAmount = swapResult.total;
+
+            if (abortController.signal.aborted) return;
+
+            if (balance !== null && balance >= requiredAmount) {
+              setSelectedToken(candidate);
+              return;
+            }
+          } catch (error) {
+            console.warn(
+              `Fallback check failed for ${candidate.symbol}:`,
+              error,
+            );
+            continue;
           }
-
-          if (abortController.signal.aborted) return;
-
-          const balance = await fetchBalance(
-            controller,
-            candidate.address,
-            ownerAddress,
-          );
-
-          if (abortController.signal.aborted) return;
-
-          if (balance !== null && balance >= requiredAmount) {
-            setSelectedToken(candidate);
-            setIsCheckingFallback(false);
-            return;
-          }
-        } catch (error) {
-          console.warn(`Fallback check failed for ${candidate.symbol}:`, error);
-          continue;
         }
+      } finally {
+        // Always clear the loading flag, even on abort / early return, so the
+        // Buy button doesn't stick in a spinning state.
+        setIsCheckingFallback(false);
       }
-
-      if (abortController.signal.aborted) return;
-
-      setIsCheckingFallback(false);
     };
 
     checkFallbacks();

--- a/packages/keychain/src/utils/api/generated.ts
+++ b/packages/keychain/src/utils/api/generated.ts
@@ -370,6 +370,14 @@ export type AchievementResult = {
   items: Array<AchievementItem>;
 };
 
+export type ActivePaymasterBudget = {
+  __typename?: "ActivePaymasterBudget";
+  budget: Scalars["Int"];
+  budgetUnit: FeeUnit;
+  name: Scalars["String"];
+  spend: Scalars["Int"];
+};
+
 export type Activity = Node & {
   __typename?: "Activity";
   account: Account;
@@ -4590,6 +4598,7 @@ export type Query = {
   accountPrivate?: Maybe<AccountPrivate>;
   accounts?: Maybe<AccountConnection>;
   achievements: AchievementResult;
+  activePaymasterBudgets: Array<ActivePaymasterBudget>;
   activities: ActivityResult;
   balance: Balance;
   balances: BalanceConnection;

--- a/packages/ui/src/utils/api/cartridge/generated.ts
+++ b/packages/ui/src/utils/api/cartridge/generated.ts
@@ -365,6 +365,14 @@ export type AchievementResult = {
   items: Array<AchievementItem>;
 };
 
+export type ActivePaymasterBudget = {
+  __typename?: 'ActivePaymasterBudget';
+  budget: Scalars['Int'];
+  budgetUnit: FeeUnit;
+  name: Scalars['String'];
+  spend: Scalars['Int'];
+};
+
 export type Activity = Node & {
   __typename?: 'Activity';
   account: Account;
@@ -1033,6 +1041,28 @@ export type CoinbaseAmount = {
   currency: Scalars['String'];
 };
 
+export type CoinbaseDateOfBirthInput = {
+  /** Day of month as a 2-digit string (e.g. "05", "15"). */
+  day: Scalars['String'];
+  /** Month as a 2-digit string (e.g. "01", "08"). */
+  month: Scalars['String'];
+  /** 4-digit year (e.g. "1990"). */
+  year: Scalars['String'];
+};
+
+/**
+ * Status of the user's Coinbase onramp limits upgrade. INELIGIBLE means the user
+ * does not currently meet Coinbase's criteria to request an upgrade (not an error).
+ */
+export enum CoinbaseLimitUpgradeStatus {
+  Active = 'ACTIVE',
+  Inactive = 'INACTIVE',
+  Ineligible = 'INELIGIBLE',
+  Pending = 'PENDING',
+  Resubmit = 'RESUBMIT',
+  Unrequested = 'UNREQUESTED'
+}
+
 export enum CoinbaseNetwork {
   Arbitrum = 'ARBITRUM',
   Base = 'BASE',
@@ -1050,6 +1080,55 @@ export type CoinbaseOnrampFee = {
   currency: Scalars['String'];
   /** The type of fee (FEE_TYPE_NETWORK or FEE_TYPE_EXCHANGE). */
   type: Scalars['String'];
+};
+
+/**
+ * A single Coinbase onramp limit. A value of "-1" for limit or remaining means
+ * unlimited — this applies to lifetime transactions after a successful upgrade.
+ */
+export type CoinbaseOnrampLimit = {
+  __typename?: 'CoinbaseOnrampLimit';
+  /** Currency code (e.g. "USD"). Absent for lifetime_transactions. */
+  currency?: Maybe<Scalars['String']>;
+  /** The maximum limit value as a string-encoded integer. "-1" means unlimited. */
+  limit: Scalars['String'];
+  /** The limit type (e.g. "weekly_spending" or "lifetime_transactions"). */
+  limitType: Scalars['String'];
+  /** How much of the limit remains. "-1" means unlimited. */
+  remaining: Scalars['String'];
+};
+
+/** What a given limit would become after a successful upgrade. */
+export type CoinbaseOnrampLimitUpgrade = {
+  __typename?: 'CoinbaseOnrampLimitUpgrade';
+  limitType: Scalars['String'];
+  maxUpgrade: Scalars['String'];
+};
+
+/**
+ * The user's current Coinbase onramp limits along with any available upgrade
+ * option. requiredFields and maxUpgrades are only populated when upgradeStatus is
+ * UNREQUESTED or RESUBMIT.
+ */
+export type CoinbaseOnrampLimits = {
+  __typename?: 'CoinbaseOnrampLimits';
+  /** The user's current limits as reported by Coinbase. */
+  limits: Array<CoinbaseOnrampLimit>;
+  /**
+   * The limits this user would receive after a successful upgrade. Populated
+   * only when an upgrade option is available.
+   */
+  maxUpgrades?: Maybe<Array<CoinbaseOnrampLimitUpgrade>>;
+  /**
+   * Identity fields Coinbase requires for a submission. Populated only for
+   * UNREQUESTED and RESUBMIT statuses.
+   */
+  requiredFields?: Maybe<Array<Scalars['String']>>;
+  /**
+   * Current upgrade status for this user. INELIGIBLE means Coinbase did not
+   * return a limitUpgradeOptions entry and the upgrade prompt should be hidden.
+   */
+  upgradeStatus: CoinbaseLimitUpgradeStatus;
 };
 
 export type CoinbaseOnrampOrder = {
@@ -3133,6 +3212,13 @@ export type Mutation = {
    */
   sendPhoneVerification: SendVerificationResponse;
   signDocument: Attestation;
+  /**
+   * Submit identity fields (SSN last 4, date of birth) to request an upgrade of
+   * the user's Coinbase onramp limits. Coinbase processes the submission
+   * asynchronously — clients should poll coinbaseOnrampLimits after calling this.
+   * Identity fields are submitted to Coinbase immediately and never persisted.
+   */
+  submitCoinbaseLimitsUpgrade: CoinbaseOnrampLimits;
   transfer: TransferResponse;
   transferDeployment: Scalars['Boolean'];
   updateDeployment: Deployment;
@@ -3413,6 +3499,11 @@ export type MutationSendPhoneVerificationArgs = {
 
 export type MutationSignDocumentArgs = {
   input: AttestationInput;
+};
+
+
+export type MutationSubmitCoinbaseLimitsUpgradeArgs = {
+  input: SubmitCoinbaseLimitsUpgradeInput;
 };
 
 
@@ -4560,9 +4651,16 @@ export type Query = {
   accountPrivate?: Maybe<AccountPrivate>;
   accounts?: Maybe<AccountConnection>;
   achievements: AchievementResult;
+  activePaymasterBudgets: Array<ActivePaymasterBudget>;
   activities: ActivityResult;
   balance: Balance;
   balances: BalanceConnection;
+  /**
+   * Get the authenticated user's current Coinbase onramp spending limits along
+   * with any available limits-upgrade option. Clients should only show the
+   * upgrade prompt when upgradeStatus is UNREQUESTED or RESUBMIT.
+   */
+  coinbaseOnrampLimits: CoinbaseOnrampLimits;
   /**
    * Get a specific Coinbase onramp order by its ID.
    * Queries the internal database for the current status.
@@ -6693,6 +6791,18 @@ export type StripeStarterpackQuoteInput = {
   referralGroup?: InputMaybe<Scalars['String']>;
   registryAddress: Scalars['String'];
   starterpackId: Scalars['String'];
+};
+
+/**
+ * Identity fields required by Coinbase to initiate or retry a limits upgrade.
+ * These fields are submitted to Coinbase and immediately discarded — they must
+ * not be persisted or logged anywhere.
+ */
+export type SubmitCoinbaseLimitsUpgradeInput = {
+  /** The user's date of birth. */
+  dateOfBirth: CoinbaseDateOfBirthInput;
+  /** Last 4 digits of the user's SSN. Must be exactly 4 numeric characters. */
+  ssnLast4: Scalars['String'];
 };
 
 export type Team = Node & {


### PR DESCRIPTION
## Summary

Fixes Coinbase Apple Pay onramp for starterpacks priced in non-USDC tokens, and two adjacent issues in the fallback-token flow surfaced while testing.

- **USDC-equivalent pricing for Apple Pay** — Previously the Coinbase quote was requested with `totalCost / 1e6`, treating the raw payment-token amount as USDC. For non-USDC tokens this inflated the USD amount and hit Coinbase's upper limit. Now use `convertedPrice.amount` (already the USDC equivalent, since `useTokenSelection` auto-picks USDC for Apple Pay and runs an Ekubo swap quote when `paymentToken != USDC`), with a 2% buffer to cover price drift before the on-chain swap executes.
- **Auto-bump quantity to meet Apple Pay minimum** — Coinbase rejects Apple Pay onramps below $1.86. When a starterpack's per-unit USDC cost is below that, derive the minimum quantity that clears the threshold, bump automatically, and surface a "Quantity Adjusted" warning. Also fixed `isApplePayAmountTooLow` / `applePayLimitExceeded` to use the live USDC total from `convertedPrice` rather than `usdAmount` (= `totalCost / 1e6`), which was meaningless for non-USDC payment tokens.
- **Unstick the Buy button in token fallback** — `useTokenFallback`'s effect could leave `isCheckingFallback=true` forever when its cleanup aborted in-flight Ekubo fetches mid-loop — the early-return paths never cleared the flag. Wrapped the loop in `try/finally` so the flag always resets.
- **Skip redundant USDC ↔ USDC.e quote** — Both are added to `availableTokens` by default and are 1:1 pegged, so quoting `paymentToken → other-variant` is a wasted Ekubo request. Treat the pair as equivalent when estimating required balance.

No backend / GraphQL schema changes. The `chore(codegen)` commit is unrelated codegen drift from main that the pre-commit hook regenerated.

## Test plan

- [ ] Apple Pay on a USDC-priced starterpack — unchanged behavior
- [ ] Apple Pay on a non-USDC-priced starterpack above $1.86/unit — Coinbase quote succeeds at ~(unit price × qty) + 2% buffer
- [ ] Apple Pay on a cheap non-USDC-priced starterpack (< $1.86/unit) — quantity bumps to `ceil(1.86 / unit)`, "Quantity Adjusted" warning appears, Coinbase quote succeeds
- [ ] Decrementing after the bump: effect re-bumps silently back to minimum
- [ ] Deselecting Apple Pay clears the warning
- [ ] Controller + USDC path with insufficient balance — Buy button no longer stuck spinning after modal open/close; only ETH/STRK are probed by fallback (USDC.e skipped)
- [ ] Ekubo insufficient-liquidity surfaces via the existing `conversionError` path, not a Coinbase RPC error