### PR TITLE
fix: return to settings screen after adding a recovery account

### DIFF
--- a/packages/keychain/src/components/settings/Recovery.tsx
+++ b/packages/keychain/src/components/settings/Recovery.tsx
@@ -38,7 +38,9 @@ export function Recovery() {
       },
     ];
 
-    const url = createExecuteUrl(transactions);
+    const url = createExecuteUrl(transactions, {
+      returnTo: "/settings",
+    });
     navigate(url, { replace: true });
   }, [controller, externalOwnerAddress, navigate]);
 

--- a/packages/keychain/src/components/settings/index.tsx
+++ b/packages/keychain/src/components/settings/index.tsx
@@ -46,6 +46,7 @@ export function Settings() {
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
   const deleteMe = useDeleteMeMutation();
   const isRegisteredAccountsEnabled = useFeature("registered-accounts");
+  const isRecoveryAccountsEnabled = useFeature("recovery-accounts");
 
   const handleDeleteAccount = useCallback(async () => {
     const result = await deleteMe.mutateAsync({});
@@ -89,7 +90,7 @@ export function Settings() {
 
         <ConnectionsSection />
 
-        <RecoveryAccountSection />
+        {isRecoveryAccountsEnabled && <RecoveryAccountSection />}
 
         {/* {featureFlags.delegate && (
           <section className="space-y-4">

--- a/packages/keychain/src/components/settings/index.tsx
+++ b/packages/keychain/src/components/settings/index.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useState } from "react";
-import { useNavigation } from "@/context/navigation";
 import { useConnection } from "@/hooks/connection";
 import { processControllerQuery } from "@/utils/signers";
 import {
@@ -32,6 +31,7 @@ import { SectionHeader } from "./section-header";
 import { SessionsSection } from "./sessions/sessions-section";
 import { SignersSection } from "./signers/signers-section";
 import { ConnectionsSection } from "./connections/connections-section";
+import { RecoveryAccountSection } from "./recovery/recovery-section";
 import { useFeature } from "@/hooks/features";
 
 const registeredAccounts: RegisteredAccount[] = [
@@ -43,7 +43,6 @@ const registeredAccounts: RegisteredAccount[] = [
 
 export function Settings() {
   const { logout, controller, chainId } = useConnection();
-  const { navigate } = useNavigation();
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
   const deleteMe = useDeleteMeMutation();
   const isRegisteredAccountsEnabled = useFeature("registered-accounts");
@@ -90,23 +89,7 @@ export function Settings() {
 
         <ConnectionsSection />
 
-        <section className="space-y-4">
-          <SectionHeader
-            title="Recovery Accounts"
-            description="Recovery accounts are Starknet wallets that can be used to recover your Controller if you lose access to your signers."
-          />
-          <Button
-            type="button"
-            variant="outline"
-            className="py-2.5 px-3 text-foreground-300 gap-1"
-            onClick={() => navigate("/settings/recovery")}
-          >
-            <PlusIcon size="sm" variant="line" />
-            <span className="normal-case font-normal font-sans text-sm">
-              Add Recovery Account
-            </span>
-          </Button>
-        </section>
+        <RecoveryAccountSection />
 
         {/* {featureFlags.delegate && (
           <section className="space-y-4">

--- a/packages/keychain/src/components/settings/recovery/index.ts
+++ b/packages/keychain/src/components/settings/recovery/index.ts
@@ -1,0 +1,2 @@
+export * from "./recovery-account-card";
+export * from "./recovery-section";

--- a/packages/keychain/src/components/settings/recovery/recovery-account-card.tsx
+++ b/packages/keychain/src/components/settings/recovery/recovery-account-card.tsx
@@ -1,0 +1,24 @@
+import { Card } from "@cartridge/controller-ui";
+import { formatAddress } from "@cartridge/controller-ui/utils";
+import { useStarkName } from "@/hooks/starknetid";
+
+interface RecoveryAccountCardProps {
+  address: string;
+}
+
+export const RecoveryAccountCard = ({ address }: RecoveryAccountCardProps) => {
+  const { name } = useStarkName({ address });
+
+  return (
+    <Card className="py-2.5 px-3 flex flex-row justify-between items-center bg-background-200">
+      <p className="text-sm text-foreground-100">
+        {name ?? formatAddress(address, { first: 6, last: 4 })}
+      </p>
+      {name && (
+        <p className="text-xs text-foreground-300">
+          {formatAddress(address, { first: 6, last: 4 })}
+        </p>
+      )}
+    </Card>
+  );
+};

--- a/packages/keychain/src/components/settings/recovery/recovery-section.tsx
+++ b/packages/keychain/src/components/settings/recovery/recovery-section.tsx
@@ -1,0 +1,38 @@
+import { Button, PlusIcon } from "@cartridge/controller-ui";
+import { SectionHeader } from "../section-header";
+import { RecoveryAccountCard } from "./recovery-account-card";
+import { useNavigation } from "@/context/navigation";
+// import { useExternalOwners } from "@/hooks/external";
+
+export const RecoveryAccountSection = () => {
+  const { navigate } = useNavigation();
+  // const { externalOwners } = useExternalOwners();
+  const externalOwners: string[] = [];
+
+  return (
+    <section className="space-y-4">
+      <SectionHeader
+        title="Recovery Accounts"
+        description="Recovery accounts are Starknet wallets that can be used to recover your Controller if you lose access to your signers."
+      />
+      {externalOwners.length > 0 && (
+        <div className="space-y-3">
+          {externalOwners.map((address) => (
+            <RecoveryAccountCard key={address} address={address} />
+          ))}
+        </div>
+      )}
+      <Button
+        type="button"
+        variant="outline"
+        className="py-2.5 px-3 text-foreground-300 gap-1"
+        onClick={() => navigate("/settings/recovery")}
+      >
+        <PlusIcon size="sm" variant="line" />
+        <span className="normal-case font-normal font-sans text-sm">
+          Add Recovery Account
+        </span>
+      </Button>
+    </section>
+  );
+};

--- a/packages/keychain/src/hooks/external.ts
+++ b/packages/keychain/src/hooks/external.ts
@@ -17,31 +17,46 @@ export function useExternalOwners() {
   );
 
   useEffect(() => {
+    let mounted = true;
+
     const init = async () => {
       if (!controller) return;
 
-      const events = await controller.provider.getEvents({
-        address: controller.address(),
-        from_block: { block_number: 0 },
-        keys: [[externalOwnerRegisteredSelector, externalOwnerRemovedSelector]],
-        chunk_size: 100,
-      });
-
       const external = new Set<string>();
+      let continuationToken: string | undefined = "0";
 
-      for (const event of events.events) {
-        if (event.keys[0] === externalOwnerRegisteredSelector) {
-          external.add(event.data[0]);
+      while (continuationToken && mounted) {
+        const events = await controller.provider.getEvents({
+          address: controller.address(),
+          from_block: { block_number: 1151644 }, // controller class hash deployed
+          keys: [
+            [externalOwnerRegisteredSelector, externalOwnerRemovedSelector],
+          ],
+          chunk_size: 100,
+          continuation_token:
+            continuationToken === "0" ? undefined : continuationToken,
+        });
+
+        for (const event of events.events) {
+          if (event.keys[0] === externalOwnerRegisteredSelector) {
+            external.add(event.data[0]);
+          }
+          if (event.keys[0] === externalOwnerRemovedSelector) {
+            external.delete(event.data[0]);
+          }
         }
-        if (event.keys[0] === externalOwnerRemovedSelector) {
-          external.delete(event.data[0]);
-        }
+
+        continuationToken = events.continuation_token;
       }
 
       setExternalOwners(Array.from(external.values()));
     };
 
     init();
+
+    return () => {
+      mounted = false;
+    };
   }, [
     controller,
     provider,

--- a/packages/keychain/src/hooks/features.tsx
+++ b/packages/keychain/src/hooks/features.tsx
@@ -17,7 +17,8 @@ export type Feature =
   | "apple-pay-support"
   | "coinflow-support"
   | "sms"
-  | "registered-accounts";
+  | "registered-accounts"
+  | "recovery-accounts";
 
 // --- Helper Functions ---
 

--- a/packages/keychain/src/hooks/starknetid.ts
+++ b/packages/keychain/src/hooks/starknetid.ts
@@ -2,6 +2,26 @@ import { useQuery } from "react-query";
 import { useConnection } from "@/hooks/connection";
 import { useState } from "react";
 
+export const useStarkName = ({ address }: { address: string }) => {
+  const { controller } = useConnection();
+  const provider = controller?.provider;
+
+  const { data, isFetching } = useQuery({
+    enabled: !!address && !!provider,
+    queryKey: ["starkname", address],
+    queryFn: async () => {
+      try {
+        const name = await provider?.getStarkName(address);
+        return name ?? null;
+      } catch {
+        return null;
+      }
+    },
+  });
+
+  return { name: data ?? null, isFetching };
+};
+
 export const useStarkAddress = ({ name }: { name: string }) => {
   const { controller } = useConnection();
   const provider = controller?.provider;

--- a/packages/keychain/src/utils/connection/execute.ts
+++ b/packages/keychain/src/utils/connection/execute.ts
@@ -41,6 +41,7 @@ export function createExecuteUrl(
     resolve?: (res: InvokeFunctionResponse | ConnectError) => void;
     reject?: (reason?: unknown) => void;
     onCancel?: () => void;
+    returnTo?: string;
   } = {},
 ): string {
   const id = generateCallbackId();
@@ -63,6 +64,10 @@ export function createExecuteUrl(
   if (options.error) {
     const errorJson = JSON.stringify(options.error);
     url += `&error=${encodeURIComponent(errorJson)}`;
+  }
+
+  if (options.returnTo) {
+    url += `&returnTo=${encodeURIComponent(options.returnTo)}`;
   }
 
   return url;


### PR DESCRIPTION
* return to the settings screen after adding a recovery account (external owner)
* we can only retrieve recovery accounts using `provider.getEvents()`, but it takes 90 calls to the provider to finish (since the controller class hash block deployment), and it only gets worse with time
* therefore, the recovery accounts are not being displayed at the settings screen to avoid an impact on performance