### PR TITLE
refactor(analytics): drop signup_page_viewed; register env props globally

### DIFF
--- a/packages/keychain/src/components/connect/create/CreateController.tsx
+++ b/packages/keychain/src/components/connect/create/CreateController.tsx
@@ -31,7 +31,6 @@ import {
 } from "@/hooks/viewport";
 import { useDevice } from "@/hooks/device";
 import { posthog } from "@/components/provider/posthog";
-import { captureAnalyticsEvent } from "@/types/analytics";
 import { AccountSearchResult } from "@/hooks/account";
 import { PasswordFormDrawer } from "./password/PasswordForm";
 import { SmsOtpDrawer } from "./sms/SmsOtpForm";
@@ -525,43 +524,6 @@ export function CreateController({
     signupSessionIdRef.current = crypto.randomUUID();
     posthog.register({ signup_session_id: signupSessionIdRef.current });
   }, []);
-
-  const [
-    {
-      isInApp: isAnalyticsInApp,
-      appKey: analyticsAppKey,
-      appName: analyticsAppName,
-    },
-  ] = useState(() => InAppSpy());
-  const isAnalyticsInAppBrowser = isAnalyticsInApp && !!analyticsAppKey;
-  const { isMobile: isAnalyticsMobile } = useDevice();
-
-  const pageViewedRef = useRef(false);
-  useEffect(() => {
-    if (pageViewedRef.current) return;
-    if (signupOptions.length === 0) return;
-    pageViewedRef.current = true;
-    captureAnalyticsEvent(posthog, "signup_page_viewed", {
-      forced_action: forcedAction,
-      forced_auth_method: forcedAuthMethod,
-      prefill_username: !!prefillUsername,
-      is_in_app_browser: isAnalyticsInAppBrowser,
-      in_app_browser_name: analyticsAppName ?? undefined,
-      is_mobile: isAnalyticsMobile,
-      is_safari: isSafari(navigator.userAgent),
-      theme_verified: !!theme.verified,
-      signup_options: signupOptions,
-    });
-  }, [
-    signupOptions,
-    forcedAction,
-    forcedAuthMethod,
-    prefillUsername,
-    isAnalyticsInAppBrowser,
-    analyticsAppName,
-    isAnalyticsMobile,
-    theme.verified,
-  ]);
 
   // Combine internal and external loading states
   const isLoading = internalIsLoading || externalIsLoading;

--- a/packages/keychain/src/components/provider/posthog.tsx
+++ b/packages/keychain/src/components/provider/posthog.tsx
@@ -1,7 +1,16 @@
 import { useConnection } from "@/hooks/connection";
+import { useDevice } from "@/hooks/device";
 import { useVersion } from "@/hooks/version";
+import { isSafari } from "@/hooks/viewport";
 import { PostHogContext, PostHogWrapper } from "@cartridge/controller-ui/utils";
-import { PropsWithChildren, useContext, useEffect, useState } from "react";
+import InAppSpy from "inapp-spy";
+import {
+  PropsWithChildren,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { useLocation } from "react-router-dom";
 
 export const posthog = new PostHogWrapper(
@@ -30,6 +39,20 @@ export function PostHogProvider({ children }: PropsWithChildren) {
       setRegistered(true);
     }
   }, [registered, controllerVersion]);
+
+  const [{ isInApp, appKey, appName }] = useState(() => InAppSpy());
+  const { isMobile } = useDevice();
+  const envRegisteredRef = useRef(false);
+  useEffect(() => {
+    if (envRegisteredRef.current) return;
+    envRegisteredRef.current = true;
+    posthog.register({
+      is_in_app_browser: isInApp && !!appKey,
+      in_app_browser_name: appName ?? undefined,
+      is_mobile: isMobile,
+      is_safari: isSafari(navigator.userAgent),
+    });
+  }, [isInApp, appKey, appName, isMobile]);
 
   useEffect(() => {
     if (controller) {

--- a/packages/keychain/src/types/analytics.ts
+++ b/packages/keychain/src/types/analytics.ts
@@ -71,17 +71,6 @@ interface SignupFailedProps {
   error_category?: SignupErrorCategory;
 }
 
-interface SignupPageViewedProps {
-  forced_action?: "signup" | "login";
-  forced_auth_method?: AuthOption;
-  prefill_username: boolean;
-  is_in_app_browser: boolean;
-  in_app_browser_name?: string;
-  is_mobile: boolean;
-  is_safari: boolean;
-  theme_verified: boolean;
-  signup_options: AuthOption[];
-}
 interface SignupEnvironmentWarningShownProps {
   warning_type: SignupEnvironmentWarning;
   app_name?: string;
@@ -220,7 +209,6 @@ export interface AnalyticsEventMap {
   signup_method_selected: SignupMethodSelectedProps;
   signup_completed: SignupCompletedProps;
   signup_failed: SignupFailedProps;
-  signup_page_viewed: SignupPageViewedProps;
   signup_environment_warning_shown: SignupEnvironmentWarningShownProps;
   signup_username_validation_failed: SignupUsernameValidationFailedProps;
   signup_account_resolved: SignupAccountResolvedProps;


### PR DESCRIPTION
## Summary

Yesterday's data verification surfaced that \`signup_page_viewed\` is a misleading funnel signal. \`CreateController\` is the **unified signup + login screen** (renders for any unauthenticated user reaching the keychain), so the event fires for login traffic too — yielding a 14 completions / 1,943 viewers = 0.7% page-view->complete ratio that mostly reflects login intent, not signup drop-off.

Real signup conversion is **14 / 17 = 82%** (\`signup_completed\` / \`signup_method_attempted\`), already captured by the existing events. No need for a separate page-view event.

This PR:

1. **Drops \`signup_page_viewed\`** — removes the typed event from \`analytics.ts\` and the emit site in \`CreateController.tsx\`.
2. **Registers env props globally** in \`PostHogProvider\` via \`posthog.register()\` — same pattern already used for \`controller_version\`, \`origin\`, \`chain_id\`, \`preset\`. Env context (\`is_in_app_browser\`, \`in_app_browser_name\`, \`is_mobile\`, \`is_safari\`) now attaches to **every** subsequent event automatically. No analytical context lost.
3. **Removes the analytics-only \`InAppSpy()\` and \`useDevice()\` calls** from \`CreateController\` (the child \`CreateControllerForm\` still has its own for UI logic — that stays).

## Resulting funnel

\`\`\`
\$pageview (filter: connect/signup pathname)   ← optional top-of-funnel exposure (already auto-fires)
       ↓
signup_started                              ← intent confirmed (new username submitted)
       ↓
signup_method_attempted                     ← method picked, ceremony started
       ↓
signup_completed                            ← success
\`\`\`

Three meaningful steps, each gated on user action. Cohorts (in-app browser vs not, mobile vs desktop) are queryable by filtering on the auto-registered env props.

## Test plan

- [x] \`pnpm exec tsc -b --noEmit\` — clean
- [x] \`pnpm exec eslint <touched files>\` — clean
- [x] \`pnpm exec vitest run src/components/connect/create/\` — all 14 tests pass
- [x] Husky pre-commit (lint + format + test:ci + graphql codegen) — passed
- [ ] After merge: verify in PostHog that next-day \`signup_started\` / \`signup_completed\` / \`signup_failed\` events carry \`is_in_app_browser\`, \`is_mobile\`, etc. as auto-properties. \`signup_page_viewed\` should stop appearing.

## Follow-up

\`cartridge-gg/workspace\` mapping (\`memory-project-mapping.yaml\`) needs the matching \`Signup funnel\` ratio entry removed — sending that PR next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)