### PR TITLE
fix(payment): reset stale coinbase purchase state

### DIFF
--- a/packages/keychain/src/components/purchasenew/checkout/coinbase/index.tsx
+++ b/packages/keychain/src/components/purchasenew/checkout/coinbase/index.tsx
@@ -298,7 +298,7 @@ export function CoinbaseCheckout() {
             }
           >
             {!hasLimitsLoaded || isFetchingCoinbaseLimits
-              ? "CHECKING LIMITS…"
+              ? "CHECKING LIMITS"
               : isCreatingOrder || isOpeningPopup
                 ? "LOADING..."
                 : "CONTINUE"}

--- a/packages/keychain/src/components/purchasenew/checkout/onchain/index.tsx
+++ b/packages/keychain/src/components/purchasenew/checkout/onchain/index.tsx
@@ -77,6 +77,7 @@ export function OnchainCheckout() {
     isCoinflowSelected,
     onCoinflowSelect,
     onCreateCoinbaseOrder,
+    resetCoinbasePurchase,
     isCreatingOrder,
     usdAmount,
     coinbaseLimits,
@@ -326,6 +327,7 @@ export function OnchainCheckout() {
         await onCreditCardPurchase();
         navigate("/purchase/checkout/coinflow");
       } else if (isApplePaySelected) {
+        resetCoinbasePurchase();
         const [{ data: meData }, { data: accountPrivateData }] =
           await Promise.all([refetchMe(), refetchAccountPrivate()]);
         const me = meData?.me;
@@ -348,7 +350,7 @@ export function OnchainCheckout() {
         }
 
         try {
-          await onCreateCoinbaseOrder();
+          await onCreateCoinbaseOrder({ force: true });
         } catch (err) {
           // Safety net: Coinbase can still reject if /limits was stale.
           // Navigate anyway so the verify flow takes over.
@@ -381,6 +383,7 @@ export function OnchainCheckout() {
     isApplePaySelected,
     applePayLimitExceeded,
     fetchCoinbaseLimits,
+    resetCoinbasePurchase,
     onCreditCardPurchase,
     refetchMe,
     refetchAccountPrivate,

--- a/packages/keychain/src/components/purchasenew/review/onchain-cost.stories.tsx
+++ b/packages/keychain/src/components/purchasenew/review/onchain-cost.stories.tsx
@@ -66,6 +66,7 @@ const MockOnchainPurchaseProvider = ({ children }: { children: ReactNode }) => {
     onCoinflowSelect: () => {},
     onCreateCoinbaseOrder: async () => undefined,
     openPaymentPopup: () => {},
+    resetCoinbasePurchase: () => {},
     orderId: undefined,
     orderStatus: undefined,
     orderTxHash: undefined,

--- a/packages/keychain/src/components/purchasenew/wallet/wallet.stories.tsx
+++ b/packages/keychain/src/components/purchasenew/wallet/wallet.stories.tsx
@@ -73,6 +73,7 @@ const mockOnchainPurchaseValue: OnchainPurchaseContextType = {
   onCoinflowSelect: () => {},
   onCreateCoinbaseOrder: async () => undefined,
   openPaymentPopup: () => {},
+  resetCoinbasePurchase: () => {},
   orderId: undefined,
   orderStatus: undefined,
   orderTxHash: undefined,

--- a/packages/keychain/src/context/starterpack/onchain-purchase.tsx
+++ b/packages/keychain/src/context/starterpack/onchain-purchase.tsx
@@ -127,6 +127,7 @@ export interface OnchainPurchaseContextType {
     force?: boolean;
   }) => Promise<CoinbaseOrderResult | undefined>;
   openPaymentPopup: (opts?: { paymentLink?: string; orderId?: string }) => void;
+  resetCoinbasePurchase: () => void;
   getTransactions: (username: string) => Promise<CoinbaseTransactionResult[]>;
   fetchCoinbaseLimits: () => Promise<CoinbaseLimitsResult | undefined>;
   submitCoinbaseLimitsUpgrade: (
@@ -305,6 +306,7 @@ export const OnchainPurchaseProvider = ({
     popupClosed,
     paymentSuccess,
     openPaymentPopup,
+    resetOrder: resetCoinbaseOrder,
     limits: coinbaseLimits,
     isFetchingLimits: isFetchingCoinbaseLimits,
     isSubmittingLimitsUpgrade,
@@ -314,23 +316,36 @@ export const OnchainPurchaseProvider = ({
     onError: setDisplayError,
   });
 
+  const resetCoinbasePurchase = useCallback(() => {
+    resetCoinbaseOrder();
+    setCoinbaseLsSwapId(undefined);
+  }, [resetCoinbaseOrder]);
+
   // Handle Apple Pay selection from URL (returning from verification)
   useEffect(() => {
     const searchParams = new URLSearchParams(location.search);
     if (searchParams.get("method") === "apple-pay") {
+      resetCoinbasePurchase();
       setIsApplePaySelected(true);
       clearSelectedWalletInternal();
     }
-  }, [location.search, clearSelectedWalletInternal]);
+  }, [location.search, clearSelectedWalletInternal, resetCoinbasePurchase]);
 
   // Reset state when starterpack changes
   useEffect(() => {
+    resetCoinbasePurchase();
     resetTokenSelection();
     resetQuantity();
     setPurchaseItems([]);
     setPurchaseDescription(undefined);
     setIssueSignature(undefined);
-  }, [bundleId, starterpackId, resetTokenSelection, resetQuantity]);
+  }, [
+    bundleId,
+    starterpackId,
+    resetTokenSelection,
+    resetQuantity,
+    resetCoinbasePurchase,
+  ]);
 
   // Update purchase items and USD amount when starterpack details change
   useEffect(() => {
@@ -685,17 +700,19 @@ export const OnchainPurchaseProvider = ({
   ]);
 
   const onApplePaySelect = useCallback(() => {
+    resetCoinbasePurchase();
     setIsApplePaySelected(true);
     setIsCoinflowSelected(false);
     clearSelectedWalletInternal();
-  }, [clearSelectedWalletInternal]);
+  }, [clearSelectedWalletInternal, resetCoinbasePurchase]);
 
   const onCoinflowSelect = useCallback(() => {
+    resetCoinbasePurchase();
     setIsCoinflowSelected(true);
     setIsApplePaySelected(false);
     clearSelectedWalletInternal();
     savePaymentMethod("coinflow");
-  }, [clearSelectedWalletInternal, savePaymentMethod]);
+  }, [clearSelectedWalletInternal, savePaymentMethod, resetCoinbasePurchase]);
 
   const onCreateCoinbaseOrder = useCallback(
     async (opts?: { force?: boolean }) => {
@@ -707,7 +724,20 @@ export const OnchainPurchaseProvider = ({
       }
 
       const force = opts?.force ?? false;
-      if (isCreatingOrder || (paymentLink && !force)) return;
+      const hasStaleCoinbaseOrder =
+        paymentSuccess ||
+        popupClosed ||
+        orderStatus === CoinbaseOnrampStatus.Completed ||
+        orderStatus === CoinbaseOnrampStatus.Failed;
+
+      if (
+        isCreatingOrder ||
+        (paymentLink && !force && !hasStaleCoinbaseOrder)
+      ) {
+        return;
+      }
+
+      setCoinbaseLsSwapId(undefined);
 
       const order = await createCoinbaseOrder({
         purchaseUSDCAmount: applePayUsdcAmount,
@@ -724,6 +754,9 @@ export const OnchainPurchaseProvider = ({
       applePayUsdcAmount,
       isCreatingOrder,
       paymentLink,
+      paymentSuccess,
+      popupClosed,
+      orderStatus,
       createCoinbaseOrder,
     ],
   );
@@ -779,6 +812,7 @@ export const OnchainPurchaseProvider = ({
     onCoinflowSelect,
     onCreateCoinbaseOrder,
     openPaymentPopup,
+    resetCoinbasePurchase,
     getTransactions,
     coinbaseLimits,
     isFetchingCoinbaseLimits,

--- a/packages/keychain/src/hooks/starterpack/coinbase.test.tsx
+++ b/packages/keychain/src/hooks/starterpack/coinbase.test.tsx
@@ -127,6 +127,49 @@ describe("useCoinbase", () => {
 
     unmount();
   });
+
+  it("clears a completed session before starting a fresh purchase", async () => {
+    vi.spyOn(window, "open").mockReturnValue({
+      closed: false,
+      close: vi.fn(),
+    } as unknown as Window);
+
+    const { result, unmount } = renderHook(() =>
+      useCoinbase({ onError: vi.fn() }),
+    );
+
+    await act(async () => {
+      await result.current.createOrder({ purchaseUSDCAmount: "2.000000" });
+    });
+
+    expect(result.current.orderId).toBe("order-1");
+    expect(result.current.paymentLink).toBe("https://pay.coinbase.com/buy");
+
+    act(() => {
+      result.current.openPaymentPopup();
+    });
+
+    act(() => {
+      dispatchCoinbaseRelay("onramp_api.polling_success");
+    });
+
+    await waitFor(() => {
+      expect(result.current.paymentSuccess).toBe(true);
+    });
+
+    act(() => {
+      result.current.resetOrder();
+    });
+
+    expect(result.current.orderId).toBeUndefined();
+    expect(result.current.paymentLink).toBeUndefined();
+    expect(result.current.orderStatus).toBeUndefined();
+    expect(result.current.orderTxHash).toBeUndefined();
+    expect(result.current.popupClosed).toBe(false);
+    expect(result.current.paymentSuccess).toBe(false);
+
+    unmount();
+  });
 });
 
 function dispatchCoinbaseRelay(

--- a/packages/keychain/src/hooks/starterpack/coinbase.ts
+++ b/packages/keychain/src/hooks/starterpack/coinbase.ts
@@ -84,6 +84,7 @@ export interface UseCoinbaseReturn {
   getTransactions: (username: string) => Promise<CoinbaseTransactionResult[]>;
   getQuote: (input: CoinbaseQuoteInput) => Promise<CoinbaseQuoteResult>;
   openPaymentPopup: (opts?: { paymentLink?: string; orderId?: string }) => void;
+  resetOrder: () => void;
   fetchLimits: () => Promise<CoinbaseLimitsResult | undefined>;
   submitLimitsUpgrade: (
     input: SubmitCoinbaseLimitsUpgradeInput,
@@ -263,6 +264,19 @@ export function useCoinbase({
 
   // Clean up on unmount
   useEffect(() => cleanup, [cleanup]);
+
+  const resetOrder = useCallback(() => {
+    cleanup();
+    setOrderId(undefined);
+    setPaymentLink(undefined);
+    setOrderError(null);
+    setOrderStatus(undefined);
+    setOrderTxHash(undefined);
+    setPopupClosed(false);
+    setPaymentSuccess(false);
+    terminalReachedRef.current = false;
+    successObservedRef.current = false;
+  }, [cleanup]);
 
   /** Stop polling and clear timeout */
   const stopPoll = useCallback(() => {
@@ -558,16 +572,7 @@ export function useCoinbase({
 
       try {
         setIsCreatingOrder(true);
-        setOrderError(null);
-        setOrderStatus(undefined);
-        setOrderTxHash(undefined);
-        setPopupClosed(false);
-        setPaymentSuccess(false);
-        terminalReachedRef.current = false;
-        successObservedRef.current = false;
-
-        // Clean up any previous session
-        cleanup();
+        resetOrder();
 
         const order = await createCoinbaseOrder(input, !isMainnet);
 
@@ -584,7 +589,7 @@ export function useCoinbase({
         setIsCreatingOrder(false);
       }
     },
-    [controller, isMainnet, onError, cleanup],
+    [controller, isMainnet, onError, resetOrder],
   );
 
   const getTransactions = useCallback(
@@ -672,6 +677,7 @@ export function useCoinbase({
     getTransactions,
     getQuote,
     openPaymentPopup,
+    resetOrder,
     fetchLimits,
     submitLimitsUpgrade,
   };


### PR DESCRIPTION
## Summary

Resets Coinbase Apple Pay purchase state when starting a new Apple Pay purchase so a completed prior order cannot be reused by the next starterpack flow.

## Root Cause

Starterpack providers are mounted globally, so after a successful Apple Pay purchase the Coinbase order state could survive after the keychain UI was closed. On a later purchase, the stale `paymentSuccess`, `paymentLink`, `orderId`, and Layerswap swap id could make checkout skip directly to pending and show the previous Coinbase/Layerswap progress.

## Changes

- Added an explicit Coinbase order reset action in `useCoinbase`.
- Added `resetCoinbasePurchase` in the onchain purchase context to clear Coinbase order state plus `coinbaseLsSwapId`.
- Reset stale Coinbase state when Apple Pay is selected, when returning from verification, when starterpack context changes, and when the Apple Pay Pay button starts a new flow.
- Force the Pay button path to create a fresh Coinbase order instead of reusing a previous completed order.
- Added hook coverage for clearing a completed Coinbase session before a fresh purchase.

## Validation

- `pnpm --dir packages/keychain test:ci src/hooks/starterpack/coinbase.test.tsx src/components/coinbase-popup.test.tsx`
- `pnpm --dir packages/keychain exec tsc --noEmit --pretty false`
- `pnpm --dir packages/keychain exec prettier --check src/hooks/starterpack/coinbase.ts src/hooks/starterpack/coinbase.test.tsx src/context/starterpack/onchain-purchase.tsx src/components/purchasenew/checkout/onchain/index.tsx src/components/purchasenew/review/onchain-cost.stories.tsx src/components/purchasenew/wallet/wallet.stories.tsx`

Pre-commit hook note: repo-wide checks reached `pnpm controller test` and failed because this local install cannot resolve `@starknet-io/get-starknet-core` from `packages/controller/src/controller.ts`. The keychain-focused checks above passed.