### PR TITLE
fix(slot): temporarily disable slot funding, point users to Discord

### DIFF
--- a/packages/keychain/src/components/slot/fund.tsx
+++ b/packages/keychain/src/components/slot/fund.tsx
@@ -32,26 +32,24 @@ const SLOT_FUNDING_DISABLED: boolean = true;
 export function Fund() {
   if (SLOT_FUNDING_DISABLED) {
     return (
-      <HeaderInner
-        variant="expanded"
-        Icon={AlertIcon}
-        title="Slot Funding Temporarily Unavailable"
-        hideIcon
-        description={
-          <>
+      <LayoutContent className="flex flex-1 flex-col items-center justify-center gap-6 py-10 text-center">
+        <AlertIcon size="3xl" className="text-foreground-400" />
+        <div className="flex flex-col gap-2">
+          <h2 className="text-lg font-semibold text-foreground-100">
+            Slot Funding Temporarily Unavailable
+          </h2>
+          <p className="text-sm text-foreground-300 max-w-sm mx-auto">
             Slot funding is currently out of order. To top up your paymasters,
-            please reach out in the Cartridge support channel on{" "}
-            <Link
-              to={CARTRIDGE_DISCORD_LINK}
-              target="_blank"
-              className="inline-flex items-center gap-1 hover:underline text-foreground-200 font-semibold"
-            >
-              Discord
-              <ExternalIcon size="sm" />
-            </Link>
-          </>
-        }
-      />
+            please reach out in the Cartridge support channel on Discord.
+          </p>
+        </div>
+        <Link to={CARTRIDGE_DISCORD_LINK} target="_blank">
+          <Button variant="secondary">
+            Contact Support on Discord
+            <ExternalIcon size="sm" />
+          </Button>
+        </Link>
+      </LayoutContent>
     );
   }
 

--- a/packages/keychain/src/components/slot/fund.tsx
+++ b/packages/keychain/src/components/slot/fund.tsx
@@ -1,13 +1,15 @@
 import { useEffect, useState, useMemo } from "react";
-import { useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { useTeamsQuery } from "@cartridge/controller-ui/utils/api/cartridge";
 import { Purchase, PurchaseType } from "../purchase";
 import {
+  AlertIcon,
   Button,
   Card,
   CardHeader,
   CardTitle,
   CheckIcon,
+  ExternalIcon,
   HeaderInner,
   LayoutContent,
   LayoutFooter,
@@ -17,6 +19,7 @@ import {
 import { Team, Teams } from "./teams";
 import { formatBalance } from "@/hooks/tokens";
 import { useNavigation } from "@/context/navigation";
+import { CARTRIDGE_DISCORD_LINK } from "@/constants";
 
 enum FundState {
   SELECT_TEAM,
@@ -24,7 +27,38 @@ enum FundState {
   SUCCESS,
 }
 
+const SLOT_FUNDING_DISABLED: boolean = true;
+
 export function Fund() {
+  if (SLOT_FUNDING_DISABLED) {
+    return (
+      <HeaderInner
+        variant="expanded"
+        Icon={AlertIcon}
+        title="Slot Funding Temporarily Unavailable"
+        hideIcon
+        description={
+          <>
+            Slot funding is currently out of order. To top up your paymasters,
+            please reach out in the Cartridge support channel on{" "}
+            <Link
+              to={CARTRIDGE_DISCORD_LINK}
+              target="_blank"
+              className="inline-flex items-center gap-1 hover:underline text-foreground-200 font-semibold"
+            >
+              Discord
+              <ExternalIcon size="sm" />
+            </Link>
+          </>
+        }
+      />
+    );
+  }
+
+  return <FundInner />;
+}
+
+function FundInner() {
   const { navigate } = useNavigation();
   const { pathname } = useLocation();
   const [state, setState] = useState<FundState>(FundState.SELECT_TEAM);


### PR DESCRIPTION
## Summary
- Gates the slot fund flow behind a `SLOT_FUNDING_DISABLED` flag (currently `true`) while paymaster top-ups are being handled manually.
- When the gate is on, the `/slot/fund` route renders a maintenance banner directing users to the Cartridge Discord support channel instead of the team selection flow.
- Existing funding logic is moved into a `FundInner` component so no hooks run behind the gate; flipping the flag back to `false` restores prior behavior with no other changes.

## Test plan
- [ ] Visit `/slot/fund` and confirm the "Slot Funding Temporarily Unavailable" banner renders with a working Discord link.
- [ ] Flip `SLOT_FUNDING_DISABLED` to `false` locally and confirm the original team-selection + purchase flow still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)