### PR TITLE
feat(slot): require verified team email before funding

### DIFF
--- a/packages/keychain/src/components/slot/fund.tsx
+++ b/packages/keychain/src/components/slot/fund.tsx
@@ -22,6 +22,7 @@ import { formatBalance } from "@/hooks/tokens";
 import { useConnection } from "@/hooks/connection";
 import { useNavigation } from "@/context/navigation";
 import { SlotCryptoFund, SlotFundingResult } from "./crypto-fund";
+import { TeamEmailVerify } from "./team-email-verify";
 import { waitForCryptoPaymentConfirmation } from "@/hooks/payments/crypto";
 import { ConfirmingTransaction } from "@/components/purchasenew/pending";
 import { getExplorer } from "@/hooks/starterpack/layerswap";
@@ -29,6 +30,7 @@ import { ErrorAlert } from "@/components/ErrorAlert";
 
 enum FundState {
   SELECT_TEAM,
+  COLLECT_EMAIL,
   PURCHASE,
   SUCCESS,
 }
@@ -84,8 +86,25 @@ export function Fund() {
         isLoading={isLoading}
         error={!!error}
         onFundTeam={(team) => {
-          setState(FundState.PURCHASE);
           setSelectedTeam(team);
+          setState(team.email ? FundState.PURCHASE : FundState.COLLECT_EMAIL);
+        }}
+      />
+    );
+  }
+
+  if (state === FundState.COLLECT_EMAIL) {
+    if (!selectedTeam) {
+      return null;
+    }
+
+    return (
+      <TeamEmailVerify
+        team={selectedTeam}
+        onBack={() => setState(FundState.SELECT_TEAM)}
+        onVerified={(email) => {
+          setSelectedTeam((prev) => (prev ? { ...prev, email } : prev));
+          setState(FundState.PURCHASE);
         }}
       />
     );

--- a/packages/keychain/src/components/slot/team-email-verify.stories.tsx
+++ b/packages/keychain/src/components/slot/team-email-verify.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { TeamEmailVerify } from "./team-email-verify";
+
+const mockTeam = {
+  id: "cmcv7v80x0004qgmy5pqja21c",
+  name: "my-game-studio",
+  credits: 0,
+  strk: 0,
+  email: null,
+};
+
+const meta: Meta<typeof TeamEmailVerify> = {
+  title: "Slot/TeamEmailVerify",
+  component: TeamEmailVerify,
+  parameters: {
+    layout: "fullscreen",
+  },
+  decorators: [
+    (Story) => (
+      <div className="min-h-screen bg-background">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    team: mockTeam,
+    onVerified: () => {},
+    onBack: () => {},
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Email input step shown when a team has no contact email before funding.",
+      },
+    },
+  },
+};

--- a/packages/keychain/src/components/slot/team-email-verify.tsx
+++ b/packages/keychain/src/components/slot/team-email-verify.tsx
@@ -1,0 +1,277 @@
+import React, { useEffect, useRef, useState } from "react";
+import {
+  useSendEmailVerificationMutation,
+  useVerifyTeamEmailMutation,
+} from "@cartridge/controller-ui/utils/api/cartridge";
+import {
+  Button,
+  EnvelopeIcon,
+  HeaderInner,
+  Input,
+  LayoutContent,
+  LayoutFooter,
+} from "@cartridge/controller-ui";
+import { ErrorAlert } from "@/components/ErrorAlert";
+import { Team } from "./teams";
+
+type Step = "EMAIL_INPUT" | "EMAIL_CODE";
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+interface TeamEmailVerifyProps {
+  team: Team;
+  onVerified: (email: string) => void;
+  onBack: () => void;
+}
+
+export function TeamEmailVerify({
+  team,
+  onVerified,
+  onBack,
+}: TeamEmailVerifyProps) {
+  const [step, setStep] = useState<Step>("EMAIL_INPUT");
+  const [email, setEmail] = useState("");
+  const [code, setCode] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [resendCooldown, setResendCooldown] = useState(0);
+
+  const sendEmail = useSendEmailVerificationMutation();
+  const verifyTeamEmail = useVerifyTeamEmailMutation();
+
+  useEffect(() => {
+    if (resendCooldown <= 0) return;
+    const timer = setTimeout(() => setResendCooldown(resendCooldown - 1), 1000);
+    return () => clearTimeout(timer);
+  }, [resendCooldown]);
+
+  const handleSendEmail = async () => {
+    setError(null);
+    if (!EMAIL_REGEX.test(email)) {
+      setError("Please enter a valid email address.");
+      return;
+    }
+    try {
+      const res = await sendEmail.mutateAsync({ input: { email } });
+      if (res.sendEmailVerification.success) {
+        setStep("EMAIL_CODE");
+        setCode("");
+        setResendCooldown(30);
+      } else {
+        setError(res.sendEmailVerification.message);
+      }
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to send email");
+    }
+  };
+
+  const handleVerify = async () => {
+    if (code.length < 6) return;
+    setError(null);
+    try {
+      const res = await verifyTeamEmail.mutateAsync({
+        input: { teamName: team.name, email, code },
+      });
+      if (res.verifyTeamEmail.success) {
+        onVerified(email);
+      } else {
+        setError(res.verifyTeamEmail.message);
+      }
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Invalid code");
+    }
+  };
+
+  const handleResend = async () => {
+    if (resendCooldown > 0) return;
+    await handleSendEmail();
+  };
+
+  if (step === "EMAIL_INPUT") {
+    return (
+      <>
+        <HeaderInner
+          title="Add Team Email"
+          icon={<EnvelopeIcon />}
+          variant="compressed"
+        />
+        <LayoutContent className="p-4 gap-4">
+          <p className="text-xs text-foreground-300">
+            {`Add a contact email for ${team.name} to receive payment receipts.`}
+          </p>
+          <div className="flex flex-col gap-2">
+            <label className="text-xs text-foreground-300 font-medium">
+              Email
+            </label>
+            <Input
+              name="email"
+              autoComplete="email"
+              type="email"
+              placeholder="team@email.com"
+              value={email}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                setEmail(e.target.value);
+                setError(null);
+              }}
+              onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) =>
+                e.key === "Enter" && email && handleSendEmail()
+              }
+            />
+          </div>
+        </LayoutContent>
+        <LayoutFooter>
+          {error && (
+            <ErrorAlert title="Error" description={error} isExpanded={true} />
+          )}
+          <div className="flex gap-3">
+            <Button variant="secondary" className="flex-1" onClick={onBack}>
+              Back
+            </Button>
+            <Button
+              variant="primary"
+              className="flex-1"
+              onClick={handleSendEmail}
+              isLoading={sendEmail.isLoading}
+              disabled={!email}
+            >
+              Continue
+            </Button>
+          </div>
+        </LayoutFooter>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <HeaderInner
+        title="Enter Confirmation Code"
+        icon={<EnvelopeIcon />}
+        variant="compressed"
+      />
+      <LayoutContent className="p-4 gap-12">
+        <p className="text-xs text-foreground-300">
+          Please check {email} for a message and enter your code below.
+        </p>
+        <PinInput
+          value={code}
+          onChange={setCode}
+          onEnter={handleVerify}
+          disabled={verifyTeamEmail.isLoading}
+        />
+        <p className="text-xs text-foreground-300">
+          Didn't get a message?{" "}
+          <button
+            className="text-primary-100 hover:underline disabled:opacity-50 disabled:no-underline"
+            onClick={handleResend}
+            disabled={
+              verifyTeamEmail.isLoading ||
+              sendEmail.isLoading ||
+              resendCooldown > 0
+            }
+          >
+            {resendCooldown > 0
+              ? `Resend Code (${resendCooldown}s)`
+              : "Resend Code"}
+          </button>
+        </p>
+      </LayoutContent>
+      <LayoutFooter>
+        {error && (
+          <ErrorAlert title="Error" description={error} isExpanded={true} />
+        )}
+        <div className="flex gap-3">
+          <Button
+            variant="secondary"
+            className="flex-1"
+            onClick={() => {
+              setStep("EMAIL_INPUT");
+              setError(null);
+            }}
+          >
+            Back
+          </Button>
+          <Button
+            variant="primary"
+            className="flex-1"
+            onClick={handleVerify}
+            isLoading={verifyTeamEmail.isLoading}
+            disabled={code.length < 6}
+          >
+            Continue
+          </Button>
+        </div>
+      </LayoutFooter>
+    </>
+  );
+}
+
+function PinInput({
+  length = 6,
+  value,
+  onChange,
+  onEnter,
+  disabled,
+}: {
+  length?: number;
+  value: string;
+  onChange: (val: string) => void;
+  onEnter?: () => void;
+  disabled?: boolean;
+}) {
+  const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+    index: number,
+  ) => {
+    const val = e.target.value;
+    if (!/^\d*$/.test(val)) return;
+    const newVal = value.split("");
+    newVal[index] = val.slice(-1);
+    onChange(newVal.join(""));
+    if (val && index < length - 1) inputRefs.current[index + 1]?.focus();
+  };
+
+  const handleKeyDown = (
+    e: React.KeyboardEvent<HTMLInputElement>,
+    index: number,
+  ) => {
+    if (e.key === "Backspace" && !value[index] && index > 0)
+      inputRefs.current[index - 1]?.focus();
+    if (e.key === "Enter" && value.length === length && onEnter) onEnter();
+  };
+
+  const handlePaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
+    const digits = e.clipboardData
+      .getData("text")
+      .replace(/\D/g, "")
+      .slice(0, length);
+    if (digits) {
+      onChange(digits);
+      inputRefs.current[Math.min(digits.length, length - 1)]?.focus();
+    }
+  };
+
+  return (
+    <div className="flex gap-3 justify-center">
+      {Array.from({ length }).map((_, i) => (
+        <Input
+          key={i}
+          ref={(el: HTMLInputElement | null) => (inputRefs.current[i] = el)}
+          className="w-11 h-14 text-center text-md bg-background-100 border-background-200 focus:border-primary-100"
+          value={value[i] || ""}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            handleChange(e, i)
+          }
+          onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) =>
+            handleKeyDown(e, i)
+          }
+          onPaste={handlePaste}
+          disabled={disabled}
+          maxLength={1}
+          inputMode="numeric"
+        />
+      ))}
+    </div>
+  );
+}

--- a/packages/keychain/src/components/slot/teams.tsx
+++ b/packages/keychain/src/components/slot/teams.tsx
@@ -24,6 +24,7 @@ export interface Team {
   name: string;
   credits: number;
   strk: number;
+  email?: string | null;
 }
 
 const STRK_ICON =

--- a/packages/keychain/src/utils/api/generated.ts
+++ b/packages/keychain/src/utils/api/generated.ts
@@ -3273,6 +3273,12 @@ export type Mutation = {
    * Updates the user's phone number and verification timestamp on success.
    */
   verifyPhone: VerifyResponse;
+  /**
+   * Verify an email address against a Twilio code and write it to the named
+   * team. The caller must be a member of the team. Uses the same code sent by
+   * sendEmailVerification.
+   */
+  verifyTeamEmail: VerifyResponse;
 };
 
 export type MutationAccountVerifyArgs = {
@@ -3561,6 +3567,10 @@ export type MutationVerifyEmailArgs = {
 
 export type MutationVerifyPhoneArgs = {
   input: VerifyPhoneInput;
+};
+
+export type MutationVerifyTeamEmailArgs = {
+  input: VerifyTeamEmailInput;
 };
 
 export enum Network {
@@ -7659,6 +7669,18 @@ export type VerifyResponse = {
   success: Scalars["Boolean"];
   /** The verified value (phone number or email) if verification succeeded. */
   verifiedValue?: Maybe<Scalars["String"]>;
+};
+
+export type VerifyTeamEmailInput = {
+  /** The 6-digit verification code received via email. */
+  code: Scalars["String"];
+  /**
+   * The email address that was sent the verification code.
+   * Must match the email used in sendEmailVerification.
+   */
+  email: Scalars["String"];
+  /** The name of the team whose email will be set. */
+  teamName: Scalars["String"];
 };
 
 export type WebauthnCredential = {

--- a/packages/ui/src/utils/api/cartridge/generated.ts
+++ b/packages/ui/src/utils/api/cartridge/generated.ts
@@ -3269,6 +3269,12 @@ export type Mutation = {
    * Updates the user's phone number and verification timestamp on success.
    */
   verifyPhone: VerifyResponse;
+  /**
+   * Verify an email address against a Twilio code and write it to the named
+   * team. The caller must be a member of the team. Uses the same code sent by
+   * sendEmailVerification.
+   */
+  verifyTeamEmail: VerifyResponse;
 };
 
 
@@ -3614,6 +3620,11 @@ export type MutationVerifyEmailArgs = {
 
 export type MutationVerifyPhoneArgs = {
   input: VerifyPhoneInput;
+};
+
+
+export type MutationVerifyTeamEmailArgs = {
+  input: VerifyTeamEmailInput;
 };
 
 export enum Network {
@@ -7789,6 +7800,18 @@ export type VerifyResponse = {
   verifiedValue?: Maybe<Scalars['String']>;
 };
 
+export type VerifyTeamEmailInput = {
+  /** The 6-digit verification code received via email. */
+  code: Scalars['String'];
+  /**
+   * The email address that was sent the verification code.
+   * Must match the email used in sendEmailVerification.
+   */
+  email: Scalars['String'];
+  /** The name of the team whose email will be set. */
+  teamName: Scalars['String'];
+};
+
 export type WebauthnCredential = {
   __typename?: 'WebauthnCredential';
   AAGUID: Scalars['String'];
@@ -8174,7 +8197,7 @@ export type StarterPackQuery = { __typename?: 'Query', starterpack?: { __typenam
 export type TeamsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type TeamsQuery = { __typename?: 'Query', me?: { __typename?: 'Account', teams: { __typename?: 'TeamConnection', totalCount: number, edges?: Array<{ __typename?: 'TeamEdge', node?: { __typename?: 'Team', id: string, name: string, credits: number, strk: number } | null } | null> | null } } | null };
+export type TeamsQuery = { __typename?: 'Query', me?: { __typename?: 'Account', teams: { __typename?: 'TeamConnection', totalCount: number, edges?: Array<{ __typename?: 'TeamEdge', node?: { __typename?: 'Team', id: string, name: string, credits: number, strk: number, email?: string | null } | null } | null> | null } } | null };
 
 export type TraceabilitiesQueryVariables = Exact<{
   projects: Array<TraceabilityProject> | TraceabilityProject;
@@ -8217,6 +8240,13 @@ export type VerifyPhoneMutationVariables = Exact<{
 
 
 export type VerifyPhoneMutation = { __typename?: 'Mutation', verifyPhone: { __typename?: 'VerifyResponse', success: boolean, message: string, verifiedValue?: string | null } };
+
+export type VerifyTeamEmailMutationVariables = Exact<{
+  input: VerifyTeamEmailInput;
+}>;
+
+
+export type VerifyTeamEmailMutation = { __typename?: 'Mutation', verifyTeamEmail: { __typename?: 'VerifyResponse', success: boolean, message: string, verifiedValue?: string | null } };
 
 export type TxsHistoryQueryVariables = Exact<{
   username: Scalars['String'];
@@ -9645,6 +9675,7 @@ export const TeamsDocument = `
           name
           credits
           strk
+          email
         }
       }
     }
@@ -9815,6 +9846,24 @@ export const useVerifyPhoneMutation = <
     useMutation<VerifyPhoneMutation, TError, VerifyPhoneMutationVariables, TContext>(
       ['VerifyPhone'],
       useFetchData<VerifyPhoneMutation, VerifyPhoneMutationVariables>(VerifyPhoneDocument),
+      options
+    );
+export const VerifyTeamEmailDocument = `
+    mutation VerifyTeamEmail($input: VerifyTeamEmailInput!) {
+  verifyTeamEmail(input: $input) {
+    success
+    message
+    verifiedValue
+  }
+}
+    `;
+export const useVerifyTeamEmailMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(options?: UseMutationOptions<VerifyTeamEmailMutation, TError, VerifyTeamEmailMutationVariables, TContext>) =>
+    useMutation<VerifyTeamEmailMutation, TError, VerifyTeamEmailMutationVariables, TContext>(
+      ['VerifyTeamEmail'],
+      useFetchData<VerifyTeamEmailMutation, VerifyTeamEmailMutationVariables>(VerifyTeamEmailDocument),
       options
     );
 export const TxsHistoryDocument = `

--- a/packages/ui/src/utils/api/cartridge/teams.graphql
+++ b/packages/ui/src/utils/api/cartridge/teams.graphql
@@ -8,6 +8,7 @@ query Teams {
           name
           credits
           strk
+          email
         }
       }
     }

--- a/packages/ui/src/utils/api/cartridge/twilio.graphql
+++ b/packages/ui/src/utils/api/cartridge/twilio.graphql
@@ -27,3 +27,11 @@ mutation VerifyPhone($input: VerifyPhoneInput!) {
     verifiedValue
   }
 }
+
+mutation VerifyTeamEmail($input: VerifyTeamEmailInput!) {
+  verifyTeamEmail(input: $input) {
+    success
+    message
+    verifiedValue
+  }
+}


### PR DESCRIPTION
## Summary
Requires teams to have a verified contact email before they can top up via slot fund, so the backend's automated purchase receipts have somewhere to be delivered.

## Changes
- **`fund.tsx`** — new `COLLECT_EMAIL` step. On team select, teams with an `email` go straight to the purchase form; teams without one must verify first.
- **`team-email-verify.tsx`** — new component: email input → `sendEmailVerification` → 6-digit code → `verifyTeamEmail({ teamName, email, code })`, with an inline resend cooldown. Self-contained (no toast provider dependency) and storybook-friendly.
- **GraphQL** — `Teams` query now selects `email`; added the `VerifyTeamEmail` mutation; regenerated `ui` and `keychain` GraphQL types.
- **`Team` interface** — added `email?: string | null`.
- Added a Storybook story for the new component.

## Test plan
- [x] `tsc --noEmit` clean, `lint` clean, slot tests pass (3/3)
- [x] Verified the email-input step renders correctly in Storybook (header, copy, input, Back/Continue) and the error path renders an `ErrorAlert`
- [ ] EMAIL_CODE (PIN) step not visually verified — Storybook's mock provider leaves the API URL empty so the mutation errors there. It reuses the proven `PinInput` + layout pattern from `purchasenew/verification`, but worth a manual click-through in the real keychain before merge.

## Notes
Pairs with the merged backend PR (cartridge-gg/internal#4693) that added the `verifyTeamEmail` mutation and the purchase-receipt pipeline.
