### PR TITLE
fix(analytics): wire purchase funnel events across all payment methods

### DIFF
--- a/packages/keychain/src/components/purchasenew/checkout/onchain/index.tsx
+++ b/packages/keychain/src/components/purchasenew/checkout/onchain/index.tsx
@@ -29,6 +29,8 @@ import {
 import { ControllerErrorAlert } from "@/components/ErrorAlert";
 import { useWebauthnAuthentication } from "@/components/connect/create/webauthn";
 import { isUnauthenticatedError } from "@/utils/bearer-token";
+import { posthog } from "@/components/provider/posthog";
+import { captureAnalyticsEvent, sanitizeErrorCode } from "@/types/analytics";
 import { Receiving } from "../../receiving";
 import { OnchainCostBreakdown } from "../../review/cost";
 import { LoadingState } from "../../loading";
@@ -360,6 +362,13 @@ export function OnchainCheckout() {
       return;
     }
 
+    const method = isCoinflowSelected
+      ? "coinflow"
+      : isApplePaySelected
+        ? "apple-pay"
+        : "onchain";
+    captureAnalyticsEvent(posthog, "purchase_checkout_started", { method });
+
     setIsLoading(true);
     clearError();
 
@@ -419,6 +428,11 @@ export function OnchainCheckout() {
       }
     } catch (error) {
       console.error("Purchase failed:", error);
+      captureAnalyticsEvent(posthog, "purchase_failed", {
+        method,
+        error_code: sanitizeErrorCode(error),
+        stage: "checkout",
+      });
     } finally {
       setIsLoading(false);
     }

--- a/packages/keychain/src/components/purchasenew/checkout/onchain/wallet-drawer.tsx
+++ b/packages/keychain/src/components/purchasenew/checkout/onchain/wallet-drawer.tsx
@@ -18,6 +18,8 @@ import { ExternalWallet } from "@cartridge/controller";
 import { useOnchainPurchaseContext, useStarterpackContext } from "@/context";
 import { useConnection } from "@/hooks/connection";
 import { useFeature } from "@/hooks/features";
+import { posthog } from "@/components/provider/posthog";
+import { captureAnalyticsEvent } from "@/types/analytics";
 import { networkWalletData } from "../../wallet/config";
 import { Network } from "../../types";
 
@@ -166,22 +168,34 @@ export function WalletSelectionDrawer({
   }, [step, showFiatOptions, setStep]);
 
   const handleApplePaySelect = useCallback(async () => {
+    captureAnalyticsEvent(posthog, "purchase_method_selected", {
+      method: "apple-pay",
+    });
     onApplePaySelect();
     onClose();
   }, [onApplePaySelect, onClose]);
 
   const handleCoinflowSelect = useCallback(async () => {
+    captureAnalyticsEvent(posthog, "purchase_method_selected", {
+      method: "coinflow",
+    });
     onCoinflowSelect();
     onClose();
   }, [onCoinflowSelect, onClose]);
 
   const onControllerWalletSelect = useCallback(() => {
+    captureAnalyticsEvent(posthog, "purchase_method_selected", {
+      method: "controller-starknet",
+    });
     clearSelectedWallet();
     onClose();
   }, [clearSelectedWallet, onClose]);
 
   const onExternalWalletSelect = useCallback(
     async (wallet: ExternalWallet, network: Network) => {
+      captureAnalyticsEvent(posthog, "purchase_method_selected", {
+        method: `${wallet.type}-${network.platform}`,
+      });
       setIsConnecting(true);
       setError(null);
 

--- a/packages/keychain/src/components/purchasenew/pending/base.tsx
+++ b/packages/keychain/src/components/purchasenew/pending/base.tsx
@@ -13,6 +13,8 @@ import { TransactionFinalityStatus } from "starknet";
 import { retryWithBackoff } from "@/utils/retry";
 import { getExplorer } from "@/hooks/starterpack/layerswap";
 import { useStarterpackPlayHandler } from "@/hooks/starterpack";
+import { posthog } from "@/components/provider/posthog";
+import { captureAnalyticsEvent, sanitizeErrorCode } from "@/types/analytics";
 
 export interface TransactionPendingBaseProps {
   /** Header title (e.g., "Purchasing Village Kit") */
@@ -31,6 +33,8 @@ export interface TransactionPendingBaseProps {
   quantityText?: string;
   /** Callback function to handle completion */
   onCompleted?: () => void;
+  /** Payment method for analytics. When set, fires purchase_completed/failed on resolution. */
+  analyticsMethod?: string;
 }
 
 /**
@@ -46,6 +50,7 @@ export function TransactionPendingBase({
   buttonText,
   quantityText,
   onCompleted,
+  analyticsMethod,
 }: TransactionPendingBaseProps) {
   const { isMainnet, controller } = useConnection();
   const handlePlay = useStarterpackPlayHandler();
@@ -53,6 +58,7 @@ export function TransactionPendingBase({
 
   useEffect(() => {
     if (controller) {
+      const startedAt = Date.now();
       retryWithBackoff(() =>
         controller.provider.waitForTransaction(transactionHash, {
           retryInterval: 1000,
@@ -64,13 +70,25 @@ export function TransactionPendingBase({
       )
         .then(() => {
           setIsPending(false);
+          if (analyticsMethod) {
+            captureAnalyticsEvent(posthog, "purchase_completed", {
+              method: analyticsMethod,
+              duration_ms: Date.now() - startedAt,
+            });
+          }
         })
         .catch((error) => {
           console.error("Failed to wait for transaction after retries:", error);
-          // Could set an error state here if needed
+          if (analyticsMethod) {
+            captureAnalyticsEvent(posthog, "purchase_failed", {
+              method: analyticsMethod,
+              error_code: sanitizeErrorCode(error),
+              stage: "confirm",
+            });
+          }
         });
     }
-  }, [controller, transactionHash]);
+  }, [controller, transactionHash, analyticsMethod]);
 
   useEffect(() => {
     if (!isPending && onCompleted && handlePlay) {

--- a/packages/keychain/src/components/purchasenew/pending/bridge.tsx
+++ b/packages/keychain/src/components/purchasenew/pending/bridge.tsx
@@ -137,7 +137,13 @@ export function BridgePending({
         reportFailure(err, "payment");
       }
     }
-  }, [paymentMethod, paymentSuccess, orderStatus, paymentCompleted, reportFailure]);
+  }, [
+    paymentMethod,
+    paymentSuccess,
+    orderStatus,
+    paymentCompleted,
+    reportFailure,
+  ]);
 
   useEffect(() => {
     if (wallet && initialBridgeHash) {

--- a/packages/keychain/src/components/purchasenew/pending/bridge.tsx
+++ b/packages/keychain/src/components/purchasenew/pending/bridge.tsx
@@ -21,6 +21,8 @@ import { ControllerErrorAlert } from "@/components/ErrorAlert";
 import { TransactionFinalityStatus } from "starknet";
 import { CoinbaseOnrampStatus } from "@/utils/api";
 import { useStarterpackPlayHandler } from "@/hooks/starterpack";
+import { posthog } from "@/components/provider/posthog";
+import { captureAnalyticsEvent, sanitizeErrorCode } from "@/types/analytics";
 
 interface TransitionStepProps {
   isVisible: boolean;
@@ -108,6 +110,18 @@ export function BridgePending({
 
   const purchaseTriggered = useRef(false);
 
+  const analyticsMethod = paymentMethod ?? "crypto";
+  const failedReportedRef = useRef(false);
+  const reportFailure = (err: Error, stage: string) => {
+    if (failedReportedRef.current) return;
+    failedReportedRef.current = true;
+    captureAnalyticsEvent(posthog, "purchase_failed", {
+      method: analyticsMethod,
+      error_code: sanitizeErrorCode(err),
+      stage,
+    });
+  };
+
   // Handle Apple Pay (Coinbase) order status from context polling
   useEffect(() => {
     if (paymentMethod === "apple-pay" && !paymentCompleted) {
@@ -115,7 +129,9 @@ export function BridgePending({
         setError(undefined);
         setDepositCompleted(true);
       } else if (orderStatus === CoinbaseOnrampStatus.Failed) {
-        setError(new Error("Coinbase payment failed. Please try again."));
+        const err = new Error("Coinbase payment failed. Please try again.");
+        setError(err);
+        reportFailure(err, "payment");
       }
     }
   }, [paymentMethod, paymentSuccess, orderStatus, paymentCompleted]);
@@ -132,6 +148,7 @@ export function BridgePending({
             err,
           );
           setError(err as Error);
+          reportFailure(err as Error, "deposit");
         });
     }
   }, [wallet, initialBridgeHash, externalWaitForTransaction]);
@@ -157,6 +174,7 @@ export function BridgePending({
         .catch((err) => {
           console.error("Failed to wait for deposit:", err);
           setError(err as Error);
+          reportFailure(err as Error, "bridge");
         });
     }
   }, [swapId, waitForDeposit, controller]);
@@ -176,6 +194,7 @@ export function BridgePending({
       onOnchainPurchase().catch((err) => {
         console.error("Auto-purchase failed:", err);
         setError(err as Error);
+        reportFailure(err as Error, "purchase");
         setIsPurchasing(false);
       });
     }
@@ -194,6 +213,7 @@ export function BridgePending({
   // Wait for Starknet purchase transaction
   useEffect(() => {
     if (purchaseTxHash && controller) {
+      const startedAt = Date.now();
       retryWithBackoff(() =>
         controller.provider.waitForTransaction(purchaseTxHash, {
           retryInterval: 1000,
@@ -203,13 +223,20 @@ export function BridgePending({
           ],
         }),
       )
-        .then(() => setPurchaseCompleted(true))
+        .then(() => {
+          setPurchaseCompleted(true);
+          captureAnalyticsEvent(posthog, "purchase_completed", {
+            method: analyticsMethod,
+            duration_ms: Date.now() - startedAt,
+          });
+        })
         .catch((err) => {
           console.error("Purchase confirmation failed:", err);
           setError(err as Error);
+          reportFailure(err as Error, "confirm");
         });
     }
-  }, [purchaseTxHash, controller]);
+  }, [purchaseTxHash, controller, analyticsMethod]);
 
   return (
     <>

--- a/packages/keychain/src/components/purchasenew/pending/bridge.tsx
+++ b/packages/keychain/src/components/purchasenew/pending/bridge.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/context";
 import { Explorer, getExplorer } from "@/hooks/starterpack/layerswap";
 import { ExternalWallet, humanizeString } from "@cartridge/controller";
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, useCallback } from "react";
 import { useConnection } from "@/hooks/connection";
 import { retryWithBackoff } from "@/utils/retry";
 import { ControllerErrorAlert } from "@/components/ErrorAlert";
@@ -112,15 +112,18 @@ export function BridgePending({
 
   const analyticsMethod = paymentMethod ?? "crypto";
   const failedReportedRef = useRef(false);
-  const reportFailure = (err: Error, stage: string) => {
-    if (failedReportedRef.current) return;
-    failedReportedRef.current = true;
-    captureAnalyticsEvent(posthog, "purchase_failed", {
-      method: analyticsMethod,
-      error_code: sanitizeErrorCode(err),
-      stage,
-    });
-  };
+  const reportFailure = useCallback(
+    (err: Error, stage: string) => {
+      if (failedReportedRef.current) return;
+      failedReportedRef.current = true;
+      captureAnalyticsEvent(posthog, "purchase_failed", {
+        method: analyticsMethod,
+        error_code: sanitizeErrorCode(err),
+        stage,
+      });
+    },
+    [analyticsMethod],
+  );
 
   // Handle Apple Pay (Coinbase) order status from context polling
   useEffect(() => {
@@ -134,7 +137,7 @@ export function BridgePending({
         reportFailure(err, "payment");
       }
     }
-  }, [paymentMethod, paymentSuccess, orderStatus, paymentCompleted]);
+  }, [paymentMethod, paymentSuccess, orderStatus, paymentCompleted, reportFailure]);
 
   useEffect(() => {
     if (wallet && initialBridgeHash) {
@@ -151,7 +154,7 @@ export function BridgePending({
           reportFailure(err as Error, "deposit");
         });
     }
-  }, [wallet, initialBridgeHash, externalWaitForTransaction]);
+  }, [wallet, initialBridgeHash, externalWaitForTransaction, reportFailure]);
 
   useEffect(() => {
     if (swapId) {
@@ -177,7 +180,7 @@ export function BridgePending({
           reportFailure(err as Error, "bridge");
         });
     }
-  }, [swapId, waitForDeposit, controller]);
+  }, [swapId, waitForDeposit, controller, reportFailure]);
 
   useEffect(() => {
     if (depositCompleted) {
@@ -198,7 +201,7 @@ export function BridgePending({
         setIsPurchasing(false);
       });
     }
-  }, [paymentCompleted, onOnchainPurchase]);
+  }, [paymentCompleted, onOnchainPurchase, reportFailure]);
 
   // Detect purchase transaction hash from context
   useEffect(() => {
@@ -236,7 +239,7 @@ export function BridgePending({
           reportFailure(err as Error, "confirm");
         });
     }
-  }, [purchaseTxHash, controller, analyticsMethod]);
+  }, [purchaseTxHash, controller, analyticsMethod, reportFailure]);
 
   return (
     <>

--- a/packages/keychain/src/components/purchasenew/pending/purchase.tsx
+++ b/packages/keychain/src/components/purchasenew/pending/purchase.tsx
@@ -26,6 +26,7 @@ export function PurchasePending({
       completedTitle="Confirmed on Starknet"
       buttonText="Play"
       onCompleted={onCompleted}
+      analyticsMethod="onchain"
     />
   );
 }


### PR DESCRIPTION
## Summary
Live PostHog data showed `purchase_started` firing **1,547 times in 30 days** with **zero** `purchase_completed`, `purchase_method_selected`, `purchase_checkout_started`, or `purchase_failed` events. The existing captures in `method.tsx` / `success.tsx` only fire on standalone routes that the bottom-sheet starterpack flow never reaches.

This wires captures into the real flow:

- `wallet-drawer.tsx` → `purchase_method_selected` for apple-pay, coinflow, controller wallet, and external wallets (with platform suffix).
- `checkout/onchain/index.tsx::handlePurchase` → `purchase_checkout_started` once gates pass; `purchase_failed` (stage="checkout") in the catch.
- `pending/base.tsx` → optional `analyticsMethod` prop. When set, fires `purchase_completed` (with `duration_ms`) on confirmation and `purchase_failed` (stage="confirm") on `.catch`. `purchase.tsx` passes `"onchain"`; the claim path stays unchanged.
- `pending/bridge.tsx` → `purchase_completed` on Starknet tx confirmation; `purchase_failed` (deduped via ref) with `stage` in {payment, deposit, bridge, purchase, confirm} at each setError site. Covers Apple Pay and crypto bridge.

Dead captures in `method.tsx` / `success.tsx` are left alone (those standalone routes are preserved as deep-link fallbacks per the existing comment).

## Test plan
- [ ] Trigger Apple Pay starterpack purchase → confirm `purchase_method_selected` (apple-pay), `purchase_checkout_started`, `purchase_completed` in PostHog
- [ ] Trigger Coinflow starterpack purchase → confirm `purchase_method_selected` (coinflow), `purchase_checkout_started`, `purchase_completed`
- [ ] Trigger crypto/Controller wallet purchase → confirm `purchase_method_selected` (controller-starknet), `purchase_checkout_started`, `purchase_completed` (onchain) with `duration_ms`
- [ ] Trigger crypto external wallet (e.g. argentx-ethereum) → confirm `purchase_method_selected` with platform suffix
- [ ] Force a failure (e.g. cancel signature) → confirm `purchase_failed` with appropriate `stage`
- [ ] Watch PostHog for ~24h after merge to verify the funnel populates