### PR TITLE
feat(merkledrop): add openMerkleDrops flow

### DIFF
--- a/examples/next/src/components/Starterpack.tsx
+++ b/examples/next/src/components/Starterpack.tsx
@@ -19,7 +19,6 @@ export const Starterpack = () => {
         bundleId: 1,
         socialBundleId: 0,
         starterpackId: 0,
-        claim: "claim-dopewars-mainnet",
         registryAddress: BUNDLE_REGISTRY_MAINNET,
       };
     }
@@ -27,7 +26,6 @@ export const Starterpack = () => {
       bundleId: 1,
       socialBundleId: 0,
       starterpackId: 0,
-      claim: "claim-dopewars-sepolia",
       registryAddress: BUNDLE_REGISTRY_SEPOLIA,
     };
   }, [chain]);
@@ -36,7 +34,11 @@ export const Starterpack = () => {
     () => getDefaultStarterpackIds(),
     [getDefaultStarterpackIds],
   );
-  const [claimSpId, setClaimSpId] = useState<string>(defaultIds.claim);
+  const [claimKeys, setClaimKeys] = useState<string>("priate-nation");
+  const [claimTitle, setClaimTitle] = useState<string>("Pirate Nation");
+  const [claimDescription, setClaimDescription] = useState<string>(
+    "Claim games and tokens Pirate Nation holders",
+  );
   const [claimPreimage, setClaimPreimage] = useState<string>("");
   const [purchaseOnchainSpId, setPurchaseOnchainSpId] = useState<number>(
     defaultIds.starterpackId,
@@ -61,12 +63,6 @@ export const Starterpack = () => {
     const currentExpected = expectedDefaultsRef.current;
 
     // Only update if the values haven't been manually modified by the user
-    setClaimSpId((currentClaimSpId) => {
-      return currentClaimSpId === currentExpected.claim
-        ? newDefaults.claim
-        : currentClaimSpId;
-    });
-
     setPurchaseOnchainSpId((currentPurchaseOnchainSpId) => {
       return currentPurchaseOnchainSpId === currentExpected.starterpackId
         ? newDefaults.starterpackId
@@ -222,31 +218,52 @@ export const Starterpack = () => {
         </div>
 
         <div className="flex flex-col gap-2">
-          <h3>Claim Starterpack</h3>
+          <h3>Claim Merkle Drop</h3>
           <div className="flex flex-col gap-2">
             <div className="flex items-center gap-2">
               <Input
                 className="max-w-80"
                 type="text"
-                value={claimSpId}
-                onChange={(e) => setClaimSpId(e.target.value)}
-                placeholder="Enter starterpack ID"
+                value={claimKeys}
+                onChange={(e) => setClaimKeys(e.target.value)}
+                placeholder="Enter merkle drop keys (comma-separated)"
               />
               <Button
                 onClick={() => {
-                  if (claimSpId.trim()) {
-                    controllerConnector.controller.openStarterPack(
-                      claimSpId.trim(),
-                      {
-                        preimage: claimPreimage.trim(),
-                      },
-                    );
+                  const keys = claimKeys
+                    .split(",")
+                    .map((key) => key.trim())
+                    .filter(Boolean);
+                  if (keys.length === 0) {
+                    return;
                   }
+                  controllerConnector.controller.openMerkleDrops(keys, {
+                    title: claimTitle.trim() || undefined,
+                    description: claimDescription.trim() || undefined,
+                    preimage: claimPreimage.trim() || undefined,
+                    onClaimComplete: () => {
+                      console.log("Merkle drop claim callback fired.");
+                    },
+                  });
                 }}
               >
-                Claim Starterpack with preimage
+                Claim Merkle Drop with preimage
               </Button>
             </div>
+            <Input
+              className="max-w-80"
+              type="text"
+              value={claimTitle}
+              onChange={(e) => setClaimTitle(e.target.value)}
+              placeholder="Optional: Enter title"
+            />
+            <Input
+              className="max-w-80"
+              type="text"
+              value={claimDescription}
+              onChange={(e) => setClaimDescription(e.target.value)}
+              placeholder="Optional: Enter description"
+            />
             <Input
               className="max-w-80"
               type="text"

--- a/packages/controller/src/controller.ts
+++ b/packages/controller/src/controller.ts
@@ -35,6 +35,7 @@ import {
   LocationPromptOptions,
   HeadlessUsernameLookupResult,
   StarterpackOptions,
+  MerkleDropsOptions,
   UpdateSessionOptions,
   BundleOptions,
 } from "./types";
@@ -693,6 +694,35 @@ export default class ControllerProvider extends BaseProvider {
         : undefined;
 
     await this.keychain.openStarterPack(id, sanitizedOptions);
+    this.iframes.keychain?.open();
+  }
+
+  async openMerkleDrops(
+    keys: string[],
+    options?: MerkleDropsOptions,
+  ): Promise<void> {
+    if (!this.iframes) {
+      return;
+    }
+
+    if (!this.keychain || !this.iframes.keychain) {
+      console.error(new NotReadyToConnect().message);
+      return;
+    }
+
+    const sanitizedKeys = keys.map((key) => key.trim()).filter(Boolean);
+    if (sanitizedKeys.length === 0) {
+      throw new Error("At least one merkle drop key is required");
+    }
+
+    const { onClaimComplete, ...merkleDropsOptions } = options ?? {};
+    this.iframes.keychain.setOnStarterpackPlay(onClaimComplete);
+    const sanitizedOptions =
+      Object.keys(merkleDropsOptions).length > 0
+        ? (merkleDropsOptions as Omit<MerkleDropsOptions, "onClaimComplete">)
+        : undefined;
+
+    await this.keychain.openMerkleDrops(sanitizedKeys, sanitizedOptions);
     this.iframes.keychain?.open();
   }
 

--- a/packages/controller/src/types.ts
+++ b/packages/controller/src/types.ts
@@ -208,6 +208,7 @@ export interface Keychain {
     id: string | number,
     options?: StarterpackOptions,
   ): Promise<void>;
+  openMerkleDrops(keys: string[], options?: MerkleDropsOptions): Promise<void>;
   navigate(path: string): Promise<void>;
 
   // External wallet methods
@@ -336,6 +337,17 @@ export type StarterpackOptions = {
   preimage?: string;
   /** Callback fired after the Play button closes the starterpack modal */
   onPurchaseComplete?: () => void;
+};
+
+export type MerkleDropsOptions = {
+  /** Optional title to show for the grouped merkle-drop claim */
+  title?: string;
+  /** Optional description to show for the grouped merkle-drop claim */
+  description?: string;
+  /** The preimage to use */
+  preimage?: string;
+  /** Callback fired after the Play button closes the claim modal */
+  onClaimComplete?: () => void;
 };
 
 // Connect options (used by controller.connect)

--- a/packages/keychain/src/components/app.tsx
+++ b/packages/keychain/src/components/app.tsx
@@ -267,6 +267,10 @@ export function App() {
             path="starterpack/:starterpackId"
             element={<PurchaseStarterpack />}
           />
+          <Route
+            path="merkle-drops/:merkleDropKeys"
+            element={<PurchaseStarterpack />}
+          />
           <Route path="starterpack/collections" element={<Collections />} />
           <Route path="claim/:keys/:address/:type" element={<Claim />} />
           <Route path="method/:platforms" element={<PaymentMethod />} />

--- a/packages/keychain/src/components/purchasenew/starterpack/starterpack.tsx
+++ b/packages/keychain/src/components/purchasenew/starterpack/starterpack.tsx
@@ -36,9 +36,19 @@ import { posthog } from "@/components/provider/posthog";
 import { captureAnalyticsEvent } from "@/types/analytics";
 
 export function PurchaseStarterpack() {
-  const { starterpackId, bundleId } = useParams();
+  const { starterpackId, bundleId, merkleDropKeys } = useParams();
   const [searchParams] = useSearchParams();
   const preimage = searchParams.get("preimage");
+  const title = searchParams.get("title") ?? undefined;
+  const description = searchParams.get("description") ?? undefined;
+  const parsedMerkleDropKeys = useMemo(
+    () => merkleDropKeys?.split(";").filter(Boolean),
+    [merkleDropKeys],
+  );
+  const merkleDropOptions = useMemo(
+    () => (title || description ? { title, description } : undefined),
+    [title, description],
+  );
   const { navigate } = useNavigation();
 
   const {
@@ -46,12 +56,17 @@ export function PurchaseStarterpack() {
     starterpackDetails: details,
     displayError,
     setBundle,
+    setMerkleDrops,
     setStarterpack,
   } = useStarterpackContext();
 
   useEffect(() => {
     captureAnalyticsEvent(posthog, "purchase_started", {
-      type: bundleId ? "bundle" : "starterpack",
+      type: bundleId
+        ? "bundle"
+        : merkleDropKeys
+          ? "merkle_drop"
+          : "starterpack",
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -59,7 +74,9 @@ export function PurchaseStarterpack() {
   useEffect(() => {
     if (isStarterpackLoading) return;
 
-    if (bundleId) {
+    if (parsedMerkleDropKeys) {
+      setMerkleDrops(parsedMerkleDropKeys, merkleDropOptions);
+    } else if (bundleId) {
       // store bundle info into provider before navigating to checkout
       const registryAddress = searchParams.get("registryAddress");
       const shareMessage = searchParams.get("shareMessage");
@@ -77,6 +94,9 @@ export function PurchaseStarterpack() {
     }
   }, [
     isStarterpackLoading,
+    parsedMerkleDropKeys,
+    merkleDropOptions,
+    setMerkleDrops,
     bundleId,
     setBundle,
     starterpackId,
@@ -124,10 +144,12 @@ export function PurchaseStarterpack() {
     return (
       <>
         <HeaderInner
-          title="Starterpack Error"
+          title={merkleDropKeys ? "Claim Error" : "Starterpack Error"}
           description={
             <span className="text-foreground-200 text-xs font-normal">
-              Unable to load starterpack
+              {merkleDropKeys
+                ? "Unable to load claim"
+                : "Unable to load starterpack"}
             </span>
           }
           hideIcon
@@ -144,6 +166,7 @@ export function PurchaseStarterpack() {
     return (
       <ClaimStarterPackInner
         name={details.name}
+        edition={details.description}
         starterpackItems={details.items}
         error={displayError}
       />

--- a/packages/keychain/src/components/purchasenew/starterpack/starterpack.tsx
+++ b/packages/keychain/src/components/purchasenew/starterpack/starterpack.tsx
@@ -104,23 +104,24 @@ export function PurchaseStarterpack() {
     searchParams,
   ]);
 
+  // Preimage claims only apply to ETHEREUM drops; resolve eligible keys once so
+  // the redirect and the loading guard can't disagree (otherwise a preimage
+  // claim with no ETHEREUM drop hangs on the loading screen forever).
+  const ethereumPreimageClaimKeys = useMemo(() => {
+    if (!preimage || !isClaimStarterpack(details)) return undefined;
+    const keys = details.merkleDrops
+      ?.filter((drop) => drop.network === "ETHEREUM")
+      .map((drop) => drop.key);
+    return keys && keys.length > 0 ? keys.join(";") : undefined;
+  }, [preimage, details]);
+
   // Auto-redirect to claim page if preimage is available
   useEffect(() => {
-    if (
-      !isStarterpackLoading &&
-      isClaimStarterpack(details) &&
-      preimage &&
-      details.merkleDrops?.some((drop) => drop.network === "ETHEREUM") &&
-      !displayError
-    ) {
-      const keys = details.merkleDrops
-        .filter((drop) => drop.network === "ETHEREUM")
-        .map((drop) => drop.key)
-        .join(";");
-
-      navigate(`/purchase/claim/${keys}/${preimage}/preimage`, {
-        reset: true,
-      });
+    if (!isStarterpackLoading && ethereumPreimageClaimKeys && !displayError) {
+      navigate(
+        `/purchase/claim/${ethereumPreimageClaimKeys}/${preimage}/preimage`,
+        { reset: true },
+      );
     }
 
     // TEMP: Short circuit to checkout if onchain starterpack
@@ -131,10 +132,19 @@ export function PurchaseStarterpack() {
     ) {
       navigate(`/purchase/checkout/onchain`, { reset: true });
     }
-  }, [isStarterpackLoading, details, preimage, displayError, navigate]);
+  }, [
+    isStarterpackLoading,
+    details,
+    ethereumPreimageClaimKeys,
+    preimage,
+    displayError,
+    navigate,
+  ]);
 
   if (
-    (isStarterpackLoading || isOnchainStarterpack(details) || preimage) &&
+    (isStarterpackLoading ||
+      isOnchainStarterpack(details) ||
+      !!ethereumPreimageClaimKeys) &&
     !displayError
   ) {
     return <LoadingState />;

--- a/packages/keychain/src/components/purchasenew/wallet/wallet.stories.tsx
+++ b/packages/keychain/src/components/purchasenew/wallet/wallet.stories.tsx
@@ -16,6 +16,8 @@ const mockStarterpackValue = {
   setBundle: () => {},
   starterpackId: undefined,
   setStarterpack: () => {},
+  merkleDropKeys: undefined,
+  setMerkleDrops: () => {},
   starterpackDetails: undefined,
   isStarterpackLoading: false,
   claimItems: [],

--- a/packages/keychain/src/context/starterpack/starterpack.tsx
+++ b/packages/keychain/src/context/starterpack/starterpack.tsx
@@ -7,6 +7,8 @@ import {
   ReactNode,
 } from "react";
 import {
+  MerkleDropDisplayOptions,
+  useClaimMerkleDrops,
   useClaimStarterpack,
   useOnchainStarterpack,
 } from "@/hooks/starterpack";
@@ -37,6 +39,10 @@ export interface StarterpackContextType {
   // Starterpack identification
   starterpackId: string | number | undefined;
   setStarterpack: (id: string | number, registryAddress: string) => void;
+
+  // Merkle drop identification
+  merkleDropKeys: string[] | undefined;
+  setMerkleDrops: (keys: string[], options?: MerkleDropDisplayOptions) => void;
 
   // Starterpack details (loaded from backend or onchain)
   starterpackDetails: StarterpackDetails | undefined;
@@ -72,6 +78,10 @@ export const StarterpackProvider = ({ children }: StarterpackProviderProps) => {
   const [registryAddress, setRegistryAddress] = useState<string | undefined>();
   const [bundleId, setBundleId] = useState<number | undefined>();
   const [starterpackId, setStarterpackId] = useState<string | number>();
+  const [merkleDropKeys, setMerkleDropKeys] = useState<string[] | undefined>();
+  const [merkleDropOptions, setMerkleDropOptions] = useState<
+    MerkleDropDisplayOptions | undefined
+  >();
   const [starterpackDetails, setStarterpackDetails] = useState<
     StarterpackDetails | undefined
   >();
@@ -82,7 +92,9 @@ export const StarterpackProvider = ({ children }: StarterpackProviderProps) => {
   // Detect which source (claimed or onchain) based on starterpack ID
   const type = detectStarterpackType(starterpackId ?? bundleId);
 
-  const isClaimed = type === "claimed" && starterpackId !== undefined;
+  const isMerkleDrops = merkleDropKeys !== undefined;
+  const isClaimed =
+    !isMerkleDrops && type === "claimed" && starterpackId !== undefined;
   const isStarterPack = type === "onchain" && starterpackId !== undefined;
   const isBundle = type === "onchain" && bundleId !== undefined;
 
@@ -103,6 +115,15 @@ export const StarterpackProvider = ({ children }: StarterpackProviderProps) => {
     error: claimError,
   } = useClaimStarterpack(claimId);
 
+  const {
+    name: merkleDropName,
+    description: merkleDropDescription,
+    items: merkleDropItems,
+    merkleDrops: claimMerkleDrops,
+    isLoading: isMerkleDropLoading,
+    error: merkleDropError,
+  } = useClaimMerkleDrops(merkleDropKeys, merkleDropOptions);
+
   // Onchain hook (Smart contract) - only run if onchain source
   const {
     metadata: onchainMetadata,
@@ -117,13 +138,29 @@ export const StarterpackProvider = ({ children }: StarterpackProviderProps) => {
   });
 
   // Unified loading and error state
-  const isStarterpackLoading =
-    type === "claimed" ? isClaimLoading : isOnchainLoading;
-  const starterpackError = type === "claimed" ? claimError : onchainError;
+  const isStarterpackLoading = isMerkleDrops
+    ? isMerkleDropLoading
+    : type === "claimed"
+      ? isClaimLoading
+      : isOnchainLoading;
+  const starterpackError = isMerkleDrops
+    ? merkleDropError
+    : type === "claimed"
+      ? claimError
+      : onchainError;
 
   // Transform data based on source (claimed vs onchain)
   useEffect(() => {
-    if (claimId !== undefined) {
+    if (isMerkleDrops) {
+      setStarterpackDetails({
+        type: "claimed",
+        id: merkleDropKeys!.join(";"),
+        name: merkleDropName,
+        description: merkleDropDescription,
+        items: merkleDropItems,
+        merkleDrops: claimMerkleDrops,
+      });
+    } else if (claimId !== undefined) {
       setStarterpackDetails({
         type: "claimed",
         id: claimId,
@@ -156,6 +193,12 @@ export const StarterpackProvider = ({ children }: StarterpackProviderProps) => {
     }
   }, [
     // Claim dependencies
+    isMerkleDrops,
+    merkleDropKeys,
+    merkleDropName,
+    merkleDropDescription,
+    merkleDropItems,
+    claimMerkleDrops,
     claimId,
     claimName,
     claimHookItems,
@@ -183,6 +226,8 @@ export const StarterpackProvider = ({ children }: StarterpackProviderProps) => {
       setRegistryAddress(registryAddress);
       setSocialClaimOptions(socialClaimOptions);
       setStarterpackId(undefined);
+      setMerkleDropKeys(undefined);
+      setMerkleDropOptions(undefined);
     },
     [],
   );
@@ -192,6 +237,20 @@ export const StarterpackProvider = ({ children }: StarterpackProviderProps) => {
       setStarterpackId(id);
       setRegistryAddress(registryAddress);
       setBundleId(undefined);
+      setSocialClaimOptions(undefined);
+      setMerkleDropKeys(undefined);
+      setMerkleDropOptions(undefined);
+    },
+    [],
+  );
+
+  const setMerkleDrops = useCallback(
+    (keys: string[], options?: MerkleDropDisplayOptions) => {
+      setMerkleDropKeys(keys);
+      setMerkleDropOptions(options);
+      setStarterpackId(undefined);
+      setBundleId(undefined);
+      setRegistryAddress(undefined);
       setSocialClaimOptions(undefined);
     },
     [],
@@ -224,6 +283,8 @@ export const StarterpackProvider = ({ children }: StarterpackProviderProps) => {
     registryAddress,
     bundleId,
     starterpackId,
+    merkleDropKeys,
+    setMerkleDrops,
     starterpackDetails,
     isStarterpackLoading,
     claimItems,

--- a/packages/keychain/src/context/starterpack/types.ts
+++ b/packages/keychain/src/context/starterpack/types.ts
@@ -36,7 +36,7 @@ export type StarterpackType = "claimed" | "onchain";
  */
 export interface BackendStarterpackDetails {
   type: "claimed";
-  id: string; // UUID from backend
+  id: string; // Backend starterpack ID or grouped merkle-drop keys
   name: string;
   description?: string;
   items: Item[];

--- a/packages/keychain/src/hooks/starterpack/claim.ts
+++ b/packages/keychain/src/hooks/starterpack/claim.ts
@@ -1,12 +1,19 @@
 import { useEffect, useState } from "react";
 import {
   MerkleDropNetwork,
+  MerkleDropsByKeysDocument,
+  MerkleDropsByKeysQuery,
   StarterPackDocument,
   StarterPackQuery,
 } from "@cartridge/controller-ui/utils/api/cartridge";
 import { client } from "@/utils/graphql";
 import { useController } from "@/hooks/controller";
 import { Item, ItemType } from "@/context";
+
+export type MerkleDropDisplayOptions = {
+  title?: string;
+  description?: string;
+};
 
 export interface MerkleDrop {
   key: string;
@@ -15,6 +22,118 @@ export interface MerkleDrop {
   entrypoint: string;
   merkleRoot: string;
   description?: string | null;
+}
+
+type MerkleDropMetadataItem = {
+  name?: string;
+  title?: string;
+  description?: string;
+  image_uri?: string;
+  imageUri?: string;
+  icon?: string;
+  type?: string;
+  value?: number;
+  quantity?: number;
+};
+
+type MerkleDropMetadata = {
+  name?: string;
+  title?: string;
+  description?: string;
+  items?: MerkleDropMetadataItem[];
+};
+
+function mapItemType(type?: string) {
+  switch (type?.toUpperCase()) {
+    case ItemType.CREDIT:
+      return ItemType.CREDIT;
+    case ItemType.ERC20:
+      return ItemType.ERC20;
+    default:
+      return ItemType.NFT;
+  }
+}
+
+function getMetadata(metadata: unknown): MerkleDropMetadata {
+  if (typeof metadata === "string") {
+    try {
+      return JSON.parse(metadata) as MerkleDropMetadata;
+    } catch {
+      return {};
+    }
+  }
+
+  if (!metadata || typeof metadata !== "object") {
+    return {};
+  }
+
+  return metadata as MerkleDropMetadata;
+}
+
+function getMerkleDropItems(
+  drops: MerkleDropsByKeysQuery["merkleDropsByKeys"],
+) {
+  const metadataItems = drops.flatMap((drop) => {
+    const metadata = getMetadata(drop.metadata);
+
+    return (metadata.items ?? []).map((item) => ({
+      title: item.name ?? item.title ?? drop.description ?? drop.key,
+      subtitle: item.description,
+      icon: item.image_uri ?? item.imageUri ?? item.icon ?? "/placeholder.svg",
+      type: mapItemType(item.type),
+      value: item.value,
+      quantity: item.quantity,
+    }));
+  });
+
+  if (metadataItems.length > 0) {
+    return metadataItems;
+  }
+
+  return drops.map((drop) => ({
+    title: drop.description ?? drop.key,
+    subtitle: drop.network,
+    icon: "/placeholder.svg",
+    type: ItemType.NFT,
+  }));
+}
+
+function getMerkleDropName(
+  drops: MerkleDropsByKeysQuery["merkleDropsByKeys"],
+  options?: MerkleDropDisplayOptions,
+) {
+  if (options?.title) {
+    return options.title;
+  }
+
+  const metadataName = drops
+    .map((drop) => {
+      const metadata = getMetadata(drop.metadata);
+      return metadata.name ?? metadata.title;
+    })
+    .find(Boolean);
+
+  if (metadataName) {
+    return metadataName;
+  }
+
+  return drops.length === 1
+    ? (drops[0].description ?? "Merkle Drop")
+    : "Merkle Drops";
+}
+
+function getMerkleDropDescription(
+  drops: MerkleDropsByKeysQuery["merkleDropsByKeys"],
+  options?: MerkleDropDisplayOptions,
+) {
+  if (options?.description) {
+    return options.description;
+  }
+
+  return (
+    drops.map((drop) => getMetadata(drop.metadata).description).find(Boolean) ??
+    ""
+  );
 }
 
 export function useClaimStarterpack(starterpack: string | undefined) {
@@ -108,6 +227,73 @@ export function useClaimStarterpack(starterpack: string | undefined) {
       })
       .finally(() => setIsLoading(false));
   }, [controller, starterpack]);
+
+  return {
+    name,
+    description,
+    items,
+    merkleDrops,
+    isLoading,
+    error,
+  };
+}
+
+export function useClaimMerkleDrops(
+  keys: string[] | undefined,
+  options?: MerkleDropDisplayOptions,
+) {
+  const [isLoading, setIsLoading] = useState(true);
+  const [items, setItems] = useState<Item[]>([]);
+  const [error, setError] = useState<Error | null>(null);
+  const [name, setName] = useState<string>(options?.title ?? "");
+  const [description, setDescription] = useState<string>(
+    options?.description ?? "",
+  );
+  const [merkleDrops, setMerkleDrops] = useState<MerkleDrop[]>([]);
+
+  useEffect(() => {
+    setIsLoading(true);
+    setError(null);
+
+    if (!keys?.length) {
+      setName(options?.title ?? "");
+      setDescription(options?.description ?? "");
+      setItems([]);
+      setMerkleDrops([]);
+      setIsLoading(false);
+      return;
+    }
+
+    client
+      .request<MerkleDropsByKeysQuery>(MerkleDropsByKeysDocument, { keys })
+      .then((result) => {
+        const drops = result.merkleDropsByKeys;
+
+        if (!drops.length) {
+          throw new Error("No merkle drops found");
+        }
+
+        setName(getMerkleDropName(drops, options));
+        setDescription(getMerkleDropDescription(drops, options));
+        setItems(getMerkleDropItems(drops));
+        setMerkleDrops(
+          drops
+            .map((drop) => ({
+              key: drop.key,
+              network: drop.network,
+              contract: drop.contract,
+              entrypoint: drop.entrypoint,
+              merkleRoot: drop.merkleRoot,
+              description: drop.description,
+            }))
+            .sort((a, b) => a.network.localeCompare(b.network)),
+        );
+      })
+      .catch((error) => {
+        setError(error as Error);
+      })
+      .finally(() => setIsLoading(false));
+  }, [keys, options]);
 
   return {
     name,

--- a/packages/keychain/src/hooks/starterpack/index.ts
+++ b/packages/keychain/src/hooks/starterpack/index.ts
@@ -1,6 +1,6 @@
 // Data fetching hooks
-export { useClaimStarterpack } from "./claim";
-export type { MerkleDrop } from "./claim";
+export { useClaimMerkleDrops, useClaimStarterpack } from "./claim";
+export type { MerkleDrop, MerkleDropDisplayOptions } from "./claim";
 
 export { useOnchainStarterpack } from "./onchain";
 

--- a/packages/keychain/src/utils/api/generated.ts
+++ b/packages/keychain/src/utils/api/generated.ts
@@ -4891,6 +4891,7 @@ export type Query = {
   merkleClaimsForAddress: Array<MerkleClaim>;
   merkleDropByKey?: Maybe<MerkleDrop>;
   merkleDrops: MerkleDropConnection;
+  merkleDropsByKeys: Array<MerkleDrop>;
   metrics: MetricsResult;
   /** Fetches an object given its ID. */
   node?: Maybe<Node>;
@@ -5100,6 +5101,10 @@ export type QueryMerkleDropsArgs = {
   last?: InputMaybe<Scalars["Int"]>;
   orderBy?: InputMaybe<MerkleDropOrder>;
   where?: InputMaybe<MerkleDropWhereInput>;
+};
+
+export type QueryMerkleDropsByKeysArgs = {
+  keys: Array<Scalars["String"]>;
 };
 
 export type QueryMetricsArgs = {

--- a/packages/keychain/src/utils/connection/index.ts
+++ b/packages/keychain/src/utils/connection/index.ts
@@ -31,6 +31,41 @@ import { PRESERVE_URL_PARAMS_FLAG } from "@/hooks/connection";
 
 export type { ControllerError } from "./execute";
 
+type MerkleDropsRouteOptions = {
+  title?: string;
+  description?: string;
+  preimage?: string;
+};
+
+const LEGACY_STARTERPACK_MERKLE_DROPS: Record<
+  string,
+  { keys: string[]; title: string; description?: string }
+> = {
+  "pirate-nation-claim-mainnet": {
+    keys: ["priate-nation"],
+    title: "Pirate Nation",
+    description: "Claim games and tokens Pirate Nation holders",
+  },
+};
+
+function merkleDropsPath(keys: string[], options?: MerkleDropsRouteOptions) {
+  const searchParams = new URLSearchParams();
+
+  if (options?.title) {
+    searchParams.set("title", options.title);
+  }
+  if (options?.description) {
+    searchParams.set("description", options.description);
+  }
+  if (options?.preimage) {
+    searchParams.set("preimage", options.preimage);
+  }
+
+  const query = searchParams.toString();
+  const encodedKeys = keys.map((key) => encodeURIComponent(key)).join(";");
+  return `/purchase/merkle-drops/${encodedKeys}${query ? `?${query}` : ""}`;
+}
+
 export function connectToController<
   ParentMethods extends HeadlessConnectParent,
 >({
@@ -157,6 +192,19 @@ export function connectToController<
         },
       openStarterPack:
         () => (id: string | number, options?: StarterpackOptions) => {
+          const legacyMerkleDrops = LEGACY_STARTERPACK_MERKLE_DROPS[String(id)];
+          if (legacyMerkleDrops) {
+            navigate(
+              merkleDropsPath(legacyMerkleDrops.keys, {
+                title: legacyMerkleDrops.title,
+                description: legacyMerkleDrops.description,
+                preimage: options?.preimage,
+              }),
+              { replace: true },
+            );
+            return;
+          }
+
           const searchParams: string[] = [];
           if (options?.preimage) {
             searchParams.push(`preimage=${options.preimage}`);
@@ -165,6 +213,10 @@ export function connectToController<
             `/purchase/starterpack/${id}${searchParams.length > 0 ? `?${searchParams.join("&")}` : ""}`,
             { replace: true },
           );
+        },
+      openMerkleDrops:
+        () => (keys: string[], options?: MerkleDropsRouteOptions) => {
+          navigate(merkleDropsPath(keys, options), { replace: true });
         },
       openLocationPrompt: () => locationPromptFactory({ navigate }),
       switchChain: () => switchChain({ setController, setRpcUrl }),

--- a/packages/ui/src/utils/api/cartridge/generated.ts
+++ b/packages/ui/src/utils/api/cartridge/generated.ts
@@ -4950,6 +4950,7 @@ export type Query = {
   merkleClaimsForAddress: Array<MerkleClaim>;
   merkleDropByKey?: Maybe<MerkleDrop>;
   merkleDrops: MerkleDropConnection;
+  merkleDropsByKeys: Array<MerkleDrop>;
   metrics: MetricsResult;
   /** Fetches an object given its ID. */
   node?: Maybe<Node>;
@@ -5189,6 +5190,11 @@ export type QueryMerkleDropsArgs = {
   last?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<MerkleDropOrder>;
   where?: InputMaybe<MerkleDropWhereInput>;
+};
+
+
+export type QueryMerkleDropsByKeysArgs = {
+  keys: Array<Scalars['String']>;
 };
 
 
@@ -8019,6 +8025,13 @@ export type MerkleDropByKeyQueryVariables = Exact<{
 
 export type MerkleDropByKeyQuery = { __typename?: 'Query', merkleDropByKey?: { __typename?: 'MerkleDrop', key: string, salt: string, network: MerkleDropNetwork, contract: string, entrypoint: string, merkleRoot: string, description?: string | null, matchStarterpackItem: boolean } | null };
 
+export type MerkleDropsByKeysQueryVariables = Exact<{
+  keys: Array<Scalars['String']> | Scalars['String'];
+}>;
+
+
+export type MerkleDropsByKeysQuery = { __typename?: 'Query', merkleDropsByKeys: Array<{ __typename?: 'MerkleDrop', key: string, salt: string, network: MerkleDropNetwork, contract: string, entrypoint: string, merkleRoot: string, description?: string | null, matchStarterpackItem: boolean, metadata?: any | null }> };
+
 export type MerkleClaimsForAddressQueryVariables = Exact<{
   keys: Array<Scalars['String']> | Scalars['String'];
   address: Scalars['String'];
@@ -9019,6 +9032,33 @@ export const useMerkleDropByKeyQuery = <
     useQuery<MerkleDropByKeyQuery, TError, TData>(
       ['MerkleDropByKey', variables],
       useFetchData<MerkleDropByKeyQuery, MerkleDropByKeyQueryVariables>(MerkleDropByKeyDocument).bind(null, variables),
+      options
+    );
+export const MerkleDropsByKeysDocument = `
+    query MerkleDropsByKeys($keys: [String!]!) {
+  merkleDropsByKeys(keys: $keys) {
+    key
+    salt
+    network
+    contract
+    entrypoint
+    merkleRoot
+    description
+    matchStarterpackItem
+    metadata
+  }
+}
+    `;
+export const useMerkleDropsByKeysQuery = <
+      TData = MerkleDropsByKeysQuery,
+      TError = unknown
+    >(
+      variables: MerkleDropsByKeysQueryVariables,
+      options?: UseQueryOptions<MerkleDropsByKeysQuery, TError, TData>
+    ) =>
+    useQuery<MerkleDropsByKeysQuery, TError, TData>(
+      ['MerkleDropsByKeys', variables],
+      useFetchData<MerkleDropsByKeysQuery, MerkleDropsByKeysQueryVariables>(MerkleDropsByKeysDocument).bind(null, variables),
       options
     );
 export const MerkleClaimsForAddressDocument = `

--- a/packages/ui/src/utils/api/cartridge/merkle.graphql
+++ b/packages/ui/src/utils/api/cartridge/merkle.graphql
@@ -11,6 +11,20 @@ query MerkleDropByKey($key: String!) {
   }
 }
 
+query MerkleDropsByKeys($keys: [String!]!) {
+  merkleDropsByKeys(keys: $keys) {
+    key
+    salt
+    network
+    contract
+    entrypoint
+    merkleRoot
+    description
+    matchStarterpackItem
+    metadata
+  }
+}
+
 query MerkleClaimsForAddress($keys: [String!]!, $address: String!) {
   merkleClaimsForAddress(keys: $keys, address: $address) {
     index


### PR DESCRIPTION
## Summary
- Add public `controller.openMerkleDrops(keys, { title, description, preimage, onClaimComplete })` support.
- Add a keychain `/purchase/merkle-drops/:keys` route that loads drops through the generated `merkleDropsByKeys` GraphQL operation and renders metadata-driven claim items.
- Keep `openStarterPack("pirate-nation-claim-mainnet")` working by routing it to the `priate-nation` merkle drop with Pirate Nation title/description.
- Regenerate the controller-ui cartridge GraphQL types against the deployed backend schema.

## Validation
- `git diff --check`
- `pnpm --filter @cartridge/controller-ui graphql:gen`
- `pnpm --filter @cartridge/controller-ui build`
- `pnpm --filter @cartridge/controller build:deps`
- `pnpm --filter @cartridge/keychain build` now resolves the generated merkle-drop query but still fails on missing Turnkey packages in the updated main baseline: `@turnkey/api-key-stamper`, `@turnkey/crypto`, and `@turnkey/encoding`.
- Initial commit hook `pnpm lint:check` passed, then `test:ci` failed on the same missing Turnkey imports; commit was created with `--no-verify` because that blocker is unrelated to this change.