### PR TITLE
fix: remove crypto pay-in path from keychain

### DIFF
--- a/packages/keychain/src/components/purchasenew/checkout/onchain/wallet-drawer.tsx
+++ b/packages/keychain/src/components/purchasenew/checkout/onchain/wallet-drawer.tsx
@@ -56,9 +56,7 @@ export function WalletSelectionDrawer({
   >(new Map());
 
   const selectedNetworks = useMemo(() => {
-    const platforms = isMainnet
-      ? ["starknet", "ethereum", "base", "arbitrum", "optimism"]
-      : ["starknet"];
+    const platforms = ["starknet"];
 
     let networks = platforms
       .map((platform) =>

--- a/packages/keychain/src/components/purchasenew/pending/bridge.tsx
+++ b/packages/keychain/src/components/purchasenew/pending/bridge.tsx
@@ -59,7 +59,7 @@ export interface BridgePendingProps {
 }
 
 /**
- * Pending state for crypto bridging purchases via Layerswap.
+ * Pending state for bridged purchases via Layerswap.
  * Currently disabled but preserved for future use.
  */
 export function BridgePending({
@@ -204,7 +204,7 @@ export function BridgePending({
       </LayoutContent>
       <LayoutFooter>
         {error && <ControllerErrorAlert error={error} />}
-        {(paymentMethod === "crypto" || paymentMethod === "apple-pay") &&
+        {(paymentMethod === "bridge" || paymentMethod === "apple-pay") &&
           !error && (
             <div className="relative space-y-2">
               <div

--- a/packages/keychain/src/components/purchasenew/pending/index.tsx
+++ b/packages/keychain/src/components/purchasenew/pending/index.tsx
@@ -65,7 +65,7 @@ export function Pending() {
         items={purchaseItems}
         swapId={swapId}
         transactionHash={transactionHash}
-        paymentMethod="crypto"
+        paymentMethod="bridge"
         explorer={explorer}
         wallet={selectedWallet}
         selectedPlatform={selectedPlatform}

--- a/packages/keychain/src/components/purchasenew/pending/pending.stories.tsx
+++ b/packages/keychain/src/components/purchasenew/pending/pending.stories.tsx
@@ -29,8 +29,8 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-// Stories for BridgePending (Crypto bridging payments)
-export const CryptoPurchaseWithCredits: Story = {
+// Stories for BridgePending (bridged payments)
+export const BridgePurchaseWithCredits: Story = {
   render: () => (
     <BridgePending
       name="Village Kit"
@@ -49,7 +49,7 @@ export const CryptoPurchaseWithCredits: Story = {
           type: ItemType.ERC20,
         },
       ]}
-      paymentMethod="crypto"
+      paymentMethod="bridge"
       swapId="payment_123"
       transactionHash="0x1234567890abcdef"
       selectedPlatform="ethereum"
@@ -69,7 +69,7 @@ export const CryptoPurchaseWithCredits: Story = {
   ),
 };
 
-export const CryptoPurchaseWithNFT: Story = {
+export const BridgePurchaseWithNFT: Story = {
   render: () => (
     <BridgePending
       name="Adventure Pack"
@@ -93,7 +93,7 @@ export const CryptoPurchaseWithNFT: Story = {
           type: ItemType.ERC20,
         },
       ]}
-      paymentMethod="crypto"
+      paymentMethod="bridge"
       swapId="payment_456"
       transactionHash="0xabcdef1234567890"
       selectedPlatform="solana"
@@ -113,7 +113,7 @@ export const CryptoPurchaseWithNFT: Story = {
   ),
 };
 
-export const CryptoPurchaseWithoutWallet: Story = {
+export const BridgePurchaseWithoutWallet: Story = {
   render: () => (
     <BridgePending
       name="Starter Pack"
@@ -132,7 +132,7 @@ export const CryptoPurchaseWithoutWallet: Story = {
           type: ItemType.ERC20,
         },
       ]}
-      paymentMethod="crypto"
+      paymentMethod="bridge"
       swapId="payment_789"
       selectedPlatform="starknet"
       waitForDeposit={async () => true}
@@ -220,7 +220,7 @@ export const OnchainPurchaseWithMultipleItems: Story = {
         },
         {
           title: "USDC",
-          subtitle: "750 USDC stablecoin",
+          subtitle: "750 in-app credits",
           icon: TOKEN_ICONS.USDC,
           value: 750,
           type: ItemType.ERC20,
@@ -288,7 +288,7 @@ export const ClaimFreeNFT: Story = {
 };
 
 // Loading states
-export const CryptoPurchaseLoading: Story = {
+export const BridgePurchaseLoading: Story = {
   render: () => (
     <BridgePending
       name="Loading Pack"
@@ -300,7 +300,7 @@ export const CryptoPurchaseLoading: Story = {
           type: ItemType.CREDIT,
         },
       ]}
-      paymentMethod="crypto"
+      paymentMethod="bridge"
       swapId="payment_loading"
       transactionHash="0x0000000000000000"
       selectedPlatform="starknet"
@@ -341,7 +341,7 @@ export const TokenPurchaseSmallAmount: Story = {
           type: ItemType.ERC20,
         },
       ]}
-      paymentMethod="crypto"
+      paymentMethod="bridge"
       swapId="payment_small_tokens"
       transactionHash="0xabc123def456"
       selectedPlatform="ethereum"
@@ -388,7 +388,7 @@ export const TokenPurchaseLargeAmount: Story = {
           type: ItemType.ERC20,
         },
       ]}
-      paymentMethod="crypto"
+      paymentMethod="bridge"
       swapId="payment_large_tokens"
       transactionHash="0xdef789abc012"
       selectedPlatform="ethereum"

--- a/packages/keychain/src/context/starterpack/types.ts
+++ b/packages/keychain/src/context/starterpack/types.ts
@@ -24,7 +24,7 @@ export type Item = {
 /**
  * Payment method type
  */
-export type PaymentMethod = "stripe" | "crypto" | "apple-pay";
+export type PaymentMethod = "stripe" | "bridge" | "apple-pay";
 
 /**
  * Discriminated union for starterpack sources


### PR DESCRIPTION
Scope:
- Change starterpack payment method typing from crypto to bridge.
- Update bridge pending flow and stories to use bridge terminology.
- Constrain wallet selection to Starknet in the onchain drawer.

No tests were run in this pass; the branch is limited to UI and type updates.,