### PR TITLE
feat(slot): add STRK as a payment option in fund flow

### DIFF
--- a/packages/keychain/src/components/slot/crypto-fund.tsx
+++ b/packages/keychain/src/components/slot/crypto-fund.tsx
@@ -30,7 +30,7 @@ import {
   SelectContent,
   SelectItem,
   SlotIcon,
-  StarknetIcon,
+  StarknetColorIcon,
   Thumbnail,
   TokenCard,
   TokenSelectHeader,
@@ -139,7 +139,7 @@ function SlotCryptoFundInner({
         name: "Starknet Token",
         decimals: 18,
         address: STRK_CONTRACT_ADDRESS,
-        icon: <StarknetIcon />,
+        icon: <StarknetColorIcon />,
         defaultAmount: "10",
         min: 1,
         max: 50000,
@@ -320,7 +320,7 @@ function SlotCryptoFundInner({
             />
             <TokenCard
               title="STRK"
-              image={<StarknetIcon />}
+              image={<StarknetColorIcon />}
               amount={`${teamStrkBalance} STRK`}
               value={teamStrkUsdValue}
               className="pointer-events-none"

--- a/packages/keychain/src/components/slot/crypto-fund.tsx
+++ b/packages/keychain/src/components/slot/crypto-fund.tsx
@@ -55,6 +55,8 @@ type SlotFundingToken = {
   address: string;
   icon: string;
   defaultAmount: string;
+  min: number;
+  max: number;
 };
 
 export type SlotFundingResult = {
@@ -122,6 +124,8 @@ function SlotCryptoFundInner({
         address: usdcAddress,
         icon: "https://static.cartridge.gg/tokens/usdc.svg",
         defaultAmount: "10",
+        min: 1,
+        max: 2000,
       },
       {
         key: "STRK",
@@ -131,6 +135,8 @@ function SlotCryptoFundInner({
         address: STRK_CONTRACT_ADDRESS,
         icon: STRK_ICON,
         defaultAmount: "10",
+        min: 1,
+        max: 50000,
       },
     ];
   }, [controller]);
@@ -189,15 +195,32 @@ function SlotCryptoFundInner({
     [amountInput, selectedToken.decimals],
   );
 
+  const minAmount = useMemo(
+    () =>
+      parseTokenAmount(selectedToken.min.toString(), selectedToken.decimals),
+    [selectedToken.min, selectedToken.decimals],
+  );
+  const maxAmount = useMemo(
+    () =>
+      parseTokenAmount(selectedToken.max.toString(), selectedToken.decimals),
+    [selectedToken.max, selectedToken.decimals],
+  );
+
   const isSubmitting = phase !== "idle";
   const hasInsufficientBalance =
     amount !== undefined && balance !== null && amount > balance;
+  const isBelowMin =
+    amount !== undefined && minAmount !== undefined && amount < minAmount;
+  const isAboveMax =
+    amount !== undefined && maxAmount !== undefined && amount > maxAmount;
   const canSubmit =
     !!controller &&
     !!extAccount &&
     amount !== undefined &&
     amount > 0n &&
     !hasInsufficientBalance &&
+    !isBelowMin &&
+    !isAboveMax &&
     !isSubmitting;
 
   const onConnect = useCallback(
@@ -374,6 +397,20 @@ function SlotCryptoFundInner({
             variant="error"
             title="Invalid Amount"
             description={`Enter a valid ${selectedToken.symbol} amount.`}
+          />
+        )}
+        {isBelowMin && (
+          <ErrorAlert
+            variant="error"
+            title="Amount Too Low"
+            description={`Minimum is ${selectedToken.min} ${selectedToken.symbol}.`}
+          />
+        )}
+        {isAboveMax && (
+          <ErrorAlert
+            variant="error"
+            title="Amount Too High"
+            description={`Maximum is ${selectedToken.max.toLocaleString()} ${selectedToken.symbol}.`}
           />
         )}
         {hasInsufficientBalance && (

--- a/packages/keychain/src/components/slot/crypto-fund.tsx
+++ b/packages/keychain/src/components/slot/crypto-fund.tsx
@@ -30,6 +30,7 @@ import {
   SelectContent,
   SelectItem,
   SlotIcon,
+  StarknetIcon,
   Thumbnail,
   TokenCard,
   TokenSelectHeader,
@@ -43,10 +44,7 @@ import {
   useFeeToken,
 } from "@/hooks/tokens";
 import { USDC_ADDRESSES } from "@/utils/ekubo";
-import {
-  STRK_CONTRACT_ADDRESS,
-  STRK_LOGO_URL,
-} from "@cartridge/controller-ui/utils";
+import { STRK_CONTRACT_ADDRESS } from "@cartridge/controller-ui/utils";
 import { ErrorAlert } from "@/components/ErrorAlert";
 import { createStarknetCryptoPayment } from "@/hooks/payments/crypto";
 import { Team } from "./teams";
@@ -57,7 +55,7 @@ type SlotFundingToken = {
   name: string;
   decimals: number;
   address: string;
-  icon: string;
+  icon: string | React.ReactNode;
   defaultAmount: string;
   min: number;
   max: number;
@@ -141,7 +139,7 @@ function SlotCryptoFundInner({
         name: "Starknet Token",
         decimals: 18,
         address: STRK_CONTRACT_ADDRESS,
-        icon: STRK_LOGO_URL,
+        icon: <StarknetIcon />,
         defaultAmount: "10",
         min: 1,
         max: 50000,
@@ -322,7 +320,7 @@ function SlotCryptoFundInner({
             />
             <TokenCard
               title="STRK"
-              image={STRK_LOGO_URL}
+              image={<StarknetIcon />}
               amount={`${teamStrkBalance} STRK`}
               value={teamStrkUsdValue}
               className="pointer-events-none"

--- a/packages/keychain/src/components/slot/crypto-fund.tsx
+++ b/packages/keychain/src/components/slot/crypto-fund.tsx
@@ -37,7 +37,11 @@ import {
 } from "@cartridge/controller-ui";
 import { useConnection } from "@/hooks/connection";
 import { useNavigation } from "@/context/navigation";
-import { formatBalance } from "@/hooks/tokens";
+import {
+  convertTokenAmountToUSD,
+  formatBalance,
+  useFeeToken,
+} from "@/hooks/tokens";
 import { USDC_ADDRESSES } from "@/utils/ekubo";
 import { STRK_CONTRACT_ADDRESS } from "@cartridge/controller-ui/utils";
 import { ErrorAlert } from "@/components/ErrorAlert";
@@ -97,8 +101,12 @@ function SlotCryptoFundInner({
     return () => setOnBackCallback(undefined);
   }, [setOnBackCallback, onBack]);
 
+  const { token: feeToken } = useFeeToken();
   const teamUsdBalance = formatBalance(BigInt(team.credits || 0), 8, 2);
   const teamStrkBalance = formatBalance(BigInt(team.strk || 0), 6, 2);
+  const teamStrkUsdValue = feeToken?.price
+    ? convertTokenAmountToUSD(BigInt(team.strk || 0), 6, feeToken.price)
+    : undefined;
 
   const [selectedTokenKey, setSelectedTokenKey] =
     useState<SlotFundingToken["key"]>("USDC");
@@ -316,6 +324,7 @@ function SlotCryptoFundInner({
               title="STRK"
               image={STRK_ICON}
               amount={`${teamStrkBalance} STRK`}
+              value={teamStrkUsdValue}
               className="pointer-events-none"
             />
           </TokenSummary>

--- a/packages/keychain/src/components/slot/crypto-fund.tsx
+++ b/packages/keychain/src/components/slot/crypto-fund.tsx
@@ -39,9 +39,13 @@ import { useConnection } from "@/hooks/connection";
 import { useNavigation } from "@/context/navigation";
 import { formatBalance } from "@/hooks/tokens";
 import { USDC_ADDRESSES } from "@/utils/ekubo";
+import { STRK_CONTRACT_ADDRESS } from "@cartridge/controller-ui/utils";
 import { ErrorAlert } from "@/components/ErrorAlert";
 import { createStarknetCryptoPayment } from "@/hooks/payments/crypto";
 import { Team } from "./teams";
+
+const STRK_ICON =
+  "https://imagedelivery.net/0xPAQaDtnQhBs8IzYRIlNg/1b126320-367c-48ed-cf5a-ba7580e49600/logo";
 
 type SlotFundingToken = {
   key: "USDC" | "STRK";
@@ -92,6 +96,7 @@ function SlotCryptoFundInner({
   }, [setOnBackCallback, onBack]);
 
   const teamUsdBalance = formatBalance(BigInt(team.credits || 0), 8, 2);
+  const teamStrkBalance = formatBalance(BigInt(team.strk || 0), 6, 2);
 
   const [selectedTokenKey, setSelectedTokenKey] =
     useState<SlotFundingToken["key"]>("USDC");
@@ -116,6 +121,15 @@ function SlotCryptoFundInner({
         decimals: 6,
         address: usdcAddress,
         icon: "https://static.cartridge.gg/tokens/usdc.svg",
+        defaultAmount: "10",
+      },
+      {
+        key: "STRK",
+        symbol: "STRK",
+        name: "Starknet Token",
+        decimals: 18,
+        address: STRK_CONTRACT_ADDRESS,
+        icon: STRK_ICON,
         defaultAmount: "10",
       },
     ];
@@ -273,6 +287,12 @@ function SlotCryptoFundInner({
               image="https://static.cartridge.gg/media/usd_icon.svg"
               amount={`${teamUsdBalance} USD`}
               value={`$${teamUsdBalance}`}
+              className="pointer-events-none"
+            />
+            <TokenCard
+              title="STRK"
+              image={STRK_ICON}
+              amount={`${teamStrkBalance} STRK`}
               className="pointer-events-none"
             />
           </TokenSummary>

--- a/packages/keychain/src/components/slot/crypto-fund.tsx
+++ b/packages/keychain/src/components/slot/crypto-fund.tsx
@@ -43,13 +43,13 @@ import {
   useFeeToken,
 } from "@/hooks/tokens";
 import { USDC_ADDRESSES } from "@/utils/ekubo";
-import { STRK_CONTRACT_ADDRESS } from "@cartridge/controller-ui/utils";
+import {
+  STRK_CONTRACT_ADDRESS,
+  STRK_LOGO_URL,
+} from "@cartridge/controller-ui/utils";
 import { ErrorAlert } from "@/components/ErrorAlert";
 import { createStarknetCryptoPayment } from "@/hooks/payments/crypto";
 import { Team } from "./teams";
-
-const STRK_ICON =
-  "https://imagedelivery.net/0xPAQaDtnQhBs8IzYRIlNg/1b126320-367c-48ed-cf5a-ba7580e49600/logo";
 
 type SlotFundingToken = {
   key: "USDC" | "STRK";
@@ -141,7 +141,7 @@ function SlotCryptoFundInner({
         name: "Starknet Token",
         decimals: 18,
         address: STRK_CONTRACT_ADDRESS,
-        icon: STRK_ICON,
+        icon: STRK_LOGO_URL,
         defaultAmount: "10",
         min: 1,
         max: 50000,
@@ -322,7 +322,7 @@ function SlotCryptoFundInner({
             />
             <TokenCard
               title="STRK"
-              image={STRK_ICON}
+              image={STRK_LOGO_URL}
               amount={`${teamStrkBalance} STRK`}
               value={teamStrkUsdValue}
               className="pointer-events-none"

--- a/packages/ui/src/utils/erc20.ts
+++ b/packages/ui/src/utils/erc20.ts
@@ -39,9 +39,6 @@ export const LORDS_CONTRACT_ADDRESS = getChecksumAddress(
   "0x0124aeb495b947201f5fac96fd1138e326ad86195b98df6dec9009158a533b49",
 );
 
-export const STRK_LOGO_URL =
-  "https://imagedelivery.net/0xPAQaDtnQhBs8IzYRIlNg/1b126320-367c-48ed-cf5a-ba7580e49600/logo";
-
 export class ERC20Contract {
   private address: string;
   private logoUrl?: string;

--- a/packages/ui/src/utils/erc20.ts
+++ b/packages/ui/src/utils/erc20.ts
@@ -39,6 +39,9 @@ export const LORDS_CONTRACT_ADDRESS = getChecksumAddress(
   "0x0124aeb495b947201f5fac96fd1138e326ad86195b98df6dec9009158a533b49",
 );
 
+export const STRK_LOGO_URL =
+  "https://imagedelivery.net/0xPAQaDtnQhBs8IzYRIlNg/1b126320-367c-48ed-cf5a-ba7580e49600/logo";
+
 export class ERC20Contract {
   private address: string;
   private logoUrl?: string;


### PR DESCRIPTION
## Summary
- Adds STRK alongside USDC in the slot fund token dropdown (canonical STRK address, 18 decimals).
- Shows the team's STRK balance in the Balances card on the funding screen.
- Enforces per-token min/max amounts: USDC `[1, 2000]`, STRK `[1, 50000]`. Out-of-range entries trigger an "Amount Too Low" / "Amount Too High" alert and disable submit.
- Backend `createCryptoPayment` already classifies the STRK address and routes the payment to the team's `strk` pool — this PR is purely frontend wiring.

## Test plan
- [x] `vitest crypto-fund` passes
- [x] `tsc --noEmit` clean
- [ ] Manual: select STRK from the dropdown on /slot/fund, fund a team, confirm balance increments
- [ ] Manual: enter `0.5`, `2001` USDC and `50001` STRK — verify alerts appear and submit is disabled