### PR TITLE
fix(starterpack): prevent double-fire of handlePurchase

### DIFF
--- a/packages/keychain/src/components/purchasenew/checkout/onchain/index.tsx
+++ b/packages/keychain/src/components/purchasenew/checkout/onchain/index.tsx
@@ -353,7 +353,9 @@ export function OnchainCheckout() {
     refetchAccountPrivate,
   ]);
 
+  const purchaseInFlightRef = useRef(false);
   const handlePurchase = useCallback(async () => {
+    if (purchaseInFlightRef.current) return;
     if (isApplePayAmountTooLow) return;
     if (isCoinflowSelected) {
       if (!isCoinflowStarterpackSupported) return;
@@ -361,6 +363,8 @@ export function OnchainCheckout() {
       console.warn("no means to pay");
       return;
     }
+
+    purchaseInFlightRef.current = true;
 
     const method = isCoinflowSelected
       ? "coinflow"
@@ -435,6 +439,7 @@ export function OnchainCheckout() {
       });
     } finally {
       setIsLoading(false);
+      purchaseInFlightRef.current = false;
     }
   }, [
     hasSufficientBalance,


### PR DESCRIPTION
## Summary
After #2594 landed, live PostHog data showed two `purchase_checkout_started` events 18ms apart on a single Apple Pay attempt, and the backend reported two `coinbase_orders` rows with separate payment links for the same attempt.

The `isCreatingOrder` check inside `onCreateCoinbaseOrder` reads from React state, which is stale when two synchronous `handlePurchase` invocations land in the same render cycle — both pass the guard and both hit the backend. The button's `disabled={isLoading}` doesn't help in that window either (likely culprit: the verification flow's `setTimeout`-driven `onSuccess` re-firing because the inline arrow at `onchain/index.tsx:714-719` gets a new identity on every render).

Add a ref-based reentry guard so `handlePurchase` is idempotent within its own in-flight window, regardless of trigger source. Reset in `finally` so the verification → re-run path still proceeds (verification's early `return` flows through `finally` and clears the flag before the `setVerificationMethod(null)` re-render).

## Test plan
- [ ] Trigger Apple Pay purchase → confirm exactly one `purchase_checkout_started` and one `coinbase_orders` row in DB
- [ ] Force a verification flow (unverified phone) → confirm verification → re-run still creates the order successfully
- [ ] Trigger crypto / Coinflow purchase → confirm no regression