### PR TITLE
fix(keychain): auto-focus password field when password method selected

### DIFF
--- a/packages/keychain/src/components/connect/create/password/PasswordForm.tsx
+++ b/packages/keychain/src/components/connect/create/password/PasswordForm.tsx
@@ -63,6 +63,7 @@ export function PasswordForm({
           placeholder="Enter password (min. 8 characters)"
           autoComplete={isLogin ? "current-password" : "new-password"}
           disabled={isLoading}
+          autoFocus
         />
       </div>
 


### PR DESCRIPTION
## Summary

Auto-focus the password input when the user selects the password sign-in method, so they can start typing immediately without an extra click.

## Changes

- Added `autoFocus` to the password `Input` in `PasswordForm` ([PasswordForm.tsx:66](packages/keychain/src/components/connect/create/password/PasswordForm.tsx)).

The form is conditionally mounted only after the user picks the password method in `ChooseSignupMethodForm`, so the focus fires exactly on that transition — including the auto-show case for login when password is the only available option.

## Test plan

- [ ] Pick an account with password as an auth method, click the password button in the sign-in sheet, confirm the password field is focused and ready for input.
- [ ] For an account where password is the only auth option, open the sign-in sheet and confirm the password field auto-focuses without extra interaction.