### PR TITLE
fix(starterpack): hide Apple Pay option on Android

### DIFF
--- a/packages/keychain/src/components/purchasenew/checkout/onchain/wallet-drawer.tsx
+++ b/packages/keychain/src/components/purchasenew/checkout/onchain/wallet-drawer.tsx
@@ -45,6 +45,12 @@ export function WalletSelectionDrawer({
     onCoinflowSelect,
   } = useOnchainPurchaseContext();
 
+  const isAndroid = useMemo(
+    () =>
+      typeof navigator !== "undefined" && /Android/i.test(navigator.userAgent),
+    [],
+  );
+
   const [step, setStep] = useState<DrawerStep>("method");
   const [selectedNetwork, setSelectedNetwork] = useState<Network | null>(null);
   const [isDetecting, setIsDetecting] = useState(false);
@@ -314,7 +320,7 @@ export function WalletSelectionDrawer({
                   )}
                 />
               )}
-              {showFiatOptions && (
+              {showFiatOptions && !isAndroid && (
                 <PurchaseCard
                   key="apple-pay"
                   text="Apple Pay"

--- a/packages/keychain/src/context/starterpack/onchain-purchase.tsx
+++ b/packages/keychain/src/context/starterpack/onchain-purchase.tsx
@@ -329,6 +329,9 @@ export const OnchainPurchaseProvider = ({
 
   // Handle Apple Pay selection from URL (returning from verification)
   useEffect(() => {
+    const isAndroid =
+      typeof navigator !== "undefined" && /Android/i.test(navigator.userAgent);
+    if (isAndroid) return;
     const searchParams = new URLSearchParams(location.search);
     if (searchParams.get("method") === "apple-pay") {
       resetCoinbasePurchase();


### PR DESCRIPTION
## Summary
- Hide the Apple Pay option in the starterpack wallet selection drawer when the user-agent matches Android.
- Ignore the `?method=apple-pay` URL param on Android so the deep-link / post-verification entry can't auto-select Apple Pay either.

## Test plan
- [ ] Open starterpack purchase on Android → no Apple Pay card in the wallet drawer
- [ ] Open starterpack purchase on iOS / desktop (US) → Apple Pay still shown
- [ ] Hit `/...?method=apple-pay` on Android → Apple Pay is not auto-selected