### PR TITLE
fix(starterpack): remove multi-quantity purchase controls

### DIFF
--- a/packages/keychain/src/components/purchasenew/checkout/onchain/quantity.tsx
+++ b/packages/keychain/src/components/purchasenew/checkout/onchain/quantity.tsx
@@ -1,4 +1,4 @@
-import { Button, MinusIcon, PlusIcon } from "@cartridge/controller-ui";
+import { Button } from "@cartridge/controller-ui";
 
 interface QuantityControlsProps {
   quantity: number;
@@ -20,36 +20,15 @@ export function QuantityControls({
   isLoading,
   isSendingDeposit,
   globalDisabled,
-  hasSufficientBalance,
   bridgeFrom,
-  onIncrement,
-  onDecrement,
   onPurchase,
   onBridge,
   purchaseLabel: customPurchaseLabel,
-  isApplePayAmountTooLow,
 }: QuantityControlsProps) {
   const purchaseLabel = customPurchaseLabel || `Buy ${quantity}`;
-  const isQuantityDisabled =
-    (globalDisabled && hasSufficientBalance && !isApplePayAmountTooLow) ||
-    isSendingDeposit;
 
   return (
     <div className="flex flex-row gap-3">
-      <Button
-        variant="secondary"
-        onClick={onDecrement}
-        disabled={isQuantityDisabled || quantity <= 1}
-      >
-        <MinusIcon size="xs" />
-      </Button>
-      <Button
-        variant="secondary"
-        onClick={onIncrement}
-        disabled={isQuantityDisabled}
-      >
-        <PlusIcon size="xs" variant="solid" />
-      </Button>
       <Button
         className="w-full"
         isLoading={isLoading || isSendingDeposit}


### PR DESCRIPTION
## Summary

- Removes the +/- quantity controls from the onchain checkout in `QuantityControls`
- Prevents users from purchasing multiple starterpacks at once
- Keeps the props interface intact (rétrocompatible with the caller in `checkout/onchain/index.tsx`); unused props are simply not destructured

## Why

Buying multiple starterpacks at once is not a supported flow — disabling the quantity stepper removes the affordance entirely.

## Test plan

- Open the onchain checkout drawer
- Verify only the "Buy" button is shown (no +/- buttons)
- Verify purchase and bridge flows still work for quantity = 1