### PR TITLE
feat(analytics): emit signup funnel events with retry tracking

### DIFF
--- a/packages/keychain/src/components/connect/create/CreateController.tsx
+++ b/packages/keychain/src/components/connect/create/CreateController.tsx
@@ -30,6 +30,8 @@ import {
   usePreventOverScrolling,
 } from "@/hooks/viewport";
 import { useDevice } from "@/hooks/device";
+import { posthog } from "@/components/provider/posthog";
+import { captureAnalyticsEvent } from "@/types/analytics";
 import { AccountSearchResult } from "@/hooks/account";
 import { PasswordFormDrawer } from "./password/PasswordForm";
 import { SmsOtpDrawer } from "./sms/SmsOtpForm";
@@ -516,6 +518,50 @@ export function CreateController({
     isSlot,
     signers,
   });
+
+  const signupSessionIdRef = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    if (signupSessionIdRef.current) return;
+    signupSessionIdRef.current = crypto.randomUUID();
+    posthog.register({ signup_session_id: signupSessionIdRef.current });
+  }, []);
+
+  const [
+    {
+      isInApp: isAnalyticsInApp,
+      appKey: analyticsAppKey,
+      appName: analyticsAppName,
+    },
+  ] = useState(() => InAppSpy());
+  const isAnalyticsInAppBrowser = isAnalyticsInApp && !!analyticsAppKey;
+  const { isMobile: isAnalyticsMobile } = useDevice();
+
+  const pageViewedRef = useRef(false);
+  useEffect(() => {
+    if (pageViewedRef.current) return;
+    if (signupOptions.length === 0) return;
+    pageViewedRef.current = true;
+    captureAnalyticsEvent(posthog, "signup_page_viewed", {
+      forced_action: forcedAction,
+      forced_auth_method: forcedAuthMethod,
+      prefill_username: !!prefillUsername,
+      is_in_app_browser: isAnalyticsInAppBrowser,
+      in_app_browser_name: analyticsAppName ?? undefined,
+      is_mobile: isAnalyticsMobile,
+      is_safari: isSafari(navigator.userAgent),
+      theme_verified: !!theme.verified,
+      signup_options: signupOptions,
+    });
+  }, [
+    signupOptions,
+    forcedAction,
+    forcedAuthMethod,
+    prefillUsername,
+    isAnalyticsInAppBrowser,
+    analyticsAppName,
+    isAnalyticsMobile,
+    theme.verified,
+  ]);
 
   // Combine internal and external loading states
   const isLoading = internalIsLoading || externalIsLoading;

--- a/packages/keychain/src/components/connect/create/useCreateController.ts
+++ b/packages/keychain/src/components/connect/create/useCreateController.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { STABLE_CONTROLLER } from "@/components/provider/upgrade";
 import { DEFAULT_SESSION_DURATION, now } from "@/constants";
 import { useConnection } from "@/hooks/connection";
@@ -47,12 +47,35 @@ import {
 } from "@/utils/connection/session-creation";
 import { hasConfiguredLocationGate } from "@/utils/location-gate";
 import { posthog } from "@/components/provider/posthog";
-import { captureAnalyticsEvent, sanitizeErrorCode } from "@/types/analytics";
+import {
+  captureAnalyticsEvent,
+  categorizeError,
+  sanitizeErrorCode,
+  type SignupAuthStep,
+  type SignupErrorCategory,
+} from "@/types/analytics";
 
 const CANCEL_RESPONSE = {
   code: ResponseCodes.CANCELED,
   message: "Canceled",
 };
+
+function mapAuthStep(step: AuthenticationStep): SignupAuthStep {
+  switch (step) {
+    case AuthenticationStep.FillForm:
+      return "fill_form";
+    case AuthenticationStep.ChooseMethod:
+      return "choose_method";
+    case AuthenticationStep.PasswordForm:
+      return "password_form";
+    case AuthenticationStep.SmsForm:
+      return "sms_form";
+    case AuthenticationStep.Pending:
+      return "pending";
+    case AuthenticationStep.Error:
+      return "error";
+  }
+}
 
 export interface SignupResponse {
   address: string;
@@ -238,6 +261,38 @@ export function useCreateController({
   );
   const [authenticationStep, setAuthenticationStep] =
     useState<AuthenticationStep>(AuthenticationStep.FillForm);
+
+  const signupAttemptIndexRef = useRef(0);
+  const signupMethodsTriedRef = useRef<AuthOption[]>([]);
+  const signupPreviousMethodRef = useRef<AuthOption | undefined>(undefined);
+  const signupPreviousErrorCategoryRef = useRef<
+    SignupErrorCategory | undefined
+  >(undefined);
+  const signupStartedRef = useRef(false);
+  const signupResolvedRef = useRef(false);
+  const signupStartTimeRef = useRef(performance.now());
+  const authStepRef = useRef<AuthenticationStep>(AuthenticationStep.FillForm);
+
+  useEffect(() => {
+    authStepRef.current = authenticationStep;
+  }, [authenticationStep]);
+
+  useEffect(() => {
+    const handlePageHide = () => {
+      if (!signupStartedRef.current || signupResolvedRef.current) return;
+      captureAnalyticsEvent(posthog, "signup_abandoned", {
+        last_step: mapAuthStep(authStepRef.current),
+        methods_tried: [...signupMethodsTriedRef.current],
+        attempt_count: signupAttemptIndexRef.current,
+        time_on_page_ms: Math.round(
+          performance.now() - signupStartTimeRef.current,
+        ),
+      });
+    };
+    window.addEventListener("pagehide", handlePageHide);
+    return () => window.removeEventListener("pagehide", handlePageHide);
+  }, []);
+
   const [searchParams, setSearchParams] = useSearchParams();
   const {
     origin,
@@ -1092,10 +1147,29 @@ export function useCreateController({
       if (exists) {
         captureAnalyticsEvent(posthog, "login_started", {});
       } else {
+        signupStartedRef.current = true;
+        signupAttemptIndexRef.current += 1;
+        const attemptIndex = signupAttemptIndexRef.current;
+        const previousMethod = signupPreviousMethodRef.current;
+        const previousErrorCategory = signupPreviousErrorCategoryRef.current;
+        if (!signupMethodsTriedRef.current.includes(method)) {
+          signupMethodsTriedRef.current.push(method);
+        }
         captureAnalyticsEvent(posthog, "signup_started", {
           has_existing_account: false,
         });
-        captureAnalyticsEvent(posthog, "signup_method_selected", { method });
+        captureAnalyticsEvent(posthog, "signup_method_selected", {
+          method,
+          attempt_index: attemptIndex,
+          previous_method: previousMethod,
+        });
+        captureAnalyticsEvent(posthog, "signup_method_attempted", {
+          method,
+          attempt_index: attemptIndex,
+          previous_method: previousMethod,
+          previous_error_category: previousErrorCategory,
+        });
+        signupPreviousMethodRef.current = method;
       }
 
       try {
@@ -1112,9 +1186,12 @@ export function useCreateController({
         } else {
           await handleSignup(username, method, password);
           if (window.controller) {
+            signupResolvedRef.current = true;
             captureAnalyticsEvent(posthog, "signup_completed", {
               method,
               duration_ms: Math.round(performance.now() - startTime),
+              attempt_count: signupAttemptIndexRef.current,
+              methods_tried: [...signupMethodsTriedRef.current],
             });
           }
         }
@@ -1130,9 +1207,12 @@ export function useCreateController({
             error_code: sanitizeErrorCode(error),
           });
         } else {
+          const errorCategory = categorizeError(error, method);
+          signupPreviousErrorCategoryRef.current = errorCategory;
           captureAnalyticsEvent(posthog, "signup_failed", {
             method,
             error_code: sanitizeErrorCode(error),
+            error_category: errorCategory,
           });
         }
       } finally {


### PR DESCRIPTION
## Summary

Wires the typed event schema from #2598 into the keychain signup flow. With this PR, PostHog starts receiving the data needed to answer the original question: **what's the user doing each step of the way, what methods are they trying, where are they retrying, where are they giving up, and why do they fail.**

Two files touched: `CreateController.tsx` (mount-time wiring) and `useCreateController.ts` (per-attempt tracking + abandonment listener).

### What fires now

| Event | When | Notable props |
|---|---|---|
| `signup_session_id` (registered) | `CreateController` mount | uuid via `crypto.randomUUID()`; attached to every subsequent event in the same window |
| `signup_page_viewed` | When `signupOptions` first resolves | `forced_action`, `forced_auth_method`, `prefill_username`, `is_in_app_browser`, `in_app_browser_name`, `is_mobile`, `is_safari`, `theme_verified`, `signup_options[]` |
| `signup_started` (legacy, retained) | On signup submit | `has_existing_account` |
| `signup_method_selected` (legacy, retained) | On signup submit | Now enriched with `attempt_index`, `previous_method` |
| `signup_method_attempted` | On signup submit | `method`, `attempt_index`, `previous_method`, `previous_error_category` |
| `signup_completed` (enriched) | On successful signup | Now adds `attempt_count`, `methods_tried[]` |
| `signup_failed` (enriched) | On signup error | Now adds `error_category` via `categorizeError()` |
| `signup_abandoned` | On `pagehide` if started but unresolved | `last_step`, `methods_tried[]`, `attempt_count`, `time_on_page_ms` |

### What's deferred

Per-method sub-events (webauthn popup, social redirect, sms otp, password form, external wallet) and the picker/warning details are **not** in this PR. They add detail but the funnel-level signals above already answer the asks. Easy follow-up if the data reveals we need finer granularity.

### Retry tracking

Per-attempt state lives in `useRef` inside `useCreateController`:
- `signupAttemptIndexRef` — incremented per signup submission
- `signupMethodsTriedRef` — deduped list of methods the user has tried this session
- `signupPreviousMethodRef` — last method attempted
- `signupPreviousErrorCategoryRef` — last error category (lets the next attempt's `signup_method_attempted` carry context)
- `signupStartedRef` / `signupResolvedRef` — gate the abandonment event
- `signupStartTimeRef` — for `time_on_page_ms`

Refs (not state) so updates don't trigger re-renders — analytics must never affect UX.

### Abandonment

`pagehide` listener fires `signup_abandoned` if:
- A signup attempt was started (`signupStartedRef === true`)
- AND signup was never completed (`signupResolvedRef === false`)

Failures don't mark resolved — a failed user might still retry, so we want them counted as abandoned if they leave.

`last_step` derived from `authenticationStep` mirrored to a ref. Mapping function `mapAuthStep` translates the numeric `AuthenticationStep` enum to the closed string union `SignupAuthStep` (defined in the schema PR).

### Privacy

No username text captured. `signup_username_validation_failed` is in the schema but not wired here — it's in the deferred set.

## Test plan

- [x] `pnpm exec tsc -b --noEmit` — clean.
- [x] `pnpm exec eslint <touched files>` — clean.
- [x] `pnpm test:ci` — all 514 tests pass (37 files, 2 skipped).
- [x] Husky pre-commit hook ran lint + format + test:ci + graphql codegen.
- [ ] **Manual smoke test** — needed before merge: load the signup flow on a dev keychain, verify `signup_session_id` registers and `signup_page_viewed` / `signup_method_attempted` / `signup_completed` events appear in the PostHog UI (project 22030) with the expected props. Hit a failure case (e.g. cancel webauthn) and confirm `signup_failed.error_category === "user_canceled"`.

## Rollout

- Once merged + deployed, events start flowing into Controller PostHog project 22030.
- The workspace mapping PR (cartridge-gg/workspace#200) registers these events with the daily anomaly-detection cron.
- Per the cron rubric (`analytics-intelligence/SKILL.md:118`), metrics with <14 days history are reported as "Insufficient data" — so Discord alerts begin ~2 weeks after this lands.

Closes the three-PR sequence:
- #2598 (schema) — merged
- cartridge-gg/workspace#200 (mapping) — open
- **this PR** (emit sites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)