### PR TITLE
fix(payment): stale payment failure

### DIFF
--- a/packages/keychain/src/components/purchasenew/pending/bridge.tsx
+++ b/packages/keychain/src/components/purchasenew/pending/bridge.tsx
@@ -85,6 +85,7 @@ export function BridgePending({
   const onOnchainPurchase = onchainContext.onOnchainPurchase;
   const orderStatus = onchainContext.orderStatus;
   const orderTxHash = onchainContext.orderTxHash;
+  const paymentSuccess = onchainContext.paymentSuccess;
 
   const [initialBridgeHash, setInitialBridgeHash] = useState(bridgeTxHash);
 
@@ -110,13 +111,14 @@ export function BridgePending({
   // Handle Apple Pay (Coinbase) order status from context polling
   useEffect(() => {
     if (paymentMethod === "apple-pay" && !paymentCompleted) {
-      if (orderStatus === CoinbaseOnrampStatus.Completed) {
+      if (paymentSuccess || orderStatus === CoinbaseOnrampStatus.Completed) {
+        setError(undefined);
         setDepositCompleted(true);
       } else if (orderStatus === CoinbaseOnrampStatus.Failed) {
         setError(new Error("Coinbase payment failed. Please try again."));
       }
     }
-  }, [paymentMethod, orderStatus, paymentCompleted]);
+  }, [paymentMethod, paymentSuccess, orderStatus, paymentCompleted]);
 
   useEffect(() => {
     if (wallet && initialBridgeHash) {

--- a/packages/keychain/src/hooks/starterpack/coinbase.test.tsx
+++ b/packages/keychain/src/hooks/starterpack/coinbase.test.tsx
@@ -1,0 +1,146 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CoinbaseOnrampStatus } from "@/utils/api";
+import { request } from "@/utils/graphql";
+import { useCoinbase } from "./coinbase";
+
+vi.mock("@/hooks/connection", () => ({
+  useConnection: () => ({
+    controller: { chainId: () => "SN_MAIN" },
+    isMainnet: true,
+  }),
+}));
+
+vi.mock("@/utils/graphql", () => ({
+  request: vi.fn(),
+}));
+
+const requestMock = vi.mocked(request);
+
+describe("useCoinbase", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    requestMock.mockReset();
+    requestMock.mockResolvedValue({
+      createCoinbaseLayerswapOrder: {
+        coinbaseOrder: {
+          orderId: "order-1",
+          paymentLink: "https://pay.coinbase.com/buy",
+        },
+        layerswapPayment: {
+          swapId: "swap-1",
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("clears a stale failed attempt when the same popup later succeeds", async () => {
+    const popup = {
+      closed: false,
+      close: vi.fn(() => {
+        popup.closed = true;
+      }),
+    };
+    vi.spyOn(window, "open").mockReturnValue(popup as unknown as Window);
+
+    const { result, unmount } = renderHook(() =>
+      useCoinbase({ onError: vi.fn() }),
+    );
+
+    await act(async () => {
+      await result.current.createOrder({ purchaseUSDCAmount: "2.000000" });
+    });
+
+    act(() => {
+      result.current.openPaymentPopup();
+    });
+
+    act(() => {
+      dispatchCoinbaseRelay("onramp_api.polling_error", {
+        errorMessage: "First attempt failed",
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.orderStatus).toBe(CoinbaseOnrampStatus.Failed);
+    });
+
+    act(() => {
+      dispatchCoinbaseRelay("onramp_api.apple_pay_button_pressed");
+    });
+
+    await waitFor(() => {
+      expect(result.current.orderStatus).toBeUndefined();
+    });
+
+    act(() => {
+      dispatchCoinbaseRelay("onramp_api.polling_success");
+    });
+
+    await waitFor(() => {
+      expect(result.current.paymentSuccess).toBe(true);
+      expect(result.current.orderStatus).toBeUndefined();
+    });
+    expect(popup.close).toHaveBeenCalled();
+
+    act(() => {
+      dispatchCoinbaseRelay("onramp_api.polling_error", {
+        errorMessage: "Late stale error",
+      });
+    });
+
+    expect(result.current.paymentSuccess).toBe(true);
+    expect(result.current.orderStatus).not.toBe(CoinbaseOnrampStatus.Failed);
+
+    unmount();
+  });
+
+  it("does not treat native payment sheet cancellation as an order failure", async () => {
+    vi.spyOn(window, "open").mockReturnValue({
+      closed: false,
+      close: vi.fn(),
+    } as unknown as Window);
+    const onError = vi.fn();
+
+    const { result, unmount } = renderHook(() => useCoinbase({ onError }));
+
+    await act(async () => {
+      await result.current.createOrder({ purchaseUSDCAmount: "2.000000" });
+    });
+
+    act(() => {
+      result.current.openPaymentPopup();
+    });
+
+    act(() => {
+      dispatchCoinbaseRelay("onramp_api.cancel");
+    });
+
+    expect(result.current.orderStatus).toBeUndefined();
+    expect(result.current.popupClosed).toBe(false);
+    expect(onError).not.toHaveBeenCalled();
+
+    unmount();
+  });
+});
+
+function dispatchCoinbaseRelay(
+  type: string,
+  data?: { errorMessage?: string; errorCode?: string },
+) {
+  window.dispatchEvent(
+    new MessageEvent("message", {
+      origin: window.location.origin,
+      data: {
+        __coinbase_relay: true,
+        type,
+        data,
+      },
+    }),
+  );
+}

--- a/packages/keychain/src/hooks/starterpack/coinbase.ts
+++ b/packages/keychain/src/hooks/starterpack/coinbase.ts
@@ -238,6 +238,8 @@ export function useCoinbase({
   const confirmTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   /** Whether a terminal status has been reached (prevents popup-closed from overriding) */
   const terminalReachedRef = useRef(false);
+  /** Whether Coinbase has reported that funds were sent for this order. */
+  const successObservedRef = useRef(false);
 
   /** Clean up message listener, popup watcher, and poll */
   const cleanup = useCallback(() => {
@@ -292,7 +294,9 @@ export function useCoinbase({
 
         if (result.status === CoinbaseOnrampStatus.Completed) {
           setOrderStatus(CoinbaseOnrampStatus.Completed);
+          setPaymentSuccess(true);
           terminalReachedRef.current = true;
+          successObservedRef.current = true;
           stopPoll();
           // Close the popup directly via window reference
           console.log(
@@ -300,6 +304,12 @@ export function useCoinbase({
           );
           popupRef.current?.close();
         } else if (result.status === CoinbaseOnrampStatus.Failed) {
+          if (successObservedRef.current) {
+            console.warn(
+              "[coinbase-hook] Ignoring failed order status after success",
+            );
+            return;
+          }
           setOrderStatus(CoinbaseOnrampStatus.Failed);
           terminalReachedRef.current = true;
           stopPoll();
@@ -328,7 +338,7 @@ export function useCoinbase({
 
   /**
    * Switch to fast 1s poll after popup signals success.
-   * Also starts a 15s timeout — if the backend doesn't confirm
+   * Also starts a timeout — if the backend doesn't confirm
    * Completed within this window, treat it as fatal.
    */
   const startConfirmationPoll = useCallback(
@@ -377,6 +387,7 @@ export function useCoinbase({
       setOrderStatus(undefined);
       setOrderTxHash(undefined);
       terminalReachedRef.current = false;
+      successObservedRef.current = false;
 
       // Clean up any previous session
       cleanup();
@@ -417,10 +428,44 @@ export function useCoinbase({
 
         console.log("[coinbase-hook] postMessage event:", type, data);
 
+        const resetAttemptFailure = () => {
+          setPopupClosed(false);
+          setOrderStatus((status) =>
+            status === CoinbaseOnrampStatus.Failed ? undefined : status,
+          );
+          if (!pollRef.current && !successObservedRef.current) {
+            startFallbackPoll(targetOrderId);
+          }
+        };
+
+        const isErrorEvent =
+          type === "onramp_api.polling_error" ||
+          type === "onramp_api.load_error" ||
+          type === "onramp_api.cancel";
+
+        if (successObservedRef.current && isErrorEvent) {
+          console.warn(
+            "[coinbase-hook] Ignoring Coinbase error event after success:",
+            type,
+            data,
+          );
+          return;
+        }
+
         switch (type) {
+          case "onramp_api.apple_pay_button_pressed":
+          case "onramp_api.pending_payment_auth":
+          case "onramp_api.payment_authorized":
+          case "onramp_api.commit_success":
+          case "onramp_api.polling_start":
+            resetAttemptFailure();
+            break;
+
           case "onramp_api.polling_success":
             // Mark terminal immediately so popup-close watcher doesn't interfere
             terminalReachedRef.current = true;
+            successObservedRef.current = true;
+            resetAttemptFailure();
             // Signal success so UI can navigate to bridge screen immediately
             setPaymentSuccess(true);
             // Close the popup directly via window reference
@@ -459,10 +504,9 @@ export function useCoinbase({
             break;
 
           case "onramp_api.cancel":
-            setOrderStatus(CoinbaseOnrampStatus.Failed);
-            terminalReachedRef.current = true;
-            stopPoll();
-            onError?.(new Error("Payment was cancelled."));
+            // Native payment-sheet cancellation is scoped to this attempt. The
+            // Coinbase iframe can stay open and the user can retry the same order.
+            setPopupClosed(false);
             break;
         }
       };
@@ -520,6 +564,7 @@ export function useCoinbase({
         setPopupClosed(false);
         setPaymentSuccess(false);
         terminalReachedRef.current = false;
+        successObservedRef.current = false;
 
         // Clean up any previous session
         cleanup();


### PR DESCRIPTION
## Summary

Fixes a Coinbase Apple Pay state race where a failed or canceled first attempt inside the same popup could leave `orderStatus` as `Failed`, then leak that stale failure into the pending bridge screen after a later retry succeeded.

## Root Cause

Coinbase popup events are attempt-level in a few cases, but keychain was treating `onramp_api.cancel`, `polling_error`, and `load_error` as order-level terminal failures. If the user canceled the native Apple Pay sheet, retried in the same popup, and then succeeded, the stale failed state could still be observed by the pending screen and show "Coinbase payment failed. Please try again." even though Coinbase/backend processing had succeeded.

## Changes

- Track whether Coinbase success has been observed for the current order.
- Clear stale failed state when Coinbase emits retry/progress events.
- Treat native payment-sheet `cancel` as attempt-scoped rather than failing the order.
- Ignore late Coinbase error/cancel events after success has been observed.
- Make the pending bridge screen prefer `paymentSuccess` over stale failed status.
- Add regression coverage for retry-after-failure and native cancel behavior.

## Validation

- `pnpm --dir packages/keychain test:ci src/hooks/starterpack/coinbase.test.tsx src/components/coinbase-popup.test.tsx`
- `pnpm --dir packages/keychain exec tsc --noEmit --pretty false`
- `pnpm --dir packages/keychain exec prettier --check src/hooks/starterpack/coinbase.test.tsx src/hooks/starterpack/coinbase.ts src/components/purchasenew/pending/bridge.tsx`