### PR TITLE
feat(keychain): bearer-token auth for Safari iframe

### DIFF
--- a/packages/keychain/src/components/ConnectRoute.tsx
+++ b/packages/keychain/src/components/ConnectRoute.tsx
@@ -21,6 +21,7 @@ import { isIframe } from "@cartridge/controller-ui/utils";
 import { safeRedirect } from "@/utils/url-validator";
 import { requestStorageAccess } from "@/utils/connection/storage-access";
 import { openPopupAuth } from "@/utils/connection/popup";
+import { setBearerToken } from "@/utils/bearer-token";
 import Controller from "@/utils/controller";
 import {
   Button,
@@ -611,7 +612,7 @@ async function createSessionViaPopup(
     origin?: string;
   },
 ): Promise<void> {
-  const popupState = await openPopupAuth({
+  const { state, sessionToken } = await openPopupAuth({
     action: "login",
     username: currentController.username(),
     preset: params.preset ?? undefined,
@@ -620,7 +621,11 @@ async function createSessionViaPopup(
     origin: params.origin ?? undefined,
   });
 
-  const controller = await Controller.importState(popupState);
+  if (sessionToken) {
+    setBearerToken(sessionToken);
+  }
+
+  const controller = await Controller.importState(state);
   window.controller = controller;
   setController(controller);
 }

--- a/packages/keychain/src/components/PopupAuth.tsx
+++ b/packages/keychain/src/components/PopupAuth.tsx
@@ -8,6 +8,7 @@ import {
   createVerifiedSession,
   requiresSessionApproval,
 } from "@/utils/connection/session-creation";
+import { issueBearerToken } from "@/utils/bearer-token";
 
 const POPUP_CLOSE_FALLBACK_MS = 2000;
 
@@ -62,12 +63,13 @@ export function PopupAuth() {
   }, [channelId, popupOrigin]);
 
   const signalComplete = useCallback(
-    (state: ImportedControllerState) => {
+    (state: ImportedControllerState, sessionToken: string | null) => {
       window.opener?.postMessage(
         {
           type: "auth-complete",
           channelId,
           state,
+          sessionToken,
         },
         popupOrigin,
       );
@@ -104,8 +106,11 @@ export function PopupAuth() {
       return;
     }
 
-    const state = await controller.exportState(origin || undefined);
-    signalComplete(state);
+    const [state, sessionToken] = await Promise.all([
+      controller.exportState(origin || undefined),
+      issueBearerToken(),
+    ]);
+    signalComplete(state, sessionToken);
     setSessionComplete(true);
   }, [controller, origin, signalComplete]);
 

--- a/packages/keychain/src/components/connect/create/useCreateController.ts
+++ b/packages/keychain/src/components/connect/create/useCreateController.ts
@@ -250,6 +250,7 @@ export function useCreateController({
     locationGate,
     locationGateVerified,
     setIsNewController,
+    webauthnPopup,
   } = useConnection();
 
   // When location gate is configured and not yet verified, skip auto-session
@@ -267,8 +268,11 @@ export function useCreateController({
   const hasPolicies = !!policies;
   const shouldAutoCreateSession = canAutoCreateSession(policies);
 
-  const { signup: signupWithWebauthn, login: loginWithWebauthn } =
-    useWebauthnAuthentication();
+  const {
+    signup: signupWithWebauthn,
+    login: loginWithWebauthn,
+    loginViaPopup: loginWithWebauthnPopup,
+  } = useWebauthnAuthentication();
   const { signup: signupWithSocial, login: loginWithSocial } =
     useSocialAuthentication(setChangeWallet);
   const { signup: signupWithExternalWallet, login: loginWithExternalWallet } =
@@ -739,6 +743,27 @@ export function useCreateController({
         throw new Error("No chainId");
       }
 
+      // Safari blocks window.open() if any await runs between the user
+      // gesture and the call. The popup path doesn't need fetchController
+      // here (the popup itself looks up the controller from the username),
+      // so route to it before any async work to keep the gesture intact.
+      if (authenticationMethod === "webauthn" && webauthnPopup.get) {
+        const loginController = await loginWithWebauthnPopup(username);
+        if (!loginController) {
+          throw new Error("Login failed");
+        }
+        if (loginController.completedInPopup && !locationGatePending) {
+          await completePopupConnect({
+            controller: loginController.controller,
+            params,
+            handleCompletion,
+            searchParams,
+            isNewController: false,
+          });
+        }
+        return;
+      }
+
       const controller = (await fetchController(chainId, username))?.controller;
       if (!controller) {
         throw new Error("Undefined controller");
@@ -899,6 +924,8 @@ export function useCreateController({
     [
       isSlot,
       loginWithWebauthn,
+      loginWithWebauthnPopup,
+      webauthnPopup,
       loginWithSocial,
       loginWithWalletConnect,
       loginWithExternalWallet,

--- a/packages/keychain/src/components/connect/create/webauthn/index.ts
+++ b/packages/keychain/src/components/connect/create/webauthn/index.ts
@@ -100,6 +100,35 @@ export function useWebauthnAuthentication() {
     ],
   );
 
+  // Popup-only login path. Skips the iframe-side controller lookup so
+  // window.open() fires synchronously from the user gesture — Safari
+  // otherwise blocks the popup because the gesture has expired by the
+  // time fetchController's await resolves. The popup handles its own
+  // controller bootstrap from the username.
+  const loginViaPopup = useCallback(
+    async (username: string) => {
+      const { state, sessionToken } = await openPopupAuth({
+        action: "login",
+        username,
+        preset: preset ?? undefined,
+        rpcUrl: rpcUrl ?? undefined,
+        policies: policiesStr ?? undefined,
+        origin: origin ?? undefined,
+      });
+
+      if (sessionToken) {
+        setBearerToken(sessionToken);
+      }
+
+      const controller = await Controller.importState(state);
+
+      window.controller = controller;
+      setController(controller);
+      return { controller, completedInPopup: true } as WebauthnAuthResult;
+    },
+    [origin, rpcUrl, setController, preset, policiesStr],
+  );
+
   const login = useCallback(
     async (
       controllerQuery: ControllerQuery["controller"],
@@ -110,24 +139,7 @@ export function useWebauthnAuthentication() {
       if (!chainId) throw new Error("No chainId found");
 
       if (webauthnPopup.get) {
-        const { state, sessionToken } = await openPopupAuth({
-          action: "login",
-          username: controllerQuery.accountID,
-          preset: preset ?? undefined,
-          rpcUrl: rpcUrl ?? undefined,
-          policies: policiesStr ?? undefined,
-          origin: origin ?? undefined,
-        });
-
-        if (sessionToken) {
-          setBearerToken(sessionToken);
-        }
-
-        const controller = await Controller.importState(state);
-
-        window.controller = controller;
-        setController(controller);
-        return { controller, completedInPopup: true } as WebauthnAuthResult;
+        return loginViaPopup(controllerQuery.accountID);
       }
 
       let controller: Controller;
@@ -158,19 +170,12 @@ export function useWebauthnAuthentication() {
       setController(controller);
       return { controller, completedInPopup: false } as WebauthnAuthResult;
     },
-    [
-      chainId,
-      rpcUrl,
-      origin,
-      setController,
-      webauthnPopup,
-      preset,
-      policiesStr,
-    ],
+    [chainId, rpcUrl, origin, setController, webauthnPopup, loginViaPopup],
   );
 
   return {
     signup,
     login,
+    loginViaPopup,
   };
 }

--- a/packages/keychain/src/components/connect/create/webauthn/index.ts
+++ b/packages/keychain/src/components/connect/create/webauthn/index.ts
@@ -4,6 +4,7 @@ import { useConnection } from "@/hooks/connection";
 import Controller from "@/utils/controller";
 import { openPopupAuth } from "@/utils/connection/popup";
 import { setBearerToken } from "@/utils/bearer-token";
+import { requestStorageAccess } from "@/utils/connection/storage-access";
 import { Owner } from "@cartridge/controller-wasm";
 import { ControllerQuery } from "@cartridge/controller-ui/utils/api/cartridge";
 import { useCallback } from "react";
@@ -107,6 +108,15 @@ export function useWebauthnAuthentication() {
   // controller bootstrap from the username.
   const loginViaPopup = useCallback(
     async (username: string) => {
+      // iOS Safari partitions iframe localStorage strictly by parent site,
+      // so a bearer token written after the popup return can land in a
+      // partition the fetcher can't see — leaving the user stuck on
+      // "Sign in required". Fire requestStorageAccess synchronously
+      // (no await before window.open or the gesture is gone) so by the
+      // time we write the token, the iframe shares the unpartitioned
+      // x.cartridge.gg storage the popup just wrote into.
+      const storageAccessGranted = requestStorageAccess().catch(() => false);
+
       const { state, sessionToken } = await openPopupAuth({
         action: "login",
         username,
@@ -115,6 +125,8 @@ export function useWebauthnAuthentication() {
         policies: policiesStr ?? undefined,
         origin: origin ?? undefined,
       });
+
+      await storageAccessGranted;
 
       if (sessionToken) {
         setBearerToken(sessionToken);

--- a/packages/keychain/src/components/connect/create/webauthn/index.ts
+++ b/packages/keychain/src/components/connect/create/webauthn/index.ts
@@ -4,7 +4,6 @@ import { useConnection } from "@/hooks/connection";
 import Controller from "@/utils/controller";
 import { openPopupAuth } from "@/utils/connection/popup";
 import { setBearerToken } from "@/utils/bearer-token";
-import { requestStorageAccess } from "@/utils/connection/storage-access";
 import { Owner } from "@cartridge/controller-wasm";
 import { ControllerQuery } from "@cartridge/controller-ui/utils/api/cartridge";
 import { useCallback } from "react";
@@ -108,15 +107,6 @@ export function useWebauthnAuthentication() {
   // controller bootstrap from the username.
   const loginViaPopup = useCallback(
     async (username: string) => {
-      // iOS Safari partitions iframe localStorage strictly by parent site,
-      // so a bearer token written after the popup return can land in a
-      // partition the fetcher can't see — leaving the user stuck on
-      // "Sign in required". Fire requestStorageAccess synchronously
-      // (no await before window.open or the gesture is gone) so by the
-      // time we write the token, the iframe shares the unpartitioned
-      // x.cartridge.gg storage the popup just wrote into.
-      const storageAccessGranted = requestStorageAccess().catch(() => false);
-
       const { state, sessionToken } = await openPopupAuth({
         action: "login",
         username,
@@ -125,8 +115,6 @@ export function useWebauthnAuthentication() {
         policies: policiesStr ?? undefined,
         origin: origin ?? undefined,
       });
-
-      await storageAccessGranted;
 
       if (sessionToken) {
         setBearerToken(sessionToken);

--- a/packages/keychain/src/components/connect/create/webauthn/index.ts
+++ b/packages/keychain/src/components/connect/create/webauthn/index.ts
@@ -3,6 +3,7 @@ import { doSignup } from "@/hooks/account";
 import { useConnection } from "@/hooks/connection";
 import Controller from "@/utils/controller";
 import { openPopupAuth } from "@/utils/connection/popup";
+import { setBearerToken } from "@/utils/bearer-token";
 import { Owner } from "@cartridge/controller-wasm";
 import { ControllerQuery } from "@cartridge/controller-ui/utils/api/cartridge";
 import { useCallback } from "react";
@@ -29,7 +30,7 @@ export function useWebauthnAuthentication() {
       if (!chainId) throw new Error("No chainId found");
 
       if (webauthnPopup.create) {
-        const popupState = await openPopupAuth({
+        const { state, sessionToken } = await openPopupAuth({
           action: "signup",
           username,
           preset: preset ?? undefined,
@@ -38,7 +39,11 @@ export function useWebauthnAuthentication() {
           origin: origin ?? undefined,
         });
 
-        const controller = await Controller.importState(popupState);
+        if (sessionToken) {
+          setBearerToken(sessionToken);
+        }
+
+        const controller = await Controller.importState(state);
 
         window.controller = controller;
         setController(controller);
@@ -105,7 +110,7 @@ export function useWebauthnAuthentication() {
       if (!chainId) throw new Error("No chainId found");
 
       if (webauthnPopup.get) {
-        const popupState = await openPopupAuth({
+        const { state, sessionToken } = await openPopupAuth({
           action: "login",
           username: controllerQuery.accountID,
           preset: preset ?? undefined,
@@ -114,7 +119,11 @@ export function useWebauthnAuthentication() {
           origin: origin ?? undefined,
         });
 
-        const controller = await Controller.importState(popupState);
+        if (sessionToken) {
+          setBearerToken(sessionToken);
+        }
+
+        const controller = await Controller.importState(state);
 
         window.controller = controller;
         setController(controller);

--- a/packages/keychain/src/components/connect/create/webauthn/index.ts
+++ b/packages/keychain/src/components/connect/create/webauthn/index.ts
@@ -2,7 +2,7 @@ import { DEFAULT_SESSION_DURATION, now } from "@/constants";
 import { doSignup } from "@/hooks/account";
 import { useConnection } from "@/hooks/connection";
 import Controller from "@/utils/controller";
-import { openPopupAuth, preOpenPopupWindow } from "@/utils/connection/popup";
+import { openPopupAuth } from "@/utils/connection/popup";
 import { setBearerToken } from "@/utils/bearer-token";
 import { requestStorageAccess } from "@/utils/connection/storage-access";
 import { Owner } from "@cartridge/controller-wasm";
@@ -109,32 +109,24 @@ export function useWebauthnAuthentication() {
   const loginViaPopup = useCallback(
     async (username: string) => {
       // iOS Safari partitions iframe localStorage strictly by parent site,
-      // so a bearer token written after the popup returns can land in a
+      // so a bearer token written after the popup return can land in a
       // partition the fetcher can't see — leaving the user stuck on
-      // "Sign in required". requestStorageAccess() lifts the partition,
-      // but it shows a native permission prompt that the popup window
-      // will steal focus from and dismiss if both fire from the same
-      // click.
-      //
-      // Order: (1) synchronously pre-open the popup at about:blank to
-      // consume the user gesture for window.open, (2) await the storage
-      // access prompt while the popup sits empty in the background, (3)
-      // navigate the already-open popup to the auth URL. Now the prompt
-      // has uninterrupted time to be answered.
-      const popup = preOpenPopupWindow();
-      await requestStorageAccess().catch(() => false);
+      // "Sign in required". Fire requestStorageAccess synchronously
+      // (no await before window.open or the gesture is gone) so by the
+      // time we write the token, the iframe shares the unpartitioned
+      // x.cartridge.gg storage the popup just wrote into.
+      const storageAccessGranted = requestStorageAccess().catch(() => false);
 
-      const { state, sessionToken } = await openPopupAuth(
-        {
-          action: "login",
-          username,
-          preset: preset ?? undefined,
-          rpcUrl: rpcUrl ?? undefined,
-          policies: policiesStr ?? undefined,
-          origin: origin ?? undefined,
-        },
-        popup,
-      );
+      const { state, sessionToken } = await openPopupAuth({
+        action: "login",
+        username,
+        preset: preset ?? undefined,
+        rpcUrl: rpcUrl ?? undefined,
+        policies: policiesStr ?? undefined,
+        origin: origin ?? undefined,
+      });
+
+      await storageAccessGranted;
 
       if (sessionToken) {
         setBearerToken(sessionToken);

--- a/packages/keychain/src/components/connect/create/webauthn/index.ts
+++ b/packages/keychain/src/components/connect/create/webauthn/index.ts
@@ -2,7 +2,7 @@ import { DEFAULT_SESSION_DURATION, now } from "@/constants";
 import { doSignup } from "@/hooks/account";
 import { useConnection } from "@/hooks/connection";
 import Controller from "@/utils/controller";
-import { openPopupAuth } from "@/utils/connection/popup";
+import { openPopupAuth, preOpenPopupWindow } from "@/utils/connection/popup";
 import { setBearerToken } from "@/utils/bearer-token";
 import { requestStorageAccess } from "@/utils/connection/storage-access";
 import { Owner } from "@cartridge/controller-wasm";
@@ -109,24 +109,32 @@ export function useWebauthnAuthentication() {
   const loginViaPopup = useCallback(
     async (username: string) => {
       // iOS Safari partitions iframe localStorage strictly by parent site,
-      // so a bearer token written after the popup return can land in a
+      // so a bearer token written after the popup returns can land in a
       // partition the fetcher can't see — leaving the user stuck on
-      // "Sign in required". Fire requestStorageAccess synchronously
-      // (no await before window.open or the gesture is gone) so by the
-      // time we write the token, the iframe shares the unpartitioned
-      // x.cartridge.gg storage the popup just wrote into.
-      const storageAccessGranted = requestStorageAccess().catch(() => false);
+      // "Sign in required". requestStorageAccess() lifts the partition,
+      // but it shows a native permission prompt that the popup window
+      // will steal focus from and dismiss if both fire from the same
+      // click.
+      //
+      // Order: (1) synchronously pre-open the popup at about:blank to
+      // consume the user gesture for window.open, (2) await the storage
+      // access prompt while the popup sits empty in the background, (3)
+      // navigate the already-open popup to the auth URL. Now the prompt
+      // has uninterrupted time to be answered.
+      const popup = preOpenPopupWindow();
+      await requestStorageAccess().catch(() => false);
 
-      const { state, sessionToken } = await openPopupAuth({
-        action: "login",
-        username,
-        preset: preset ?? undefined,
-        rpcUrl: rpcUrl ?? undefined,
-        policies: policiesStr ?? undefined,
-        origin: origin ?? undefined,
-      });
-
-      await storageAccessGranted;
+      const { state, sessionToken } = await openPopupAuth(
+        {
+          action: "login",
+          username,
+          preset: preset ?? undefined,
+          rpcUrl: rpcUrl ?? undefined,
+          policies: policiesStr ?? undefined,
+          origin: origin ?? undefined,
+        },
+        popup,
+      );
 
       if (sessionToken) {
         setBearerToken(sessionToken);

--- a/packages/keychain/src/components/purchasenew/checkout/coinbase/index.tsx
+++ b/packages/keychain/src/components/purchasenew/checkout/coinbase/index.tsx
@@ -191,6 +191,20 @@ export function CoinbaseCheckout({
     // will flip us into verify-* if the user is actually blocked.
     if (!hasLimitsLoaded || limitExceeded) return;
 
+    // iOS Safari requires window.open() to fire synchronously from the user
+    // gesture. onCreateCoinbaseOrder is async and would consume the gesture
+    // before we get a payment link, so pre-open at about:blank now and
+    // navigate the same window after the order resolves.
+    const width = 500;
+    const height = 700;
+    const left = (window.screen.width - width) / 2;
+    const top = (window.screen.height - height) / 2;
+    const preOpenedPopup = window.open(
+      "about:blank",
+      "coinbase-payment",
+      `width=${width},height=${height},left=${left},top=${top},toolbar=no,menubar=no,scrollbars=yes,resizable=yes`,
+    );
+
     setMode("status");
     setIsOpeningPopup(true);
     try {
@@ -202,9 +216,15 @@ export function CoinbaseCheckout({
         openPaymentPopup({
           paymentLink: nextPaymentLink,
           orderId: nextOrderId,
+          preOpenedPopup,
         });
+      } else if (preOpenedPopup && !preOpenedPopup.closed) {
+        preOpenedPopup.close();
       }
     } catch (err) {
+      if (preOpenedPopup && !preOpenedPopup.closed) {
+        preOpenedPopup.close();
+      }
       // Coinbase can still reject after we pass our local check — for example,
       // if /limits came back stale. Re-fetch limits so the mode-setting effect
       // can transition to the verify flow on the next render.

--- a/packages/keychain/src/components/purchasenew/checkout/onchain/index.tsx
+++ b/packages/keychain/src/components/purchasenew/checkout/onchain/index.tsx
@@ -27,6 +27,8 @@ import {
   COINBASE_APPLE_PAY_MIN_USD,
 } from "@/hooks/starterpack";
 import { ControllerErrorAlert } from "@/components/ErrorAlert";
+import { useWebauthnAuthentication } from "@/components/connect/create/webauthn";
+import { isUnauthenticatedError } from "@/utils/bearer-token";
 import { Receiving } from "../../receiving";
 import { OnchainCostBreakdown } from "../../review/cost";
 import { LoadingState } from "../../loading";
@@ -94,6 +96,7 @@ export function OnchainCheckout() {
   const { refetch: refetchMe } = useMeQuery(undefined, { enabled: false });
   const { data: accountPrivateData, refetch: refetchAccountPrivate } =
     useAccountPrivateQuery();
+  const { loginViaPopup: loginWithWebauthnPopup } = useWebauthnAuthentication();
   const hasVerifiedPhone =
     !!accountPrivateData?.accountPrivate?.phoneNumber &&
     !!accountPrivateData?.accountPrivate?.phoneNumberVerifiedAt;
@@ -315,6 +318,35 @@ export function OnchainCheckout() {
     setIsDrawerOpen(true);
   }, []);
 
+  // Bearer-token expiry on the iframe surfaces here as an Authentication
+  // Required error. Re-mint via the popup-backed login (cookie session is
+  // first-party there), then clear the error and refetch — the user can
+  // continue without leaving the screen.
+  const needsReauth = useMemo(
+    () => isUnauthenticatedError(displayError),
+    [displayError],
+  );
+  const [isSigningIn, setIsSigningIn] = useState(false);
+  const handleSignIn = useCallback(async () => {
+    if (!controller) return;
+    setIsSigningIn(true);
+    try {
+      await loginWithWebauthnPopup(controller.username());
+      clearError();
+      await Promise.all([refetchMe(), refetchAccountPrivate()]);
+    } catch (e) {
+      console.error("Re-auth popup failed:", e);
+    } finally {
+      setIsSigningIn(false);
+    }
+  }, [
+    controller,
+    loginWithWebauthnPopup,
+    clearError,
+    refetchMe,
+    refetchAccountPrivate,
+  ]);
+
   const handlePurchase = useCallback(async () => {
     if (isApplePayAmountTooLow) return;
     if (isCoinflowSelected) {
@@ -485,137 +517,158 @@ export function OnchainCheckout() {
       </LayoutContent>
 
       <LayoutFooter>
-        {displayError && !showBridgeAmountTooLow && (
-          <ControllerErrorAlert error={displayError} />
-        )}
-
-        {socialClaimConditions ? (
-          <SocialClaimCheckout
-            bundleId={(starterpackDetails as OnchainStarterpackDetails).id}
-            options={socialClaimOptions}
-            conditions={socialClaimConditions}
-            isLoading={isLoading}
-            handlePurchase={handlePurchase}
-            isFree={isFree}
-          />
-        ) : isFree ? (
-          <Button
-            className="w-full"
-            isLoading={isLoading}
-            onClick={handlePurchase}
-          >
-            Claim
-          </Button>
+        {needsReauth ? (
+          <>
+            <ErrorCard
+              variant="warning"
+              title="Sign in required"
+              message="Your session has expired. Please sign in again to complete your purchase."
+            />
+            <Button
+              className="w-full"
+              isLoading={isSigningIn}
+              onClick={handleSignIn}
+            >
+              Sign in
+            </Button>
+          </>
         ) : (
           <>
-            {balanceError && (
-              <ErrorCard
-                variant="error"
-                title="Balance Check Failed"
-                message={balanceError}
-              />
+            {displayError && !showBridgeAmountTooLow && (
+              <ControllerErrorAlert error={displayError} />
             )}
 
-            {showInsufficientBalance && (
-              <ErrorCard
-                variant="warning"
-                title="Insufficient Balance"
-                message={`You need more ${tokenSymbol} to complete this purchase.`}
+            {socialClaimConditions ? (
+              <SocialClaimCheckout
+                bundleId={(starterpackDetails as OnchainStarterpackDetails).id}
+                options={socialClaimOptions}
+                conditions={socialClaimConditions}
+                isLoading={isLoading}
+                handlePurchase={handlePurchase}
+                isFree={isFree}
               />
+            ) : isFree ? (
+              <Button
+                className="w-full"
+                isLoading={isLoading}
+                onClick={handlePurchase}
+              >
+                Claim
+              </Button>
+            ) : (
+              <>
+                {balanceError && (
+                  <ErrorCard
+                    variant="error"
+                    title="Balance Check Failed"
+                    message={balanceError}
+                  />
+                )}
+
+                {showInsufficientBalance && (
+                  <ErrorCard
+                    variant="warning"
+                    title="Insufficient Balance"
+                    message={`You need more ${tokenSymbol} to complete this purchase.`}
+                  />
+                )}
+
+                {showConversionError && (
+                  <ErrorCard
+                    variant="error"
+                    title="Insufficient Liquidity"
+                    message={`Unable to swap to ${selectedToken?.symbol}. Try selecting a different token.`}
+                  />
+                )}
+
+                {showBridgeAmountTooLow && (
+                  <ErrorCard
+                    variant="warning"
+                    title="Amount Too Low"
+                    message="Bridge amount is too low for this network. Try increasing quantity or selecting a different network."
+                  />
+                )}
+
+                {isCoinflowSelected && !isCoinflowStarterpackSupported && (
+                  <ErrorCard
+                    variant="error"
+                    title="Credit Card Checkout Unavailable"
+                    message="Credit card checkout is only available for starterpacks priced in USDC."
+                  />
+                )}
+
+                {isApplePayAmountTooLow && (
+                  <ErrorCard
+                    variant="warning"
+                    title="Amount Too Low"
+                    message="Minimum purchase amount is $2.00 for Apple Pay."
+                  />
+                )}
+
+                {isApplePaySelected && applePayMinQuantity !== undefined && (
+                  <ErrorCard
+                    variant="warning"
+                    title="Quantity Adjusted"
+                    message={`Quantity set to ${applePayMinQuantity} to meet the $2.00 Apple Pay minimum.`}
+                  />
+                )}
+
+                <WalletSelector
+                  walletName={
+                    isCoinflowSelected
+                      ? "Credit Card"
+                      : isApplePaySelected
+                        ? "Apple Pay"
+                        : wallet.name
+                  }
+                  walletIcon={
+                    isCoinflowSelected ? (
+                      <CreditCardIcon size="xs" variant="solid" />
+                    ) : isApplePaySelected ? (
+                      <AppleIcon size="xs" />
+                    ) : (
+                      wallet.subIcon
+                    )
+                  }
+                  bridgeFrom={bridgeFrom}
+                  onClick={handleWalletSelect}
+                />
+
+                <OnchainCostBreakdown quote={quote} />
+
+                <QuantityControls
+                  quantity={quantity}
+                  isLoading={
+                    isLoading ||
+                    isCheckingFallback ||
+                    (bridgeFrom !== null && isFetchingFees) ||
+                    isCreatingOrder ||
+                    isCoinflowLoading ||
+                    applePayLimitsLoading
+                  }
+                  isSendingDeposit={isSendingDeposit}
+                  globalDisabled={globalDisabled}
+                  hasSufficientBalance={
+                    hasSufficientBalance ||
+                    isApplePaySelected ||
+                    isCoinflowSelected
+                  }
+                  bridgeFrom={bridgeFrom}
+                  onIncrement={incrementQuantity}
+                  onDecrement={decrementQuantity}
+                  onPurchase={handlePurchase}
+                  onBridge={handleBridge}
+                  isApplePayAmountTooLow={isApplePayAmountTooLow}
+                  purchaseLabel={
+                    isCoinflowSelected
+                      ? "Continue"
+                      : applePayLimitExceeded
+                        ? "Verify to continue"
+                        : undefined
+                  }
+                />
+              </>
             )}
-
-            {showConversionError && (
-              <ErrorCard
-                variant="error"
-                title="Insufficient Liquidity"
-                message={`Unable to swap to ${selectedToken?.symbol}. Try selecting a different token.`}
-              />
-            )}
-
-            {showBridgeAmountTooLow && (
-              <ErrorCard
-                variant="warning"
-                title="Amount Too Low"
-                message="Bridge amount is too low for this network. Try increasing quantity or selecting a different network."
-              />
-            )}
-
-            {isCoinflowSelected && !isCoinflowStarterpackSupported && (
-              <ErrorCard
-                variant="error"
-                title="Credit Card Checkout Unavailable"
-                message="Credit card checkout is only available for starterpacks priced in USDC."
-              />
-            )}
-
-            {isApplePayAmountTooLow && (
-              <ErrorCard
-                variant="warning"
-                title="Amount Too Low"
-                message="Minimum purchase amount is $2.00 for Apple Pay."
-              />
-            )}
-
-            {isApplePaySelected && applePayMinQuantity !== undefined && (
-              <ErrorCard
-                variant="warning"
-                title="Quantity Adjusted"
-                message={`Quantity set to ${applePayMinQuantity} to meet the $2.00 Apple Pay minimum.`}
-              />
-            )}
-
-            <WalletSelector
-              walletName={
-                isCoinflowSelected
-                  ? "Credit Card"
-                  : isApplePaySelected
-                    ? "Apple Pay"
-                    : wallet.name
-              }
-              walletIcon={
-                isCoinflowSelected ? (
-                  <CreditCardIcon size="xs" variant="solid" />
-                ) : isApplePaySelected ? (
-                  <AppleIcon size="xs" />
-                ) : (
-                  wallet.subIcon
-                )
-              }
-              bridgeFrom={bridgeFrom}
-              onClick={handleWalletSelect}
-            />
-
-            <OnchainCostBreakdown quote={quote} />
-
-            <QuantityControls
-              quantity={quantity}
-              isLoading={
-                isLoading ||
-                isCheckingFallback ||
-                (bridgeFrom !== null && isFetchingFees) ||
-                isCreatingOrder ||
-                isCoinflowLoading ||
-                applePayLimitsLoading
-              }
-              isSendingDeposit={isSendingDeposit}
-              globalDisabled={globalDisabled}
-              hasSufficientBalance={
-                hasSufficientBalance || isApplePaySelected || isCoinflowSelected
-              }
-              bridgeFrom={bridgeFrom}
-              onIncrement={incrementQuantity}
-              onDecrement={decrementQuantity}
-              onPurchase={handlePurchase}
-              onBridge={handleBridge}
-              isApplePayAmountTooLow={isApplePayAmountTooLow}
-              purchaseLabel={
-                isCoinflowSelected
-                  ? "Continue"
-                  : applePayLimitExceeded
-                    ? "Verify to continue"
-                    : undefined
-              }
-            />
           </>
         )}
       </LayoutFooter>

--- a/packages/keychain/src/context/starterpack/onchain-purchase.tsx
+++ b/packages/keychain/src/context/starterpack/onchain-purchase.tsx
@@ -126,7 +126,11 @@ export interface OnchainPurchaseContextType {
   onCreateCoinbaseOrder: (opts?: {
     force?: boolean;
   }) => Promise<CoinbaseOrderResult | undefined>;
-  openPaymentPopup: (opts?: { paymentLink?: string; orderId?: string }) => void;
+  openPaymentPopup: (opts?: {
+    paymentLink?: string;
+    orderId?: string;
+    preOpenedPopup?: Window | null;
+  }) => void;
   closePaymentPopup: () => void;
   resetCoinbasePurchase: () => void;
   getTransactions: (username: string) => Promise<CoinbaseTransactionResult[]>;

--- a/packages/keychain/src/hooks/connection.ts
+++ b/packages/keychain/src/hooks/connection.ts
@@ -401,10 +401,19 @@ export function useConnectionValue() {
     const isWindows = navigator.userAgent.indexOf("Win") !== -1;
     const isChromium = /Chrome|Chromium/i.test(navigator.userAgent);
 
+    // Safari ITP partitions the cookie jar by parent site, so any iframe
+    // context (not just nested) needs the popup to mint a bearer token.
+    let isIframed = false;
+    try {
+      isIframed = window.self !== window.top;
+    } catch {
+      isIframed = true;
+    }
+
     if (isSafari || (isWindows && isChromium)) {
       return {
         create: true,
-        get: isSafari ? isNestedIframe() : true,
+        get: isSafari ? isIframed : true,
       };
     }
 

--- a/packages/keychain/src/hooks/starterpack/coinbase.ts
+++ b/packages/keychain/src/hooks/starterpack/coinbase.ts
@@ -83,7 +83,11 @@ export interface UseCoinbaseReturn {
   createOrder: (input: CreateOrderInput) => Promise<CoinbaseOrderResult>;
   getTransactions: (username: string) => Promise<CoinbaseTransactionResult[]>;
   getQuote: (input: CoinbaseQuoteInput) => Promise<CoinbaseQuoteResult>;
-  openPaymentPopup: (opts?: { paymentLink?: string; orderId?: string }) => void;
+  openPaymentPopup: (opts?: {
+    paymentLink?: string;
+    orderId?: string;
+    preOpenedPopup?: Window | null;
+  }) => void;
   /** Force-close the in-flight payment popup. The internal popup-closed
    * watcher then runs its normal cleanup path (stops polling, sets
    * `popupClosed=true` if no terminal status was reached). */
@@ -384,10 +388,21 @@ export function useCoinbase({
 
   /** Open the payment link in a popup and listen via postMessage */
   const openPaymentPopup = useCallback(
-    (opts?: { paymentLink?: string; orderId?: string }) => {
+    (opts?: {
+      paymentLink?: string;
+      orderId?: string;
+      preOpenedPopup?: Window | null;
+    }) => {
       const targetPaymentLink = opts?.paymentLink ?? paymentLink;
       const targetOrderId = opts?.orderId ?? orderId;
-      if (!targetPaymentLink || !targetOrderId) return;
+      if (!targetPaymentLink || !targetOrderId) {
+        // Caller pre-opened a window but we have nothing to navigate it to;
+        // close it so the user doesn't see a stranded blank popup.
+        if (opts?.preOpenedPopup && !opts.preOpenedPopup.closed) {
+          opts.preOpenedPopup.close();
+        }
+        return;
+      }
 
       // Reset state for a new popup session
       setPopupClosed(false);
@@ -412,11 +427,19 @@ export function useCoinbase({
       const left = (window.screen.width - width) / 2;
       const top = (window.screen.height - height) / 2;
 
-      const popup = window.open(
-        popupUrl.toString(),
-        "coinbase-payment",
-        `width=${width},height=${height},left=${left},top=${top},toolbar=no,menubar=no,scrollbars=yes,resizable=yes`,
-      );
+      let popup: Window | null;
+      if (opts?.preOpenedPopup && !opts.preOpenedPopup.closed) {
+        // Reuse the popup the caller pre-opened to keep window.open
+        // synchronous to the user gesture (iOS Safari blocks otherwise).
+        popup = opts.preOpenedPopup;
+        popup.location.href = popupUrl.toString();
+      } else {
+        popup = window.open(
+          popupUrl.toString(),
+          "coinbase-payment",
+          `width=${width},height=${height},left=${left},top=${top},toolbar=no,menubar=no,scrollbars=yes,resizable=yes`,
+        );
+      }
       popupRef.current = popup;
 
       // Start slow 15s fallback poll (catches completions even if postMessage signal is lost)

--- a/packages/keychain/src/utils/api/fetcher.tsx
+++ b/packages/keychain/src/utils/api/fetcher.tsx
@@ -1,4 +1,5 @@
 import { useCartridgeAPI } from "@cartridge/controller-ui/utils";
+import { getBearerToken } from "@/utils/bearer-token";
 
 export function fetchDataCreator(
   url: string,
@@ -12,11 +13,13 @@ export function fetchDataCreator(
     variables?: TVariables,
     signal?: AbortSignal,
   ): Promise<TData> => {
+    const bearerToken = getBearerToken();
     const res = await fetch(url, {
       method: "POST",
       credentials: options?.credentials || "include",
       headers: {
         "Content-Type": "application/json",
+        ...(bearerToken && { Authorization: `Bearer ${bearerToken}` }),
         ...options?.headers,
       },
       body: JSON.stringify({

--- a/packages/keychain/src/utils/api/generated.ts
+++ b/packages/keychain/src/utils/api/generated.ts
@@ -3182,6 +3182,12 @@ export type Mutation = {
    */
   coinflowCardCheckout: CoinflowCardCheckoutResult;
   /**
+   * Issues a 14-day Bearer JWT for the currently authenticated cookie session.
+   * Used to bridge first-party cookie auth (e.g. set in a top-level popup) to
+   * contexts where the cookie is unavailable, like a third-party iframe in Safari.
+   */
+  createBearerToken: Scalars["String"];
+  /**
    * Create a unified Coinbase onramp order.
    * This mutation orchestrates both Coinbase and Layerswap to bridge USDC from Apple Pay to Starknet.
    */

--- a/packages/keychain/src/utils/bearer-token.ts
+++ b/packages/keychain/src/utils/bearer-token.ts
@@ -1,0 +1,65 @@
+// Bearer token storage and issuance for cookie-less auth.
+//
+// The keychain iframe cannot rely on the auth cookie when embedded in a
+// third-party parent because Safari ITP partitions the cookie jar by parent
+// site. Instead, the popup (running first-party at x.cartridge.gg) exchanges
+// its cookie for a JWT via createBearerToken, posts the JWT to the iframe,
+// and the iframe attaches it as Authorization: Bearer on every request.
+//
+// localStorage is automatically partitioned per parent site by both Safari
+// and Chrome, so each embedding site gets its own token without extra keying.
+
+const STORAGE_KEY = "cartridge.bearerToken";
+
+export function setBearerToken(token: string): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, token);
+  } catch {
+    // localStorage may be unavailable in private browsing modes.
+  }
+}
+
+export function getBearerToken(): string | null {
+  try {
+    return localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function clearBearerToken(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+// Calls createBearerToken in the popup, where the cookie is first-party.
+// Returns null on failure so the popup can still complete (the iframe will
+// fall back to whatever auth path it can — useful in non-Safari contexts).
+export async function issueBearerToken(): Promise<string | null> {
+  const apiUrl = import.meta.env.VITE_CARTRIDGE_API_URL;
+  if (!apiUrl) return null;
+
+  try {
+    const res = await fetch(`${apiUrl}/query`, {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query: "mutation { createBearerToken }" }),
+    });
+
+    if (!res.ok) return null;
+
+    const json = (await res.json()) as {
+      data?: { createBearerToken?: string };
+      errors?: unknown;
+    };
+
+    if (json.errors || !json.data?.createBearerToken) return null;
+    return json.data.createBearerToken;
+  } catch {
+    return null;
+  }
+}

--- a/packages/keychain/src/utils/bearer-token.ts
+++ b/packages/keychain/src/utils/bearer-token.ts
@@ -9,6 +9,11 @@
 // localStorage is automatically partitioned per parent site by both Safari
 // and Chrome, so each embedding site gets its own token without extra keying.
 
+// Intentionally NOT prefixed `@cartridge/` — keys with that prefix are bundled
+// into the cross-domain encrypted snapshot (see utils/storageSnapshot.ts) and
+// would follow the user across embedding sites. We want the bearer token to
+// stay scoped to its parent-site-partitioned localStorage, so each embedding
+// site requires its own popup-auth.
 const STORAGE_KEY = "cartridge.bearerToken";
 
 export function setBearerToken(token: string): void {

--- a/packages/keychain/src/utils/bearer-token.ts
+++ b/packages/keychain/src/utils/bearer-token.ts
@@ -40,6 +40,17 @@ export function clearBearerToken(): void {
   }
 }
 
+// Heuristic: does this error look like the API rejected our auth?
+// Matches both the GRPC code surfaced by the Go resolvers ("Unauthenticated")
+// and the friendly summary text from utils/errors.ts.
+export function isUnauthenticatedError(error?: Error | null): boolean {
+  if (!error) return false;
+  const msg = error.message?.toLowerCase() ?? "";
+  return (
+    msg.includes("unauthenticated") || msg.includes("authentication required")
+  );
+}
+
 // Calls createBearerToken in the popup, where the cookie is first-party.
 // Returns null on failure so the popup can still complete (the iframe will
 // fall back to whatever auth path it can — useful in non-Safari contexts).

--- a/packages/keychain/src/utils/connection/popup.ts
+++ b/packages/keychain/src/utils/connection/popup.ts
@@ -35,15 +35,40 @@ export type PopupAuthResult = {
 
 let activePopup: Window | null = null;
 
-export function openPopupAuth(
-  options: PopupAuthOptions,
-): Promise<PopupAuthResult> {
-  // Prevent multiple concurrent popups
+const POPUP_NAME = "cartridge-popup-auth";
+
+function popupFeatures(): string {
+  const left = Math.round(
+    (window.screen.width - POPUP_WIDTH) / 2 + (window.screenX || 0),
+  );
+  const top = Math.round(
+    (window.screen.height - POPUP_HEIGHT) / 2 + (window.screenY || 0),
+  );
+  return `width=${POPUP_WIDTH},height=${POPUP_HEIGHT},left=${left},top=${top},scrollbars=yes,resizable=yes`;
+}
+
+// Synchronously open an empty popup window. Use when the caller needs to do
+// async work (e.g. requestStorageAccess) before navigating — the user gesture
+// for window.open() must be consumed inside the click handler, before any
+// await yields a microtask. The returned window can later be passed to
+// openPopupAuth, which will navigate it to the auth URL.
+export function preOpenPopupWindow(): Window | null {
   if (activePopup && !activePopup.closed) {
     activePopup.focus();
-    return Promise.reject(new Error("A popup auth window is already open"));
+    return null;
   }
 
+  const popup = window.open("about:blank", POPUP_NAME, popupFeatures());
+  if (popup) {
+    activePopup = popup;
+  }
+  return popup;
+}
+
+export function openPopupAuth(
+  options: PopupAuthOptions,
+  preOpened?: Window | null,
+): Promise<PopupAuthResult> {
   const channelId = crypto.randomUUID();
 
   const url = new URL(`${window.location.origin}/auth`);
@@ -66,29 +91,25 @@ export function openPopupAuth(
     url.searchParams.set("username", options.username);
   }
 
-  // Center the popup on screen
-  const left = Math.round(
-    (window.screen.width - POPUP_WIDTH) / 2 + (window.screenX || 0),
-  );
-  const top = Math.round(
-    (window.screen.height - POPUP_HEIGHT) / 2 + (window.screenY || 0),
-  );
-
-  const popup = window.open(
-    url.toString(),
-    "cartridge-popup-auth",
-    `width=${POPUP_WIDTH},height=${POPUP_HEIGHT},left=${left},top=${top},scrollbars=yes,resizable=yes`,
-  );
-
-  if (!popup) {
-    return Promise.reject(
-      new Error(
-        "Popup blocked. Please allow popups for this site and try again.",
-      ),
-    );
+  let popup: Window | null;
+  if (preOpened && !preOpened.closed) {
+    popup = preOpened;
+    popup.location.href = url.toString();
+  } else {
+    if (activePopup && !activePopup.closed) {
+      activePopup.focus();
+      return Promise.reject(new Error("A popup auth window is already open"));
+    }
+    popup = window.open(url.toString(), POPUP_NAME, popupFeatures());
+    if (!popup) {
+      return Promise.reject(
+        new Error(
+          "Popup blocked. Please allow popups for this site and try again.",
+        ),
+      );
+    }
+    activePopup = popup;
   }
-
-  activePopup = popup;
 
   return new Promise<PopupAuthResult>((resolve, reject) => {
     let settled = false;

--- a/packages/keychain/src/utils/connection/popup.ts
+++ b/packages/keychain/src/utils/connection/popup.ts
@@ -11,6 +11,7 @@ type PopupMessage =
       type: "auth-complete";
       channelId: string;
       state: ImportedControllerState;
+      sessionToken: string | null;
     }
   | {
       type: "auth-error";
@@ -27,7 +28,10 @@ export interface PopupAuthOptions {
   username?: string;
 }
 
-export type PopupAuthResult = ImportedControllerState;
+export type PopupAuthResult = {
+  state: ImportedControllerState;
+  sessionToken: string | null;
+};
 
 let activePopup: Window | null = null;
 
@@ -109,7 +113,7 @@ export function openPopupAuth(
           window.location.origin,
         );
         cleanup();
-        resolve(data.state);
+        resolve({ state: data.state, sessionToken: data.sessionToken });
       } else if (data.type === "auth-error") {
         cleanup();
         reject(new Error(data.error ?? "Popup authentication failed"));

--- a/packages/keychain/src/utils/connection/popup.ts
+++ b/packages/keychain/src/utils/connection/popup.ts
@@ -35,40 +35,15 @@ export type PopupAuthResult = {
 
 let activePopup: Window | null = null;
 
-const POPUP_NAME = "cartridge-popup-auth";
-
-function popupFeatures(): string {
-  const left = Math.round(
-    (window.screen.width - POPUP_WIDTH) / 2 + (window.screenX || 0),
-  );
-  const top = Math.round(
-    (window.screen.height - POPUP_HEIGHT) / 2 + (window.screenY || 0),
-  );
-  return `width=${POPUP_WIDTH},height=${POPUP_HEIGHT},left=${left},top=${top},scrollbars=yes,resizable=yes`;
-}
-
-// Synchronously open an empty popup window. Use when the caller needs to do
-// async work (e.g. requestStorageAccess) before navigating — the user gesture
-// for window.open() must be consumed inside the click handler, before any
-// await yields a microtask. The returned window can later be passed to
-// openPopupAuth, which will navigate it to the auth URL.
-export function preOpenPopupWindow(): Window | null {
-  if (activePopup && !activePopup.closed) {
-    activePopup.focus();
-    return null;
-  }
-
-  const popup = window.open("about:blank", POPUP_NAME, popupFeatures());
-  if (popup) {
-    activePopup = popup;
-  }
-  return popup;
-}
-
 export function openPopupAuth(
   options: PopupAuthOptions,
-  preOpened?: Window | null,
 ): Promise<PopupAuthResult> {
+  // Prevent multiple concurrent popups
+  if (activePopup && !activePopup.closed) {
+    activePopup.focus();
+    return Promise.reject(new Error("A popup auth window is already open"));
+  }
+
   const channelId = crypto.randomUUID();
 
   const url = new URL(`${window.location.origin}/auth`);
@@ -91,25 +66,29 @@ export function openPopupAuth(
     url.searchParams.set("username", options.username);
   }
 
-  let popup: Window | null;
-  if (preOpened && !preOpened.closed) {
-    popup = preOpened;
-    popup.location.href = url.toString();
-  } else {
-    if (activePopup && !activePopup.closed) {
-      activePopup.focus();
-      return Promise.reject(new Error("A popup auth window is already open"));
-    }
-    popup = window.open(url.toString(), POPUP_NAME, popupFeatures());
-    if (!popup) {
-      return Promise.reject(
-        new Error(
-          "Popup blocked. Please allow popups for this site and try again.",
-        ),
-      );
-    }
-    activePopup = popup;
+  // Center the popup on screen
+  const left = Math.round(
+    (window.screen.width - POPUP_WIDTH) / 2 + (window.screenX || 0),
+  );
+  const top = Math.round(
+    (window.screen.height - POPUP_HEIGHT) / 2 + (window.screenY || 0),
+  );
+
+  const popup = window.open(
+    url.toString(),
+    "cartridge-popup-auth",
+    `width=${POPUP_WIDTH},height=${POPUP_HEIGHT},left=${left},top=${top},scrollbars=yes,resizable=yes`,
+  );
+
+  if (!popup) {
+    return Promise.reject(
+      new Error(
+        "Popup blocked. Please allow popups for this site and try again.",
+      ),
+    );
   }
+
+  activePopup = popup;
 
   return new Promise<PopupAuthResult>((resolve, reject) => {
     let settled = false;

--- a/packages/keychain/src/utils/controller.ts
+++ b/packages/keychain/src/utils/controller.ts
@@ -32,6 +32,7 @@ import {
 
 import { credentialToAuth } from "@/components/connect/types";
 import { ParsedSessionPolicies } from "@/hooks/session";
+import { clearBearerToken } from "@/utils/bearer-token";
 import { toWasmPolicies } from "@cartridge/controller";
 import { CredentialMetadata } from "@cartridge/controller-ui/utils/api/cartridge";
 import { DeployedAccountTransaction } from "@starknet-io/types-js";
@@ -81,6 +82,7 @@ export default class Controller {
 
   async disconnect() {
     await this.cartridge.disconnect();
+    clearBearerToken();
     delete window.controller;
   }
 

--- a/packages/keychain/src/utils/graphql.ts
+++ b/packages/keychain/src/utils/graphql.ts
@@ -5,12 +5,42 @@ import {
 } from "graphql-request";
 import { fetchDataCreator } from "@cartridge/controller-ui/utils";
 import { parseClientError, type ErrorWithGraphQL } from "./errors";
+import { getBearerToken } from "./bearer-token";
 
 export const ENDPOINT = `${import.meta.env.VITE_CARTRIDGE_API_URL}/query`;
 
-export const client = new GraphQLClient(ENDPOINT, { credentials: "include" });
+// Read fresh per request — bearer token can appear/change after popup login
+// without anything calling fetchDataCreator/GraphQLClient again.
+function authHeader(): Record<string, string> {
+  const token = getBearerToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
 
-export const fetchData = fetchDataCreator(ENDPOINT);
+export const client = new GraphQLClient(ENDPOINT, {
+  credentials: "include",
+  requestMiddleware: (req) => ({
+    ...req,
+    headers: { ...req.headers, ...authHeader() },
+  }),
+});
+
+const baseFetchData = fetchDataCreator(ENDPOINT);
+export async function fetchData<TData, TVariables>(
+  query: string,
+  variables?: TVariables,
+  signal?: AbortSignal,
+): Promise<TData> {
+  const headers = authHeader();
+  if (Object.keys(headers).length === 0) {
+    return baseFetchData<TData, TVariables>(query, variables, signal);
+  }
+  // Build a fresh fetcher with the current bearer; cheap, captures token at call time.
+  return fetchDataCreator(ENDPOINT, { headers })<TData, TVariables>(
+    query,
+    variables,
+    signal,
+  );
+}
 
 /**
  * Wrapper for GraphQL requests that handles RPC errors wrapped in GraphQL errors.

--- a/packages/ui/src/utils/api/cartridge/fetcher.ts
+++ b/packages/ui/src/utils/api/cartridge/fetcher.ts
@@ -1,6 +1,24 @@
 import { useCartridgeAPI } from "../../hooks";
 import { fetchDataCreator } from "../fetcher";
 
+// Mirrors the key used by the keychain bearer-token util
+// (packages/keychain/src/utils/bearer-token.ts). The token is written by
+// the keychain after popup auth, and queries here need to attach it on
+// every request so iframe contexts where the auth cookie is unavailable
+// (Safari ITP) still authenticate. Read fresh per request — the token
+// can appear/change after login without re-rendering the consumer.
+const BEARER_TOKEN_KEY = "cartridge.bearerToken";
+
+function getBearerToken(): string | null {
+  try {
+    return typeof window !== "undefined"
+      ? window.localStorage.getItem(BEARER_TOKEN_KEY)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 export function useFetchData<TData, TVariables>(
   query: string,
   options?: {
@@ -10,13 +28,16 @@ export function useFetchData<TData, TVariables>(
 ): (variables?: TVariables) => Promise<TData> {
   const { url, credentials, headers } = useCartridgeAPI();
 
-  const fetchData = fetchDataCreator(url, {
-    credentials: options?.credentials || credentials,
-    headers: {
-      ...headers,
-      ...options?.headers,
-    },
-  });
-
-  return (variables?: TVariables) => fetchData(query, variables);
+  return async (variables?: TVariables) => {
+    const bearerToken = getBearerToken();
+    const fetchData = fetchDataCreator(url, {
+      credentials: options?.credentials || credentials,
+      headers: {
+        ...headers,
+        ...(bearerToken && { Authorization: `Bearer ${bearerToken}` }),
+        ...options?.headers,
+      },
+    });
+    return fetchData(query, variables);
+  };
 }

--- a/packages/ui/src/utils/api/cartridge/generated.ts
+++ b/packages/ui/src/utils/api/cartridge/generated.ts
@@ -34,6 +34,7 @@ export type Account = Node & {
   id: Scalars['ID'];
   membership: AccountTeamConnection;
   name?: Maybe<Scalars['String']>;
+  notificationDevices: NotificationDeviceConnection;
   oauthConnections?: Maybe<Array<OAuthConnection>>;
   /** If true, the account is billed for paid slot deployments */
   slotBilling: Scalars['Boolean'];
@@ -80,6 +81,16 @@ export type AccountMembershipArgs = {
   first?: InputMaybe<Scalars['Int']>;
   last?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<AccountTeamWhereInput>;
+};
+
+
+export type AccountNotificationDevicesArgs = {
+  after?: InputMaybe<Scalars['Cursor']>;
+  before?: InputMaybe<Scalars['Cursor']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<NotificationDeviceOrder>;
+  where?: InputMaybe<NotificationDeviceWhereInput>;
 };
 
 
@@ -247,6 +258,9 @@ export type AccountWhereInput = {
   /** membership edge predicates */
   hasMembership?: InputMaybe<Scalars['Boolean']>;
   hasMembershipWith?: InputMaybe<Array<AccountTeamWhereInput>>;
+  /** notification_devices edge predicates */
+  hasNotificationDevices?: InputMaybe<Scalars['Boolean']>;
+  hasNotificationDevicesWith?: InputMaybe<Array<NotificationDeviceWhereInput>>;
   /** oauth_connections edge predicates */
   hasOauthConnections?: InputMaybe<Scalars['Boolean']>;
   hasOauthConnectionsWith?: InputMaybe<Array<OAuthConnectionWhereInput>>;
@@ -3164,6 +3178,12 @@ export type Mutation = {
    */
   coinflowCardCheckout: CoinflowCardCheckoutResult;
   /**
+   * Issues a 14-day Bearer JWT for the currently authenticated cookie session.
+   * Used to bridge first-party cookie auth (e.g. set in a top-level popup) to
+   * contexts where the cookie is unavailable, like a third-party iframe in Safari.
+   */
+  createBearerToken: Scalars['String'];
+  /**
    * Create a unified Coinbase onramp order.
    * This mutation orchestrates both Coinbase and Layerswap to bridge USDC from Apple Pay to Starknet.
    */
@@ -3199,11 +3219,13 @@ export type Mutation = {
   deleteRpcCorsDomain: Scalars['Boolean'];
   deleteTeam: Scalars['Boolean'];
   deploy: Account;
+  disableNotificationDevice: Scalars['Boolean'];
   disconnectOAuth: Scalars['Boolean'];
   finalizeLogin: Scalars['String'];
   finalizeRegistration: Account;
   increaseBudget: Paymaster;
   register: Account;
+  registerNotificationDevice: NotificationDevice;
   removeAllPolicies: Scalars['Boolean'];
   removeFromTeam: Scalars['Boolean'];
   removeOwner: Scalars['Boolean'];
@@ -3215,6 +3237,7 @@ export type Mutation = {
    * The code expires after 10 minutes.
    */
   sendEmailVerification: SendVerificationResponse;
+  sendNotification: NotificationSendResult;
   /**
    * Send a verification code via SMS to the specified phone number.
    * The code expires after 10 minutes.
@@ -3428,6 +3451,11 @@ export type MutationDeployArgs = {
 };
 
 
+export type MutationDisableNotificationDeviceArgs = {
+  id: Scalars['ID'];
+};
+
+
 export type MutationDisconnectOAuthArgs = {
   provider: OAuthProvider;
 };
@@ -3458,6 +3486,11 @@ export type MutationRegisterArgs = {
   owner: SignerInput;
   session: SessionInput;
   username: Scalars['String'];
+};
+
+
+export type MutationRegisterNotificationDeviceArgs = {
+  input: RegisterNotificationDeviceInput;
 };
 
 
@@ -3498,6 +3531,11 @@ export type MutationRevokeSessionsArgs = {
 
 export type MutationSendEmailVerificationArgs = {
   input: SendEmailVerificationInput;
+};
+
+
+export type MutationSendNotificationArgs = {
+  input: SendNotificationInput;
 };
 
 
@@ -3590,6 +3628,168 @@ export enum Network {
 export type Node = {
   /** The id of the object. */
   id: Scalars['ID'];
+};
+
+export type NotificationDataInput = {
+  key: Scalars['String'];
+  value: Scalars['String'];
+};
+
+export type NotificationDevice = Node & {
+  __typename?: 'NotificationDevice';
+  account: Account;
+  /** Application namespace for the token, such as dopewars or cartridge */
+  appID: Scalars['String'];
+  createdAt: Scalars['Time'];
+  enabled: Scalars['Boolean'];
+  id: Scalars['ID'];
+  lastSeenAt: Scalars['Time'];
+  platform: NotificationDevicePlatform;
+  provider: NotificationDeviceProvider;
+  revokedAt?: Maybe<Scalars['Time']>;
+  updatedAt: Scalars['Time'];
+};
+
+/** A connection to a list of items. */
+export type NotificationDeviceConnection = {
+  __typename?: 'NotificationDeviceConnection';
+  /** A list of edges. */
+  edges?: Maybe<Array<Maybe<NotificationDeviceEdge>>>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Identifies the total count of items in the connection. */
+  totalCount: Scalars['Int'];
+};
+
+/** An edge in a connection. */
+export type NotificationDeviceEdge = {
+  __typename?: 'NotificationDeviceEdge';
+  /** A cursor for use in pagination. */
+  cursor: Scalars['Cursor'];
+  /** The item at the end of the edge. */
+  node?: Maybe<NotificationDevice>;
+};
+
+/** Ordering options for NotificationDevice connections */
+export type NotificationDeviceOrder = {
+  /** The ordering direction. */
+  direction?: OrderDirection;
+  /** The field by which to order NotificationDevices. */
+  field: NotificationDeviceOrderField;
+};
+
+/** Properties by which NotificationDevice connections can be ordered. */
+export enum NotificationDeviceOrderField {
+  CreatedAt = 'CREATED_AT'
+}
+
+/** NotificationDevicePlatform is enum for the field platform */
+export enum NotificationDevicePlatform {
+  Android = 'ANDROID',
+  Ios = 'IOS',
+  Web = 'WEB'
+}
+
+/** NotificationDeviceProvider is enum for the field provider */
+export enum NotificationDeviceProvider {
+  Apns = 'APNS',
+  Fcm = 'FCM'
+}
+
+/**
+ * NotificationDeviceWhereInput is used for filtering NotificationDevice objects.
+ * Input was generated by ent.
+ */
+export type NotificationDeviceWhereInput = {
+  and?: InputMaybe<Array<NotificationDeviceWhereInput>>;
+  /** app_id field predicates */
+  appID?: InputMaybe<Scalars['String']>;
+  appIDContains?: InputMaybe<Scalars['String']>;
+  appIDContainsFold?: InputMaybe<Scalars['String']>;
+  appIDEqualFold?: InputMaybe<Scalars['String']>;
+  appIDGT?: InputMaybe<Scalars['String']>;
+  appIDGTE?: InputMaybe<Scalars['String']>;
+  appIDHasPrefix?: InputMaybe<Scalars['String']>;
+  appIDHasSuffix?: InputMaybe<Scalars['String']>;
+  appIDIn?: InputMaybe<Array<Scalars['String']>>;
+  appIDLT?: InputMaybe<Scalars['String']>;
+  appIDLTE?: InputMaybe<Scalars['String']>;
+  appIDNEQ?: InputMaybe<Scalars['String']>;
+  appIDNotIn?: InputMaybe<Array<Scalars['String']>>;
+  /** created_at field predicates */
+  createdAt?: InputMaybe<Scalars['Time']>;
+  createdAtGT?: InputMaybe<Scalars['Time']>;
+  createdAtGTE?: InputMaybe<Scalars['Time']>;
+  createdAtIn?: InputMaybe<Array<Scalars['Time']>>;
+  createdAtLT?: InputMaybe<Scalars['Time']>;
+  createdAtLTE?: InputMaybe<Scalars['Time']>;
+  createdAtNEQ?: InputMaybe<Scalars['Time']>;
+  createdAtNotIn?: InputMaybe<Array<Scalars['Time']>>;
+  /** enabled field predicates */
+  enabled?: InputMaybe<Scalars['Boolean']>;
+  enabledNEQ?: InputMaybe<Scalars['Boolean']>;
+  /** account edge predicates */
+  hasAccount?: InputMaybe<Scalars['Boolean']>;
+  hasAccountWith?: InputMaybe<Array<AccountWhereInput>>;
+  /** id field predicates */
+  id?: InputMaybe<Scalars['ID']>;
+  idContainsFold?: InputMaybe<Scalars['ID']>;
+  idEqualFold?: InputMaybe<Scalars['ID']>;
+  idGT?: InputMaybe<Scalars['ID']>;
+  idGTE?: InputMaybe<Scalars['ID']>;
+  idIn?: InputMaybe<Array<Scalars['ID']>>;
+  idLT?: InputMaybe<Scalars['ID']>;
+  idLTE?: InputMaybe<Scalars['ID']>;
+  idNEQ?: InputMaybe<Scalars['ID']>;
+  idNotIn?: InputMaybe<Array<Scalars['ID']>>;
+  /** last_seen_at field predicates */
+  lastSeenAt?: InputMaybe<Scalars['Time']>;
+  lastSeenAtGT?: InputMaybe<Scalars['Time']>;
+  lastSeenAtGTE?: InputMaybe<Scalars['Time']>;
+  lastSeenAtIn?: InputMaybe<Array<Scalars['Time']>>;
+  lastSeenAtLT?: InputMaybe<Scalars['Time']>;
+  lastSeenAtLTE?: InputMaybe<Scalars['Time']>;
+  lastSeenAtNEQ?: InputMaybe<Scalars['Time']>;
+  lastSeenAtNotIn?: InputMaybe<Array<Scalars['Time']>>;
+  not?: InputMaybe<NotificationDeviceWhereInput>;
+  or?: InputMaybe<Array<NotificationDeviceWhereInput>>;
+  /** platform field predicates */
+  platform?: InputMaybe<NotificationDevicePlatform>;
+  platformIn?: InputMaybe<Array<NotificationDevicePlatform>>;
+  platformNEQ?: InputMaybe<NotificationDevicePlatform>;
+  platformNotIn?: InputMaybe<Array<NotificationDevicePlatform>>;
+  /** provider field predicates */
+  provider?: InputMaybe<NotificationDeviceProvider>;
+  providerIn?: InputMaybe<Array<NotificationDeviceProvider>>;
+  providerNEQ?: InputMaybe<NotificationDeviceProvider>;
+  providerNotIn?: InputMaybe<Array<NotificationDeviceProvider>>;
+  /** revoked_at field predicates */
+  revokedAt?: InputMaybe<Scalars['Time']>;
+  revokedAtGT?: InputMaybe<Scalars['Time']>;
+  revokedAtGTE?: InputMaybe<Scalars['Time']>;
+  revokedAtIn?: InputMaybe<Array<Scalars['Time']>>;
+  revokedAtIsNil?: InputMaybe<Scalars['Boolean']>;
+  revokedAtLT?: InputMaybe<Scalars['Time']>;
+  revokedAtLTE?: InputMaybe<Scalars['Time']>;
+  revokedAtNEQ?: InputMaybe<Scalars['Time']>;
+  revokedAtNotIn?: InputMaybe<Array<Scalars['Time']>>;
+  revokedAtNotNil?: InputMaybe<Scalars['Boolean']>;
+  /** updated_at field predicates */
+  updatedAt?: InputMaybe<Scalars['Time']>;
+  updatedAtGT?: InputMaybe<Scalars['Time']>;
+  updatedAtGTE?: InputMaybe<Scalars['Time']>;
+  updatedAtIn?: InputMaybe<Array<Scalars['Time']>>;
+  updatedAtLT?: InputMaybe<Scalars['Time']>;
+  updatedAtLTE?: InputMaybe<Scalars['Time']>;
+  updatedAtNEQ?: InputMaybe<Scalars['Time']>;
+  updatedAtNotIn?: InputMaybe<Array<Scalars['Time']>>;
+};
+
+export type NotificationSendResult = {
+  __typename?: 'NotificationSendResult';
+  disabled: Scalars['Int'];
+  failed: Scalars['Int'];
+  sent: Scalars['Int'];
 };
 
 export type OAuthConnection = Node & {
@@ -4731,6 +4931,7 @@ export type Query = {
   node?: Maybe<Node>;
   /** Lookup nodes by a list of IDs. */
   nodes: Array<Maybe<Node>>;
+  notificationDevices: Array<NotificationDevice>;
   ownerships: OwnershipResult;
   paymaster?: Maybe<Paymaster>;
   paymasterStats: PaymasterStats;
@@ -4979,6 +5180,11 @@ export type QueryNodeArgs = {
 
 export type QueryNodesArgs = {
   ids: Array<Scalars['ID']>;
+};
+
+
+export type QueryNotificationDevicesArgs = {
+  appId?: InputMaybe<Scalars['String']>;
 };
 
 
@@ -5697,6 +5903,13 @@ export type RpcLogWhereInput = {
   userAgentNotNil?: InputMaybe<Scalars['Boolean']>;
 };
 
+export type RegisterNotificationDeviceInput = {
+  appId: Scalars['String'];
+  platform: NotificationDevicePlatform;
+  provider: NotificationDeviceProvider;
+  token: Scalars['String'];
+};
+
 export type Resources = {
   __typename?: 'Resources';
   cpu?: Maybe<Scalars['Float']>;
@@ -5728,6 +5941,14 @@ export type SiwsCredentials = {
 export type SendEmailVerificationInput = {
   /** The email address to send the verification code to. */
   email: Scalars['String'];
+};
+
+export type SendNotificationInput = {
+  accountId: Scalars['ID'];
+  appId: Scalars['String'];
+  body: Scalars['String'];
+  data?: InputMaybe<Array<NotificationDataInput>>;
+  title: Scalars['String'];
 };
 
 export type SendPhoneVerificationInput = {


### PR DESCRIPTION
## Summary

- New `bearer-token.ts` util: `set/get/clear` localStorage-backed JWT, plus `issueBearerToken()` which calls the new `createBearerToken` mutation (companion backend PR cartridge-gg/internal#4610) from inside the popup.
- Popup → iframe handshake now carries `sessionToken` alongside the controller state via postMessage. Iframe persists it in localStorage and the keychain fetcher attaches `Authorization: Bearer <jwt>` on every API call.
- Safari signin now uses the popup whenever the keychain runs in any iframe (not just nested). Previously only signup popped up; signin in a single-level iframe silently failed because the iframe couldn't see the cookie.

## Why

Safari ITP partitions the third-party cookie jar by parent site. The popup (top-level `x.cartridge.gg`) writes the session cookie in the `(x.cartridge.gg, x.cartridge.gg)` partition, but the iframe at `x.cartridge.gg` embedded in `gamesite.com` reads from the `(gamesite.com, x.cartridge.gg)` partition — so the cookie is structurally invisible to it. That's the "unauthenticated user" error after signup/signin in Safari.

Fix: mint a 14-day Bearer JWT in the popup (where the cookie works first-party), postMessage it back, store in localStorage (auto-partitioned per parent site), and send `Authorization: Bearer` from the iframe. The cookie path stays as a fallback for top-level/popup contexts, untouched. Cookie attribute changes are deferred to a follow-up so Chrome stays on the existing partitioned-cookie flow it's been using.

## Test plan

- [ ] CI green (`pnpm lint`, `pnpm test`, `pnpm test:storybook`)
- [ ] In Safari with the keychain iframe embedded in a third-party site, signup completes and subsequent API calls (e.g. controller queries) succeed without "unauthenticated user"
- [ ] Signin in Safari (single-level iframe) now also pops up and round-trips the bearer token
- [ ] In Chrome, no regression — existing partitioned-cookie path still works for users who haven't gone through the bearer flow
- [ ] Verify the JWT is set in `localStorage` under `cartridge.bearerToken` after popup completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rob3uqWqjP3BCEHR1ydhYb)_