### PR TITLE
fix(keychain): external wallet network-switch prompts (Ready)

### DIFF
--- a/packages/keychain/src/components/purchase/checkout/onchain/wallet-drawer.tsx
+++ b/packages/keychain/src/components/purchase/checkout/onchain/wallet-drawer.tsx
@@ -131,6 +131,13 @@ export function WalletSelectionDrawer({
           (chain) => chain.isMainnet === isMainnet,
         )?.chainId;
 
+        console.log("[chain-debug] wallet-drawer resolve chainId", {
+          isMainnet,
+          platform: selectedNetwork.platform,
+          chains: selectedNetwork.chains,
+          resolvedChainId: chainId,
+        });
+
         if (chainId) {
           newChainIds.set(selectedNetwork.platform, chainId);
         }

--- a/packages/keychain/src/components/purchase/wallet/wallet.tsx
+++ b/packages/keychain/src/components/purchase/wallet/wallet.tsx
@@ -89,6 +89,13 @@ export function SelectWallet() {
           (chain) => chain.isMainnet === isMainnet,
         )?.chainId;
 
+        console.log("[chain-debug] wallet.tsx resolve chainId", {
+          isMainnet,
+          platform: network.platform,
+          chains: network.chains,
+          resolvedChainId: chainId,
+        });
+
         if (chainId) {
           newChainIds.set(network.platform, chainId);
         }

--- a/packages/keychain/src/hooks/connection.ts
+++ b/packages/keychain/src/hooks/connection.ts
@@ -664,6 +664,13 @@ export function useConnectionValue() {
     // changes, so it can go stale (e.g. after an in-place network switch),
     // leaving isMainnet wrong regardless of the actual connected network.
     const currentChainId = chainId ?? controller?.chainId();
+    console.log("[chain-debug] isMainnet effect", {
+      chainIdState: chainId,
+      controllerChainId: controller?.chainId(),
+      currentChainId,
+      SN_MAIN: constants.StarknetChainId.SN_MAIN,
+      isMainnet: currentChainId === constants.StarknetChainId.SN_MAIN,
+    });
     setIsMainnet(currentChainId === constants.StarknetChainId.SN_MAIN);
   }, [chainId, controller]);
 

--- a/packages/keychain/src/hooks/connection.ts
+++ b/packages/keychain/src/hooks/connection.ts
@@ -659,8 +659,13 @@ export function useConnectionValue() {
   }, [controller?.username, chainId, controller]);
 
   useEffect(() => {
-    setIsMainnet(controller?.chainId() === constants.StarknetChainId.SN_MAIN);
-  }, [controller]);
+    // Prefer the RPC-derived chainId state since it tracks network switches;
+    // controller.chainId() is only re-read when the controller object identity
+    // changes, so it can go stale (e.g. after an in-place network switch),
+    // leaving isMainnet wrong regardless of the actual connected network.
+    const currentChainId = chainId ?? controller?.chainId();
+    setIsMainnet(currentChainId === constants.StarknetChainId.SN_MAIN);
+  }, [chainId, controller]);
 
   // Load config when preset is provided
   useEffect(() => {

--- a/packages/keychain/src/hooks/starterpack/external-wallet.ts
+++ b/packages/keychain/src/hooks/starterpack/external-wallet.ts
@@ -95,6 +95,16 @@ export function useExternalWallet({
               ? normalizeChainId(wallet.chainId)
               : undefined;
 
+            console.log("[chain-debug] onExternalConnect switch decision", {
+              walletType: wallet.type,
+              walletChainIdRaw: wallet.chainId,
+              targetChainIdRaw: chainId,
+              normalizedCurrent: current,
+              normalizedTarget: target,
+              controllerChainId: controller?.chainId(),
+              willSwitch: current !== target,
+            });
+
             if (current !== target) {
               const res = await switchChain(wallet.type, chainId.toString());
               if (!res) {

--- a/packages/keychain/src/hooks/starterpack/external-wallet.ts
+++ b/packages/keychain/src/hooks/starterpack/external-wallet.ts
@@ -1,7 +1,17 @@
 import { useState, useCallback } from "react";
 import { ExternalPlatform, ExternalWallet } from "@cartridge/controller";
+import { shortString } from "starknet";
 import { useWallets } from "@/hooks/wallets";
 import { useConnection } from "../connection";
+
+function normalizeChainId(chainId: string | number): string {
+  if (typeof chainId === "number") {
+    return `0x${chainId.toString(16)}`.toLowerCase();
+  }
+  return (
+    chainId.startsWith("0x") ? chainId : shortString.encodeShortString(chainId)
+  ).toLowerCase();
+}
 
 export interface UseExternalWalletOptions {
   onError?: (error: Error) => void;
@@ -77,12 +87,22 @@ export function useExternalWallet({
               "Braavos does not support `wallet_switchStarknetChain`",
             );
           } else {
-            const res = await switchChain(wallet.type, chainId.toString());
-            if (!res) {
-              const error = new Error(
-                `${wallet.name} failed to switch chain (${chainId})`,
-              );
-              throw error;
+            // Only request a chain switch when the wallet isn't already on the
+            // target chain. Switching unconditionally makes wallets (e.g. Ready)
+            // prompt every time, even when no change is needed.
+            const target = normalizeChainId(chainId);
+            const current = wallet.chainId
+              ? normalizeChainId(wallet.chainId)
+              : undefined;
+
+            if (current !== target) {
+              const res = await switchChain(wallet.type, chainId.toString());
+              if (!res) {
+                const error = new Error(
+                  `${wallet.name} failed to switch chain (${chainId})`,
+                );
+                throw error;
+              }
             }
           }
         }


### PR DESCRIPTION
## Problem
Selecting an external Starknet wallet (e.g. **Ready**) in the purchase flow prompts a network switch even when the wallet is already on the controller's network — and the requested target is the *wrong* network (Sepolia while the controller is on Mainnet), sometimes prompting Sepolia then Mainnet back-to-back.

## Diagnosis so far
Two contributing issues:
1. **`onExternalConnect` switched unconditionally** — it called `wallet_switchStarknetChain` on every connect without checking the wallet's current chain.
2. **`isMainnet` could go stale** — it was derived from `controller.chainId()` with a `[controller]` dependency, so it only recomputed when the controller object identity changed. After an in-place network switch (or if `chainId()` wasn't ready at first set) it stayed at its initial `false`, making the flow resolve the wrong target chain.

## Changes
- `external-wallet.ts`: only request a switch when the wallet's current chain differs from the target (normalized compare).
- `connection.ts`: derive `isMainnet` from the RPC-derived `chainId` state (which tracks `rpcUrl`/network changes), falling back to `controller.chainId()`.

## ⚠️ Draft / WIP
- A previous local test showed the prompt persisting, so this is **not yet confirmed**.
- Includes **temporary `[chain-debug]` console logging** (connection isMainnet effect, chainId resolution in the wallet picker/drawer, and the switch decision) to capture runtime values on the preview. **These logs must be removed before merge.**

## Verification plan
- [ ] Reproduce Ready connect on Mainnet, capture `[chain-debug]` console output
- [ ] Confirm no spurious switch prompt when already on the controller's network
- [ ] Remove `[chain-debug]` logging
- [ ] Mark ready for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)