### PR TITLE
chore(payment): remove coinbase postMessage debug logs

### DIFF
--- a/packages/keychain/src/components/coinbase-popup.tsx
+++ b/packages/keychain/src/components/coinbase-popup.tsx
@@ -91,9 +91,7 @@ export function CoinbasePopup() {
     const handleKeychainMessage = (event: MessageEvent) => {
       if (event.origin !== keychainOrigin) return;
       if (event.data?.__coinbase_relay) return; // Ignore our own relayed events
-      console.log("[coinbase-popup] Message from keychain:", event.data);
       if (event.data?.type === "close") {
-        console.log("[coinbase-popup] Close command received from keychain");
         window.close();
       }
     };
@@ -106,47 +104,19 @@ export function CoinbasePopup() {
   useEffect(() => {
     // Derive the allowed origin from the payment link URL
     const allowedOrigin = paymentLink ? new URL(paymentLink).origin : null;
-    console.log(
-      "[coinbase-popup] Listening for postMessages, allowedOrigin:",
-      allowedOrigin,
-    );
-    console.log("[coinbase-popup] paymentLink:", paymentLink);
-    console.log(
-      "[coinbase-popup] sandbox attrs: allow-scripts allow-same-origin",
-    );
 
     const handleMessage = (event: MessageEvent) => {
-      // Log ALL incoming messages for debugging
-      console.log("[coinbase-popup] Raw postMessage received:", {
-        origin: event.origin,
-        data: event.data,
-        type: typeof event.data,
-        source: event.source ? "has source" : "no source",
-      });
-
       // Verify the message origin matches the Coinbase payment link domain
       if (allowedOrigin && event.origin !== allowedOrigin) {
-        console.warn(
-          `[coinbase-popup] Origin mismatch: got "${event.origin}", expected "${allowedOrigin}"`,
-        );
         return;
       }
 
       // Coinbase may send object payloads or JSON-encoded strings.
       const data = parseCoinbaseMessage(event.data);
       if (!data?.eventName?.startsWith("onramp_api.")) {
-        console.log(
-          "[coinbase-popup] Ignoring non-Coinbase message:",
-          event.data,
-        );
         return;
       }
 
-      console.log(
-        "[coinbase-popup] ✅ Coinbase event:",
-        data.eventName,
-        data.data,
-      );
       coinbaseEventReceived.current = true;
 
       // Clear the load timeout since we got a valid Coinbase event
@@ -157,12 +127,6 @@ export function CoinbasePopup() {
 
       // Relay every Coinbase event to the keychain via postMessage
       const opener = window.opener;
-      console.log(
-        "[coinbase-popup] postMessage relay:",
-        data.eventName,
-        "opener:",
-        !!opener,
-      );
       if (opener) {
         opener.postMessage(
           {
@@ -172,7 +136,6 @@ export function CoinbasePopup() {
           },
           keychainOrigin,
         );
-        console.log("[coinbase-popup] Message posted via postMessage");
       } else {
         console.error(
           "[coinbase-popup] window.opener is null — message NOT relayed!",
@@ -345,7 +308,6 @@ export function CoinbasePopup() {
           referrerPolicy="no-referrer"
           title="Coinbase Onramp"
           onLoad={() => {
-            console.log("[coinbase-popup] iframe onLoad fired");
             setIframeReady(true);
 
             // If no Coinbase postMessage event arrives within the timeout,

--- a/packages/keychain/src/hooks/starterpack/coinbase.ts
+++ b/packages/keychain/src/hooks/starterpack/coinbase.ts
@@ -295,12 +295,6 @@ export function useCoinbase({
     async (targetOrderId: string) => {
       try {
         const result = await getCoinbaseOrderStatus(targetOrderId);
-        console.log(
-          "[coinbase-hook] pollOnce result:",
-          result.status,
-          "txHash:",
-          result.txHash,
-        );
 
         if (result.txHash) {
           setOrderTxHash(result.txHash);
@@ -312,10 +306,6 @@ export function useCoinbase({
           terminalReachedRef.current = true;
           successObservedRef.current = true;
           stopPoll();
-          // Close the popup directly via window reference
-          console.log(
-            "[coinbase-hook] Poll detected completed — closing popup directly",
-          );
           popupRef.current?.close();
         } else if (result.status === CoinbaseOnrampStatus.Failed) {
           if (successObservedRef.current) {
@@ -440,8 +430,6 @@ export function useCoinbase({
           data?: { errorCode?: string; errorMessage?: string };
         };
 
-        console.log("[coinbase-hook] postMessage event:", type, data);
-
         const resetAttemptFailure = () => {
           setPopupClosed(false);
           setOrderStatus((status) =>
@@ -482,8 +470,6 @@ export function useCoinbase({
             resetAttemptFailure();
             // Signal success so UI can navigate to bridge screen immediately
             setPaymentSuccess(true);
-            // Close the popup directly via window reference
-            console.log("[coinbase-hook] Closing popup directly");
             popupRef.current?.close();
             // Switch from 15s fallback to fast 1s poll + 15s timeout
             startConfirmationPoll(targetOrderId);
@@ -531,24 +517,13 @@ export function useCoinbase({
       // Watch for the popup being closed by the user
       popupCheckRef.current = setInterval(() => {
         if (popup && popup.closed) {
-          console.log(
-            "[coinbase-hook] Popup closed detected. terminalReachedRef:",
-            terminalReachedRef.current,
-          );
           if (popupCheckRef.current) {
             clearInterval(popupCheckRef.current);
             popupCheckRef.current = null;
           }
           if (!terminalReachedRef.current) {
-            console.log(
-              "[coinbase-hook] No terminal status — stopping poll and setting popupClosed",
-            );
             stopPoll();
             setPopupClosed(true);
-          } else {
-            console.log(
-              "[coinbase-hook] Terminal already reached — ignoring popup close",
-            );
           }
         }
       }, 1000);

--- a/packages/keychain/src/utils/api/generated.ts
+++ b/packages/keychain/src/utils/api/generated.ts
@@ -4276,11 +4276,15 @@ export type PaymasterPolicyWhereInput = {
 
 export type PaymasterStats = {
   __typename?: "PaymasterStats";
+  avgStrkFee?: Maybe<Scalars["Float"]>;
   avgUsdFee?: Maybe<Scalars["Float"]>;
+  maxStrkFee?: Maybe<Scalars["Float"]>;
   maxUsdFee?: Maybe<Scalars["Float"]>;
+  minStrkFee?: Maybe<Scalars["Float"]>;
   minUsdFee?: Maybe<Scalars["Float"]>;
   revertedTransactions: Scalars["Int"];
   successfulTransactions: Scalars["Int"];
+  totalStrkFees?: Maybe<Scalars["Float"]>;
   totalTransactions: Scalars["Int"];
   totalUsdFees?: Maybe<Scalars["Float"]>;
   uniqueUsers: Scalars["Int"];
@@ -4290,6 +4294,7 @@ export type PaymasterTransaction = {
   __typename?: "PaymasterTransaction";
   executedAt: Scalars["Time"];
   status: ActivityStatus;
+  strkFee: Scalars["Float"];
   transactionHash: Scalars["String"];
   usdFee: Scalars["Float"];
 };

--- a/packages/ui/src/utils/api/cartridge/generated.ts
+++ b/packages/ui/src/utils/api/cartridge/generated.ts
@@ -4329,11 +4329,15 @@ export type PaymasterPolicyWhereInput = {
 
 export type PaymasterStats = {
   __typename?: 'PaymasterStats';
+  avgStrkFee?: Maybe<Scalars['Float']>;
   avgUsdFee?: Maybe<Scalars['Float']>;
+  maxStrkFee?: Maybe<Scalars['Float']>;
   maxUsdFee?: Maybe<Scalars['Float']>;
+  minStrkFee?: Maybe<Scalars['Float']>;
   minUsdFee?: Maybe<Scalars['Float']>;
   revertedTransactions: Scalars['Int'];
   successfulTransactions: Scalars['Int'];
+  totalStrkFees?: Maybe<Scalars['Float']>;
   totalTransactions: Scalars['Int'];
   totalUsdFees?: Maybe<Scalars['Float']>;
   uniqueUsers: Scalars['Int'];
@@ -4343,6 +4347,7 @@ export type PaymasterTransaction = {
   __typename?: 'PaymasterTransaction';
   executedAt: Scalars['Time'];
   status: ActivityStatus;
+  strkFee: Scalars['Float'];
   transactionHash: Scalars['String'];
   usdFee: Scalars['Float'];
 };


### PR DESCRIPTION
## Summary

Removes the `[coinbase-popup]` and `[coinbase-hook]` `console.log` instrumentation that was added while debugging the postMessage relay between the Coinbase popup and the keychain. These logs were noisy in production (every postMessage event, every poll, every popup-close watcher tick) and no longer needed.

Kept the `console.error` / `console.warn` calls for genuine edge cases:
- `window.opener is null` (relay can't happen)
- "No Coinbase events received after iframe load" (server-error fallback)
- Ignored-after-success guards
- Non-terminal `commit_error` and `not supported` warnings

Also picks up regenerated GraphQL types for paymaster STRK fees (same as #2580).

## Test plan

- [ ] Coinbase Apple Pay flow still completes end-to-end
- [ ] Cancelling/closing the Coinbase popup behaves as before
- [ ] Browser console is quiet during a normal purchase