### PR TITLE
fix(starterpack): reuse pre-created Coinbase order on Continue

### DIFF
--- a/packages/keychain/src/components/purchasenew/checkout/coinbase/index.tsx
+++ b/packages/keychain/src/components/purchasenew/checkout/coinbase/index.tsx
@@ -61,6 +61,7 @@ export function CoinbaseCheckout({
 }: CoinbaseCheckoutProps = {}) {
   const {
     paymentLink,
+    orderId,
     isCreatingOrder,
     onCreateCoinbaseOrder,
     openPaymentPopup,
@@ -208,9 +209,15 @@ export function CoinbaseCheckout({
     setMode("status");
     setIsOpeningPopup(true);
     try {
-      const order = await onCreateCoinbaseOrder({ force: true });
+      // Don't pass `force` — if `handlePurchase` already pre-created an order
+      // and its paymentLink is still fresh, the guard inside
+      // `onCreateCoinbaseOrder` short-circuits and we reuse it. The
+      // `hasStaleCoinbaseOrder` branch of that guard still creates a new order
+      // when the previous one is in a terminal state (popupClosed,
+      // paymentSuccess, Completed, Failed).
+      const order = await onCreateCoinbaseOrder();
       const nextPaymentLink = order?.coinbaseOrder.paymentLink ?? paymentLink;
-      const nextOrderId = order?.coinbaseOrder.orderId;
+      const nextOrderId = order?.coinbaseOrder.orderId ?? orderId;
 
       if (nextPaymentLink && nextOrderId) {
         openPaymentPopup({
@@ -245,6 +252,7 @@ export function CoinbaseCheckout({
     limitExceeded,
     onCreateCoinbaseOrder,
     paymentLink,
+    orderId,
     openPaymentPopup,
     fetchCoinbaseLimits,
   ]);


### PR DESCRIPTION
## Summary
The "Buy 1" button calls `handlePurchase`, which pre-creates a Coinbase order with `force: true` (order #1). When the Coinbase Policies drawer then opens and the user clicks "Continue", `handleContinue` ALSO calls `onCreateCoinbaseOrder({ force: true })`, creating **order #2** — same purchase, two backend rows with separate payment links.

## Why was `force` there in the first place
- **#2449 (Feb 25)** added `force: true` to `handleContinue` as a workaround so a retry after canceling the popup wouldn't reuse a stale link.
- **#2577 (Apr 28)** moved that staleness detection into `onCreateCoinbaseOrder` itself via `hasStaleCoinbaseOrder` — which detects the same conditions (`popupClosed`, `paymentSuccess`, `Completed`, `Failed`).

After April, `force` here became redundant — and now actively harmful, since it bypasses the existing-paymentLink reuse on the happy path.

## Fix
- Drop `force` from `handleContinue` so the guard short-circuits and reuses the pre-created order. `hasStaleCoinbaseOrder` still triggers a fresh order on the recovery flows.
- Pull `orderId` from context and use it as a fallback for `nextOrderId` when the guard short-circuits and we don't get a fresh order back from the call.

## Test plan
- [ ] Apple Pay purchase: click Buy 1 → click Continue → confirm exactly one `coinbase_orders` row in the DB
- [ ] Cancel popup mid-flight → click Continue again → confirm a fresh order is created (recovery still works)
- [ ] Deep-link `/purchase/checkout/coinbase` → click Continue → confirm one order created (eager-create + reuse)