### PR TITLE
fix(starterpack): skip coinbase limits fetch without verified phone

### DIFF
--- a/packages/keychain/src/components/purchasenew/checkout/onchain/index.tsx
+++ b/packages/keychain/src/components/purchasenew/checkout/onchain/index.tsx
@@ -92,9 +92,11 @@ export function OnchainCheckout() {
     useCreditPurchaseContext();
 
   const { refetch: refetchMe } = useMeQuery(undefined, { enabled: false });
-  const { refetch: refetchAccountPrivate } = useAccountPrivateQuery(undefined, {
-    enabled: false,
-  });
+  const { data: accountPrivateData, refetch: refetchAccountPrivate } =
+    useAccountPrivateQuery();
+  const hasVerifiedPhone =
+    !!accountPrivateData?.accountPrivate?.phoneNumber &&
+    !!accountPrivateData?.accountPrivate?.phoneNumberVerifiedAt;
   const isCoinflowEnabled = useFeature("coinflow-support");
   const { enableFeature } = useFeatures();
 
@@ -162,11 +164,13 @@ export function OnchainCheckout() {
 
   // Pre-fetch Coinbase limits as soon as Apple Pay is selected so we can gate
   // the Buy button and skip a doomed order-create for users over the cap.
+  // Skip when the user lacks a verified phone — the limits query requires one
+  // and would error; handlePurchase will route those users to verification.
   useEffect(() => {
-    if (isApplePaySelected) {
+    if (isApplePaySelected && hasVerifiedPhone) {
       fetchCoinbaseLimits();
     }
-  }, [isApplePaySelected, fetchCoinbaseLimits]);
+  }, [isApplePaySelected, hasVerifiedPhone, fetchCoinbaseLimits]);
 
   const applePayLimitsLoading = useMemo(
     () => isApplePaySelected && !coinbaseLimits && isFetchingCoinbaseLimits,


### PR DESCRIPTION
## Summary

When a user selected Apple Pay without a verified phone, an effect pre-fetched `coinbaseOnrampLimits`, which the backend rejects with `User must have a phone number for coinbase onramp`. The raw GraphQL error rendered in `<ControllerErrorAlert>` before the user even clicked Buy.

The click path (`handlePurchase`) already routes phone-less users to the existing `VerificationDrawer` (email + phone). This change just gates the pre-fetch on `hasVerifiedPhone` so the failing query never fires for those users; the cached `useAccountPrivateQuery` updates after verification, and the limits fetch then runs automatically.

## Test plan

- [ ] Apple Pay with no phone → no error alert; Buy click opens VerificationDrawer
- [ ] Complete email + phone verify → coinbase drawer opens, limits load normally
- [ ] Apple Pay with already-verified phone → limits pre-fetch as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)