### PR TITLE
feat(analytics): add signup funnel event schema and error categorizer

### DIFF
--- a/packages/keychain/src/types/analytics.ts
+++ b/packages/keychain/src/types/analytics.ts
@@ -1,4 +1,5 @@
 import type { PostHogWrapper } from "@cartridge/controller-ui/utils";
+import type { AuthOption } from "@cartridge/controller";
 
 /**
  * Typed event catalog for PostHog analytics.
@@ -10,20 +11,137 @@ import type { PostHogWrapper } from "@cartridge/controller-ui/utils";
  */
 
 // Signup / Login
+
+export type SignupErrorCategory =
+  | "user_canceled"
+  | "popup_blocked"
+  | "popup_required"
+  | "network"
+  | "provider_denied"
+  | "username_taken"
+  | "invalid_input"
+  | "webauthn_unsupported"
+  | "rate_limited"
+  | "server"
+  | "unknown";
+
+export type SignupAuthStep =
+  | "fill_form"
+  | "choose_method"
+  | "password_form"
+  | "sms_form"
+  | "pending"
+  | "error";
+
+export type SignupUsernameValidationReason =
+  | "too_short"
+  | "invalid_chars"
+  | "taken"
+  | "reserved"
+  | "network"
+  | "unknown";
+
+export type SignupMethodPickerTrigger =
+  | "multiple_signers"
+  | "multiple_options"
+  | "password_required"
+  | "forced";
+
+export type SignupEnvironmentWarning = "in_app_browser" | "unverified_domain";
+
 interface SignupStartedProps {
   has_existing_account: boolean;
+  is_in_app_browser?: boolean;
+  signup_options?: AuthOption[];
 }
 interface SignupMethodSelectedProps {
   method: string;
+  attempt_index?: number;
+  previous_method?: AuthOption;
 }
 interface SignupCompletedProps {
   method: string;
   duration_ms: number;
+  attempt_count?: number;
+  methods_tried?: AuthOption[];
 }
 interface SignupFailedProps {
   method: string;
   error_code: string;
+  error_category?: SignupErrorCategory;
 }
+
+interface SignupPageViewedProps {
+  forced_action?: "signup" | "login";
+  forced_auth_method?: AuthOption;
+  prefill_username: boolean;
+  is_in_app_browser: boolean;
+  in_app_browser_name?: string;
+  is_mobile: boolean;
+  is_safari: boolean;
+  theme_verified: boolean;
+  signup_options: AuthOption[];
+}
+interface SignupEnvironmentWarningShownProps {
+  warning_type: SignupEnvironmentWarning;
+  app_name?: string;
+}
+interface SignupUsernameValidationFailedProps {
+  reason: SignupUsernameValidationReason;
+  length: number;
+}
+interface SignupAccountResolvedProps {
+  exists: boolean;
+  signer_count: number;
+  signer_types: AuthOption[];
+}
+interface SignupMethodPickerShownProps {
+  available_methods: AuthOption[];
+  trigger: SignupMethodPickerTrigger;
+}
+interface SignupMethodPickerDismissedProps {
+  selected_method?: AuthOption;
+}
+interface SignupMethodAttemptedProps {
+  method: AuthOption;
+  attempt_index: number;
+  previous_method?: AuthOption;
+  previous_error_category?: SignupErrorCategory;
+}
+interface SignupWebauthnPromptShownProps {
+  needs_popup: boolean;
+}
+type SignupWebauthnPromptCanceledProps = Record<string, never>;
+type SignupWebauthnPopupRequiredProps = Record<string, never>;
+interface SignupSocialRedirectStartedProps {
+  method: "google" | "discord";
+}
+interface SignupSocialRedirectReturnedProps {
+  method: "google" | "discord";
+  granted: boolean;
+}
+type SignupSmsOtpRequestedProps = Record<string, never>;
+type SignupSmsOtpSubmittedProps = Record<string, never>;
+interface SignupSmsOtpInvalidProps {
+  reason: "expired" | "wrong" | "rate_limited" | "unknown";
+}
+type SignupPasswordFormShownProps = Record<string, never>;
+interface SignupPasswordValidationFailedProps {
+  reason: "too_weak" | "too_short" | "mismatch" | "unknown";
+}
+interface SignupExternalWalletConnectStartedProps {
+  method: AuthOption;
+}
+interface SignupExternalWalletConnectRejectedProps {
+  method: AuthOption;
+}
+interface SignupAbandonedProps {
+  last_step: SignupAuthStep;
+  methods_tried: AuthOption[];
+  attempt_count: number;
+  time_on_page_ms: number;
+}
+
 type LoginStartedProps = Record<string, never>;
 interface LoginCompletedProps {
   method: string;
@@ -102,6 +220,26 @@ export interface AnalyticsEventMap {
   signup_method_selected: SignupMethodSelectedProps;
   signup_completed: SignupCompletedProps;
   signup_failed: SignupFailedProps;
+  signup_page_viewed: SignupPageViewedProps;
+  signup_environment_warning_shown: SignupEnvironmentWarningShownProps;
+  signup_username_validation_failed: SignupUsernameValidationFailedProps;
+  signup_account_resolved: SignupAccountResolvedProps;
+  signup_method_picker_shown: SignupMethodPickerShownProps;
+  signup_method_picker_dismissed: SignupMethodPickerDismissedProps;
+  signup_method_attempted: SignupMethodAttemptedProps;
+  signup_webauthn_prompt_shown: SignupWebauthnPromptShownProps;
+  signup_webauthn_prompt_canceled: SignupWebauthnPromptCanceledProps;
+  signup_webauthn_popup_required: SignupWebauthnPopupRequiredProps;
+  signup_social_redirect_started: SignupSocialRedirectStartedProps;
+  signup_social_redirect_returned: SignupSocialRedirectReturnedProps;
+  signup_sms_otp_requested: SignupSmsOtpRequestedProps;
+  signup_sms_otp_submitted: SignupSmsOtpSubmittedProps;
+  signup_sms_otp_invalid: SignupSmsOtpInvalidProps;
+  signup_password_form_shown: SignupPasswordFormShownProps;
+  signup_password_validation_failed: SignupPasswordValidationFailedProps;
+  signup_external_wallet_connect_started: SignupExternalWalletConnectStartedProps;
+  signup_external_wallet_connect_rejected: SignupExternalWalletConnectRejectedProps;
+  signup_abandoned: SignupAbandonedProps;
   login_started: LoginStartedProps;
   login_completed: LoginCompletedProps;
   login_failed: LoginFailedProps;
@@ -157,4 +295,64 @@ export function sanitizeErrorCode(error: unknown): string {
         : "unknown";
   // Strip hex strings longer than 20 chars (addresses, hashes)
   return msg.replace(/0x[a-fA-F0-9]{20,}/g, "[hex]").slice(0, 200);
+}
+
+export function categorizeError(
+  error: unknown,
+  method?: AuthOption,
+): SignupErrorCategory {
+  if (!error) return "unknown";
+  const msg = (
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : ""
+  ).toLowerCase();
+  const name = error instanceof Error ? error.name : "";
+
+  if (name === "AbortError" || /user (?:canc|reject)/i.test(msg)) {
+    return "user_canceled";
+  }
+  if (
+    method === "webauthn" &&
+    (name === "NotAllowedError" ||
+      /operation (?:either )?timed out|not allowed/i.test(msg))
+  ) {
+    return "user_canceled";
+  }
+  if (/popup.*(?:block|denied)/i.test(msg)) {
+    return "popup_blocked";
+  }
+  if (/popup.*(?:required|needed)/i.test(msg)) {
+    return "popup_required";
+  }
+  if (name === "TypeError" && /fetch|network/i.test(msg)) {
+    return "network";
+  }
+  if (/network|offline|disconnect/i.test(msg)) {
+    return "network";
+  }
+  if (/access[_ ]denied|consent|provider.*denied/i.test(msg)) {
+    return "provider_denied";
+  }
+  if (/(?:username|name).*(?:taken|exists|already)/i.test(msg)) {
+    return "username_taken";
+  }
+  if (/rate[_ ]?limit|too many|429/i.test(msg)) {
+    return "rate_limited";
+  }
+  if (
+    method === "webauthn" &&
+    /(?:webauthn|passkey).*(?:unsupported|not supported)/i.test(msg)
+  ) {
+    return "webauthn_unsupported";
+  }
+  if (/invalid|required|must be/i.test(msg)) {
+    return "invalid_input";
+  }
+  if (/5\d\d|internal server|server error/i.test(msg)) {
+    return "server";
+  }
+  return "unknown";
 }

--- a/packages/keychain/src/utils/api/generated.ts
+++ b/packages/keychain/src/utils/api/generated.ts
@@ -2634,7 +2634,7 @@ export enum LayerswapDestinationNetwork {
 
 export type LayerswapPayment = {
   __typename?: "LayerswapPayment";
-  cryptoPaymentId: Scalars["ID"];
+  cryptoPaymentId?: Maybe<Scalars["ID"]>;
   expiresAt: Scalars["Time"];
   sourceDepositAddress: Scalars["String"];
   sourceNetwork: LayerswapSourceNetwork;
@@ -7983,7 +7983,7 @@ export type CreateLayerswapPaymentMutation = {
   __typename?: "Mutation";
   createLayerswapPayment: {
     __typename?: "LayerswapPayment";
-    cryptoPaymentId: string;
+    cryptoPaymentId?: string | null;
     swapId: string;
     status: LayerswapStatus;
     sourceNetwork: LayerswapSourceNetwork;
@@ -8002,7 +8002,7 @@ export type CreateLayerswapDepositMutation = {
   __typename?: "Mutation";
   createLayerswapDeposit: {
     __typename?: "LayerswapPayment";
-    cryptoPaymentId: string;
+    cryptoPaymentId?: string | null;
     swapId: string;
     status: LayerswapStatus;
     sourceNetwork: LayerswapSourceNetwork;
@@ -8113,7 +8113,7 @@ export type CreateCoinbaseOnRampOrderMutation = {
     };
     layerswapPayment?: {
       __typename?: "LayerswapPayment";
-      cryptoPaymentId: string;
+      cryptoPaymentId?: string | null;
       swapId: string;
       status: LayerswapStatus;
       sourceNetwork: LayerswapSourceNetwork;
@@ -8153,7 +8153,7 @@ export type CreateCoinbaseLayerswapOrderMutation = {
     };
     layerswapPayment?: {
       __typename?: "LayerswapPayment";
-      cryptoPaymentId: string;
+      cryptoPaymentId?: string | null;
       swapId: string;
       status: LayerswapStatus;
       sourceNetwork: LayerswapSourceNetwork;
@@ -8296,7 +8296,7 @@ export type CryptoPaymentFieldsFragment = {
 
 export type LayerswapPaymentFieldsFragment = {
   __typename?: "LayerswapPayment";
-  cryptoPaymentId: string;
+  cryptoPaymentId?: string | null;
   swapId: string;
   status: LayerswapStatus;
   sourceNetwork: LayerswapSourceNetwork;
@@ -8347,7 +8347,7 @@ export type CoinbaseOnrampOrderResponseFieldsFragment = {
   };
   layerswapPayment?: {
     __typename?: "LayerswapPayment";
-    cryptoPaymentId: string;
+    cryptoPaymentId?: string | null;
     swapId: string;
     status: LayerswapStatus;
     sourceNetwork: LayerswapSourceNetwork;

--- a/packages/ui/src/utils/api/cartridge/generated.ts
+++ b/packages/ui/src/utils/api/cartridge/generated.ts
@@ -2629,7 +2629,7 @@ export enum LayerswapDestinationNetwork {
 
 export type LayerswapPayment = {
   __typename?: 'LayerswapPayment';
-  cryptoPaymentId: Scalars['ID'];
+  cryptoPaymentId?: Maybe<Scalars['ID']>;
   expiresAt: Scalars['Time'];
   sourceDepositAddress: Scalars['String'];
   sourceNetwork: LayerswapSourceNetwork;
@@ -8046,14 +8046,14 @@ export type CreateLayerswapPaymentMutationVariables = Exact<{
 }>;
 
 
-export type CreateLayerswapPaymentMutation = { __typename?: 'Mutation', createLayerswapPayment: { __typename?: 'LayerswapPayment', cryptoPaymentId: string, swapId: string, status: LayerswapStatus, sourceNetwork: LayerswapSourceNetwork, sourceTokenAmount: string, sourceTokenAddress: string, sourceDepositAddress: string, expiresAt: string } };
+export type CreateLayerswapPaymentMutation = { __typename?: 'Mutation', createLayerswapPayment: { __typename?: 'LayerswapPayment', cryptoPaymentId?: string | null, swapId: string, status: LayerswapStatus, sourceNetwork: LayerswapSourceNetwork, sourceTokenAmount: string, sourceTokenAddress: string, sourceDepositAddress: string, expiresAt: string } };
 
 export type CreateLayerswapDepositMutationVariables = Exact<{
   input: CreateLayerswapDepositInput;
 }>;
 
 
-export type CreateLayerswapDepositMutation = { __typename?: 'Mutation', createLayerswapDeposit: { __typename?: 'LayerswapPayment', cryptoPaymentId: string, swapId: string, status: LayerswapStatus, sourceNetwork: LayerswapSourceNetwork, sourceTokenAmount: string, sourceTokenAddress: string, sourceDepositAddress: string, expiresAt: string } };
+export type CreateLayerswapDepositMutation = { __typename?: 'Mutation', createLayerswapDeposit: { __typename?: 'LayerswapPayment', cryptoPaymentId?: string | null, swapId: string, status: LayerswapStatus, sourceNetwork: LayerswapSourceNetwork, sourceTokenAmount: string, sourceTokenAddress: string, sourceDepositAddress: string, expiresAt: string } };
 
 export type LayerswapQuoteQueryVariables = Exact<{
   input: CreateLayerswapDepositInput;
@@ -8082,14 +8082,14 @@ export type CreateCoinbaseOnRampOrderMutationVariables = Exact<{
 }>;
 
 
-export type CreateCoinbaseOnRampOrderMutation = { __typename?: 'Mutation', createCoinbaseOnrampOrder: { __typename?: 'CoinbaseOnrampOrderResponse', coinbaseOrder: { __typename?: 'CoinbaseOnrampOrder', orderId: string, paymentLink: string, paymentLinkType: string, paymentTotal: string, paymentCurrency: string, purchaseAmount: string, purchaseCurrency: string, destinationAddress: string, destinationNetwork: string, fees: Array<{ __typename?: 'CoinbaseOnrampFee', type: string, amount: string, currency: string }> }, layerswapPayment?: { __typename?: 'LayerswapPayment', cryptoPaymentId: string, swapId: string, status: LayerswapStatus, sourceNetwork: LayerswapSourceNetwork, sourceTokenAmount: string, sourceTokenAddress: string, sourceDepositAddress: string, expiresAt: string } | null } };
+export type CreateCoinbaseOnRampOrderMutation = { __typename?: 'Mutation', createCoinbaseOnrampOrder: { __typename?: 'CoinbaseOnrampOrderResponse', coinbaseOrder: { __typename?: 'CoinbaseOnrampOrder', orderId: string, paymentLink: string, paymentLinkType: string, paymentTotal: string, paymentCurrency: string, purchaseAmount: string, purchaseCurrency: string, destinationAddress: string, destinationNetwork: string, fees: Array<{ __typename?: 'CoinbaseOnrampFee', type: string, amount: string, currency: string }> }, layerswapPayment?: { __typename?: 'LayerswapPayment', cryptoPaymentId?: string | null, swapId: string, status: LayerswapStatus, sourceNetwork: LayerswapSourceNetwork, sourceTokenAmount: string, sourceTokenAddress: string, sourceDepositAddress: string, expiresAt: string } | null } };
 
 export type CreateCoinbaseLayerswapOrderMutationVariables = Exact<{
   input: CreateCoinbaseLayerswapOrderInput;
 }>;
 
 
-export type CreateCoinbaseLayerswapOrderMutation = { __typename?: 'Mutation', createCoinbaseLayerswapOrder: { __typename?: 'CoinbaseOnrampOrderResponse', coinbaseOrder: { __typename?: 'CoinbaseOnrampOrder', orderId: string, paymentLink: string, paymentLinkType: string, paymentTotal: string, paymentCurrency: string, purchaseAmount: string, purchaseCurrency: string, destinationAddress: string, destinationNetwork: string, fees: Array<{ __typename?: 'CoinbaseOnrampFee', type: string, amount: string, currency: string }> }, layerswapPayment?: { __typename?: 'LayerswapPayment', cryptoPaymentId: string, swapId: string, status: LayerswapStatus, sourceNetwork: LayerswapSourceNetwork, sourceTokenAmount: string, sourceTokenAddress: string, sourceDepositAddress: string, expiresAt: string } | null } };
+export type CreateCoinbaseLayerswapOrderMutation = { __typename?: 'Mutation', createCoinbaseLayerswapOrder: { __typename?: 'CoinbaseOnrampOrderResponse', coinbaseOrder: { __typename?: 'CoinbaseOnrampOrder', orderId: string, paymentLink: string, paymentLinkType: string, paymentTotal: string, paymentCurrency: string, purchaseAmount: string, purchaseCurrency: string, destinationAddress: string, destinationNetwork: string, fees: Array<{ __typename?: 'CoinbaseOnrampFee', type: string, amount: string, currency: string }> }, layerswapPayment?: { __typename?: 'LayerswapPayment', cryptoPaymentId?: string | null, swapId: string, status: LayerswapStatus, sourceNetwork: LayerswapSourceNetwork, sourceTokenAmount: string, sourceTokenAddress: string, sourceDepositAddress: string, expiresAt: string } | null } };
 
 export type CoinbaseOnRampOrderQueryVariables = Exact<{
   orderId: Scalars['String'];
@@ -8107,11 +8107,11 @@ export type CoinbaseOnRampQuoteQuery = { __typename?: 'Query', coinbaseOnrampQuo
 
 export type CryptoPaymentFieldsFragment = { __typename?: 'CryptoPayment', id: string, tokenAmount: string, status: CryptoPaymentStatus, network: Network, tokenAddress: string, depositAddress: string, expiresAt: string };
 
-export type LayerswapPaymentFieldsFragment = { __typename?: 'LayerswapPayment', cryptoPaymentId: string, swapId: string, status: LayerswapStatus, sourceNetwork: LayerswapSourceNetwork, sourceTokenAmount: string, sourceTokenAddress: string, sourceDepositAddress: string, expiresAt: string };
+export type LayerswapPaymentFieldsFragment = { __typename?: 'LayerswapPayment', cryptoPaymentId?: string | null, swapId: string, status: LayerswapStatus, sourceNetwork: LayerswapSourceNetwork, sourceTokenAmount: string, sourceTokenAddress: string, sourceDepositAddress: string, expiresAt: string };
 
 export type CoinbaseOnrampOrderFieldsFragment = { __typename?: 'CoinbaseOnrampOrder', orderId: string, paymentLink: string, paymentLinkType: string, paymentTotal: string, paymentCurrency: string, purchaseAmount: string, purchaseCurrency: string, destinationAddress: string, destinationNetwork: string, fees: Array<{ __typename?: 'CoinbaseOnrampFee', type: string, amount: string, currency: string }> };
 
-export type CoinbaseOnrampOrderResponseFieldsFragment = { __typename?: 'CoinbaseOnrampOrderResponse', coinbaseOrder: { __typename?: 'CoinbaseOnrampOrder', orderId: string, paymentLink: string, paymentLinkType: string, paymentTotal: string, paymentCurrency: string, purchaseAmount: string, purchaseCurrency: string, destinationAddress: string, destinationNetwork: string, fees: Array<{ __typename?: 'CoinbaseOnrampFee', type: string, amount: string, currency: string }> }, layerswapPayment?: { __typename?: 'LayerswapPayment', cryptoPaymentId: string, swapId: string, status: LayerswapStatus, sourceNetwork: LayerswapSourceNetwork, sourceTokenAmount: string, sourceTokenAddress: string, sourceDepositAddress: string, expiresAt: string } | null };
+export type CoinbaseOnrampOrderResponseFieldsFragment = { __typename?: 'CoinbaseOnrampOrderResponse', coinbaseOrder: { __typename?: 'CoinbaseOnrampOrder', orderId: string, paymentLink: string, paymentLinkType: string, paymentTotal: string, paymentCurrency: string, purchaseAmount: string, purchaseCurrency: string, destinationAddress: string, destinationNetwork: string, fees: Array<{ __typename?: 'CoinbaseOnrampFee', type: string, amount: string, currency: string }> }, layerswapPayment?: { __typename?: 'LayerswapPayment', cryptoPaymentId?: string | null, swapId: string, status: LayerswapStatus, sourceNetwork: LayerswapSourceNetwork, sourceTokenAmount: string, sourceTokenAddress: string, sourceDepositAddress: string, expiresAt: string } | null };
 
 export type PlaythroughsQueryVariables = Exact<{
   projects: Array<PlaythroughProject> | PlaythroughProject;


### PR DESCRIPTION
## Summary

Extends the typed PostHog event catalog (`packages/keychain/src/types/analytics.ts`) to support a richer signup funnel: per-step views, method-picker open/dismiss, per-method sub-steps, retry tracking, error categorization, and abandonment.

**Schema-only PR — no call sites updated.** Follow-up PRs will wire emit sites. Existing signup events keep their required shape; new fields are optional, so nothing breaks.

### What's added

- **5 closed-enum types**: `SignupErrorCategory`, `SignupAuthStep`, `SignupUsernameValidationReason`, `SignupMethodPickerTrigger`, `SignupEnvironmentWarning`.
- **20 new event interfaces** wired into `AnalyticsEventMap`:
  - View / environment: `signup_page_viewed`, `signup_environment_warning_shown`
  - Identify: `signup_username_validation_failed`, `signup_account_resolved`
  - Method picker: `signup_method_picker_shown`, `signup_method_picker_dismissed`, `signup_method_attempted`
  - Per-method sub-events: webauthn (3), social (2), sms (3), password (2), external-wallet (2)
  - Abandonment: `signup_abandoned`
- **Optional retry-tracking fields** on existing `signup_started` / `signup_method_selected` / `signup_completed` / `signup_failed` (`attempt_index`, `attempt_count`, `previous_method`, `methods_tried`, `error_category`).
- **`categorizeError(error, method?)` helper** that classifies errors into the closed `SignupErrorCategory` enum (regex heuristics for `user_canceled`, `popup_blocked`, `network`, `provider_denied`, `username_taken`, etc.). Sits next to the existing `sanitizeErrorCode`.

### Why

Today's signup events fire once per submit with a free-text `error_code`, so dashboards can't reconstruct retries (`webauthn → fail → switch to Google → succeed`), can't aggregate failure reasons without regex'ing strings, and have no abandonment signal. This schema lets us answer: what method, what step, what error category, how many attempts, where did they drop off.

### Privacy

Username text is never captured — username events only carry `length` and validation reason. Existing `sanitizeErrorCode` (hex/address stripping) is unchanged.

## Test plan

- [x] `pnpm exec tsc -b --noEmit` — no new errors (4 pre-existing `PhoneNumberInput` errors confirmed on `main` via `git stash`).
- [x] `pnpm exec eslint src/types/analytics.ts` — clean.
- [x] Husky pre-commit hook ran full lint + format + test suite + graphql codegen.
- [ ] Follow-up PR will exercise the schema by adding `captureAnalyticsEvent` call sites.

### Note on bundled generated file changes

`packages/keychain/src/utils/api/generated.ts` and `packages/ui/src/utils/api/cartridge/generated.ts` were regenerated by the pre-commit hook to reflect upstream GraphQL schema drift (`LayerswapPayment.cryptoPaymentId` became nullable). Unrelated to the analytics work; included because the hook regenerates on every commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)