### PR TITLE
fix(keychain): grant sensor permissions to Coinbase iframe

### DIFF
--- a/packages/keychain/src/components/coinbase-popup.tsx
+++ b/packages/keychain/src/components/coinbase-popup.tsx
@@ -303,7 +303,7 @@ export function CoinbasePopup() {
         <iframe
           src={paymentLink}
           className="h-full w-full border-none"
-          allow="payment"
+          allow="accelerometer; gyroscope; magnetometer; clipboard-write; payment"
           sandbox="allow-scripts allow-same-origin"
           referrerPolicy="no-referrer"
           title="Coinbase Onramp"


### PR DESCRIPTION
## Summary

Expand the Coinbase popup iframe's `allow` attribute from just `payment` to `accelerometer; gyroscope; magnetometer; clipboard-write; payment` so Coinbase's biometric/risk-fingerprinting SDK stops throwing on Android Chrome.

## Why

Reported as: blank popup on Android Chrome after clicking Continue on the Coinbase policy screen, no error visible to the user. Inspecting via remote DevTools showed the iframe loading but Coinbase's scripts erroring repeatedly:

```
Permissions policy violation: accelerometer is not allowed in this document
The devicemotion events are blocked by permissions policy
The deviceorientation events are blocked by permissions policy
```

Coinbase's onramp SDK uses device sensors for biometric/risk signal collection. With our iframe's `allow="payment"`, mobile Chrome strictly enforced the permissions policy and blocked those API calls.

Desktop browsers don't meaningfully expose these sensors (no hardware) so the policy never gets evaluated for them — which is why this only manifested on mobile.

## Scope

This is a **partial fix** — it eliminates the sensor permission errors but the popup is still blank on Android Chrome. The remaining error is `Analytics SDK: Error: SDK platform not initialized`, originating from Coinbase's `isValidPlatform` check inside their analytics SDK during provider construction. Stack points to a bootstrap-order bug inside Coinbase's iframe (a constructor calls `logEvent` before the SDK has finished init) — not something we can fix from our side.

Tracking the remaining issue separately. Landing this fix because:

1. Reduces error noise in the Coinbase iframe across all browsers
2. Aligns our `allow` attribute with what Coinbase's SDK actually expects
3. Strict subset of permissions — adds nothing the SDK didn't already try to use

## Test plan

- [ ] CI green
- [ ] No regression on iOS Safari / desktop browsers (Coinbase onramp still works there)
- [ ] On Android Chrome — sensor errors no longer logged in the popup console (verified via remote DevTools)
- [ ] Follow-up: Coinbase analytics SDK init failure on Android Chrome still leaves popup blank

🤖 Generated with [Claude Code](https://claude.com/claude-code)
