### PR TITLE
feat: auto detect SMS contry code

### DIFF
--- a/packages/keychain/src/components/connect/create/CreateController.tsx
+++ b/packages/keychain/src/components/connect/create/CreateController.tsx
@@ -450,8 +450,9 @@ export function CreateControllerView({
       />
       <SignerPendingDrawer
         isOpen={
-          authenticationStep === AuthenticationStep.Pending ||
-          authenticationStep === AuthenticationStep.Error
+          !!authMethod &&
+          (authenticationStep === AuthenticationStep.Pending ||
+            authenticationStep === AuthenticationStep.Error)
         }
         isLogin={isLogin}
         isLoading={isLoading}

--- a/packages/keychain/src/components/connect/create/sms/SmsOtpForm.tsx
+++ b/packages/keychain/src/components/connect/create/sms/SmsOtpForm.tsx
@@ -9,6 +9,8 @@ import {
   formatPhoneNumber,
   isValidPhoneNumber,
 } from "@cartridge/controller-ui";
+import { getIpLocation } from "@/utils";
+import { IpLocation } from "@/utils/ip";
 
 export interface SmsOtpState {
   username?: string;
@@ -68,6 +70,26 @@ export function SmsOtpDrawer({
     setOtpCodeError(undefined);
     setOtpSentAt(null);
   }, []);
+
+  const [geoLocation, setGeoLocation] = useState<IpLocation | null>(null);
+  useEffect(() => {
+    if (!isOpen || geoLocation) return;
+    let mounted = true;
+    (async () => {
+      try {
+        const geo = await getIpLocation();
+        if (mounted) {
+          setGeoLocation(geo);
+        }
+      } catch (err) {
+        console.error("getIpLocation failed:", err);
+      }
+    })();
+
+    return () => {
+      mounted = false;
+    };
+  }, [isOpen, geoLocation]);
 
   useEffect(() => {
     if (isOpen) {
@@ -215,6 +237,7 @@ export function SmsOtpDrawer({
                 placeholder={
                   isResolvingPhoneNumber ? smsState?.phoneNumber : undefined
                 }
+                userCountryCode={geoLocation?.countryCode}
               />
             </div>
           ) : (

--- a/packages/keychain/src/components/provider/connection.tsx
+++ b/packages/keychain/src/components/provider/connection.tsx
@@ -34,6 +34,7 @@ export type ConnectionContextValue = {
   theme: VerifiableControllerTheme;
   isConfigLoading: boolean;
   isPoliciesResolved: boolean;
+  isPoliciesError: boolean;
   isMainnet: boolean;
   verified: boolean;
   chainId?: string;

--- a/packages/keychain/src/components/provider/index.test.tsx
+++ b/packages/keychain/src/components/provider/index.test.tsx
@@ -134,6 +134,7 @@ const baseConnection = {
   },
   isConfigLoading: false,
   isPoliciesResolved: true,
+  isPoliciesError: false,
   isMainnet: false,
   verified: true,
   chainId: undefined,

--- a/packages/keychain/src/components/session.test.tsx
+++ b/packages/keychain/src/components/session.test.tsx
@@ -85,6 +85,7 @@ describe("Session", () => {
       },
       isConfigLoading: false,
       isPoliciesResolved: true,
+      isPoliciesError: false,
       isMainnet: false,
       verified: true,
       chainId: "SN_MAIN",

--- a/packages/keychain/src/hooks/connection.ts
+++ b/packages/keychain/src/hooks/connection.ts
@@ -161,7 +161,7 @@ export type ParentMethods = AsyncMethodReturns<{
  */
 export function parseUrlPolicies(
   policiesStr: string | null,
-): ParsedSessionPolicies | undefined {
+): ParsedSessionPolicies | undefined | Error {
   if (!policiesStr) {
     return undefined;
   }
@@ -175,7 +175,7 @@ export function parseUrlPolicies(
     });
   } catch (e) {
     console.error("Failed to parse URL policies:", e);
-    return undefined;
+    return new Error("Failed to parse URL policies");
   }
 }
 
@@ -190,7 +190,7 @@ function getConfigChainPolicies(
   configData: Record<string, unknown> | null,
   chainId: string | undefined,
   verified: boolean,
-): ParsedSessionPolicies | undefined {
+): ParsedSessionPolicies | undefined | Error {
   if (!configData || !chainId) {
     return undefined;
   }
@@ -201,8 +201,8 @@ function getConfigChainPolicies(
     return parseSessionPolicies({ verified, policies: sessionPolicies });
   } catch (e) {
     console.error("Failed to process chain policies from config:", e);
+    return new Error("Failed to process chain policies from config");
   }
-  return undefined;
 }
 
 export function resolvePolicies({
@@ -224,8 +224,13 @@ export function resolvePolicies({
 }): {
   policies: ParsedSessionPolicies | undefined;
   isPoliciesResolved: boolean;
+  error?: boolean;
 } {
   const urlPolicies = parseUrlPolicies(policiesStr);
+
+  if (urlPolicies instanceof Error) {
+    return { policies: undefined, isPoliciesResolved: true, error: true };
+  }
 
   if (shouldOverridePresetPolicies && urlPolicies) {
     return { policies: urlPolicies, isPoliciesResolved: true };
@@ -241,6 +246,9 @@ export function resolvePolicies({
       chainId,
       verified,
     );
+    if (configPolicies instanceof Error) {
+      return { policies: undefined, isPoliciesResolved: true, error: true };
+    }
     if (configPolicies) {
       return { policies: configPolicies, isPoliciesResolved: true };
     }
@@ -333,6 +341,7 @@ export function useConnectionValue() {
   );
   const [policies, setPolicies] = useState<ParsedSessionPolicies>();
   const [isPoliciesResolved, setIsPoliciesResolved] = useState<boolean>(false);
+  const [isPoliciesError, setIsPoliciesError] = useState<boolean>(false);
   const [verified, setVerified] = useState<boolean>(false);
   const initialPreset =
     typeof window !== "undefined"
@@ -805,19 +814,23 @@ export function useConnectionValue() {
       preset,
       shouldOverridePresetPolicies,
     } = urlParams;
-    const { policies: resolvedPolicies, isPoliciesResolved: resolved } =
-      resolvePolicies({
-        policiesStr: policyStr,
-        preset,
-        shouldOverridePresetPolicies,
-        configData,
-        chainId,
-        verified,
-        isConfigLoading,
-      });
+    const {
+      policies: resolvedPolicies,
+      isPoliciesResolved: resolved,
+      error,
+    } = resolvePolicies({
+      policiesStr: policyStr,
+      preset,
+      shouldOverridePresetPolicies,
+      configData,
+      chainId,
+      verified,
+      isConfigLoading,
+    });
 
-    setPolicies(resolvedPolicies);
+    setPolicies(resolvedPolicies || { verified: false });
     setIsPoliciesResolved(resolved);
+    setIsPoliciesError(error ?? false);
   }, [urlParams, chainId, verified, configData, isConfigLoading]);
 
   useThemeEffect({ theme, assetUrl: "" });
@@ -1050,6 +1063,7 @@ export function useConnectionValue() {
     policiesStr: urlParams.policies,
     isConfigLoading,
     isPoliciesResolved,
+    isPoliciesError,
     isMainnet,
     verified,
     chainId,

--- a/packages/keychain/src/test/mocks/connection.tsx
+++ b/packages/keychain/src/test/mocks/connection.tsx
@@ -33,6 +33,7 @@ export const defaultMockConnection: ConnectionContextValue = {
   verified: false,
   isConfigLoading: false,
   isPoliciesResolved: true,
+  isPoliciesError: false,
   isMainnet: false,
   theme: {
     verified: true,

--- a/packages/keychain/src/utils/ip.ts
+++ b/packages/keychain/src/utils/ip.ts
@@ -1,4 +1,4 @@
-type IpLocation = {
+export type IpLocation = {
   countryCode: string | null;
   regionCode: string | null;
 };

--- a/packages/ui/src/components/primitives/phone-input/countries.ts
+++ b/packages/ui/src/components/primitives/phone-input/countries.ts
@@ -10,6 +10,9 @@ export type Country = {
   maxLength?: number;
 };
 
+/** Fallback ISO 3166-1 alpha-2 country code when no user/locale hint is given. */
+export const DEFAULT_COUNTRY = "US";
+
 export const COUNTRIES: Country[] = [
   {
     name: "Afghanistan",

--- a/packages/ui/src/components/primitives/phone-input/phone-country-code-select.tsx
+++ b/packages/ui/src/components/primitives/phone-input/phone-country-code-select.tsx
@@ -1,10 +1,11 @@
+import { useMemo } from "react";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
 } from "@/components/primitives/select";
-import { COUNTRIES } from "./countries";
+import { COUNTRIES, DEFAULT_COUNTRY } from "./countries";
 import { cn } from "@/utils";
 
 export interface PhoneCountryCodeSelectProps {
@@ -16,6 +17,9 @@ export interface PhoneCountryCodeSelectProps {
   /** ISO country codes to filter the list. When undefined or empty, all
    * countries are listed. */
   allowedCountries?: string[];
+  /** ISO 3166-1 alpha-2 country code to use as fallback when `value` does
+   * not match a known country. Defaults to {@link DEFAULT_COUNTRY}. */
+  userCountryCode?: string | null;
 }
 
 export function PhoneCountryCodeSelect({
@@ -24,11 +28,24 @@ export function PhoneCountryCodeSelect({
   disabled,
   className,
   allowedCountries,
+  userCountryCode,
 }: PhoneCountryCodeSelectProps) {
-  const selected = COUNTRIES.find((c) => c.code === value);
-  const visibleCountries = allowedCountries?.length
-    ? COUNTRIES.filter((c) => allowedCountries.includes(c.code))
-    : COUNTRIES;
+  const selected = useMemo(
+    () =>
+      COUNTRIES.find((c) => c.code === value) ??
+      (userCountryCode
+        ? COUNTRIES.find((c) => c.code === userCountryCode)
+        : undefined) ??
+      COUNTRIES.find((c) => c.code === DEFAULT_COUNTRY),
+    [value, userCountryCode],
+  );
+  const visibleCountries = useMemo(
+    () =>
+      allowedCountries?.length
+        ? COUNTRIES.filter((c) => allowedCountries.includes(c.code))
+        : COUNTRIES,
+    [allowedCountries],
+  );
 
   return (
     <Select

--- a/packages/ui/src/components/primitives/phone-input/phone-number-input.tsx
+++ b/packages/ui/src/components/primitives/phone-input/phone-number-input.tsx
@@ -1,10 +1,8 @@
-import { forwardRef, useEffect, useMemo, useState } from "react";
+import { forwardRef, useEffect, useMemo, useRef, useState } from "react";
 import { Input } from "@/components/primitives/input";
 import { ErrorAlertIcon } from "@/components/icons/error-alert-icon";
 import { PhoneCountryCodeSelect } from "./phone-country-code-select";
-import { COUNTRIES, type Country } from "./countries";
-
-const DEFAULT_COUNTRY = "US";
+import { COUNTRIES, DEFAULT_COUNTRY, type Country } from "./countries";
 
 function countryOf(code: string): Country | undefined {
   return COUNTRIES.find((c) => c.code === code);
@@ -58,6 +56,10 @@ export interface PhoneNumberInputProps {
    * undefined or empty, all countries are listed. When a single code is
    * passed, it is pre-selected and the select is disabled. */
   allowedCountries?: string[];
+  /** ISO 3166-1 alpha-2 country code used as the initial selection when no
+   * country can be detected from `value` and no `allowedCountries` apply.
+   * Falls back to {@link DEFAULT_COUNTRY} when undefined. */
+  userCountryCode?: string | null;
   inputId?: string;
   placeholder?: string;
 }
@@ -72,6 +74,7 @@ export const PhoneNumberInput = forwardRef<
     error,
     disabled,
     allowedCountries,
+    userCountryCode,
     inputId,
     placeholder = "(234)567-8900",
   },
@@ -87,8 +90,19 @@ export const PhoneNumberInput = forwardRef<
     const detected = detectCountry(value);
     if (detected && isAllowed(detected)) return detected;
     if (allowedCountries?.length) return allowedCountries[0];
+    if (
+      userCountryCode &&
+      countryOf(userCountryCode) &&
+      isAllowed(userCountryCode)
+    ) {
+      return userCountryCode;
+    }
     return DEFAULT_COUNTRY;
   });
+
+  // `userCountryCode` may arrive after mount (async geolocation). Apply it
+  // only while the user hasn't explicitly picked a country or typed digits.
+  const hasUserInteractedRef = useRef(false);
 
   const effectiveCountry = lockedCountry ?? country;
   const countryData = countryOf(effectiveCountry);
@@ -104,6 +118,18 @@ export const PhoneNumberInput = forwardRef<
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value, dialCode, lockedCountry, allowedCountries]);
 
+  // Adopt a late-arriving `userCountryCode` as the default selection.
+  useEffect(() => {
+    if (lockedCountry) return;
+    if (hasUserInteractedRef.current) return;
+    if (!userCountryCode || !countryOf(userCountryCode)) return;
+    if (!isAllowed(userCountryCode)) return;
+    const detected = detectCountry(value);
+    if (detected && isAllowed(detected)) return;
+    setCountry(userCountryCode);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userCountryCode]);
+
   const digits = useMemo(() => {
     if (value.startsWith(dialCode)) {
       return value.slice(dialCode.length).replace(/\D/g, "");
@@ -117,11 +143,13 @@ export const PhoneNumberInput = forwardRef<
   );
 
   const handleCountryChange = (newCountry: string) => {
+    hasUserInteractedRef.current = true;
     setCountry(newCountry);
     setValue(`${countryOf(newCountry)?.dial_code ?? ""}${digits}`);
   };
 
   const handleDigitsChange = (raw: string) => {
+    hasUserInteractedRef.current = true;
     const sanitized = raw.replace(/\D/g, "");
     // Re-format to apply the format's digit cap, then strip back to digits.
     const capped = formatPhoneDigits(countryData, sanitized).replace(/\D/g, "");
@@ -136,6 +164,7 @@ export const PhoneNumberInput = forwardRef<
           setValue={handleCountryChange}
           disabled={disabled || !!lockedCountry}
           allowedCountries={allowedCountries}
+          userCountryCode={userCountryCode}
           className="w-20 shrink-0"
         />
         <Input

--- a/packages/ui/src/stories/phone-input.stories.tsx
+++ b/packages/ui/src/stories/phone-input.stories.tsx
@@ -1,6 +1,6 @@
-import { PhoneNumberInput as UIPhoneNumberInput } from "@/components/primitives/phone-input";
+import { useEffect, useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
-import { useState } from "react";
+import { PhoneNumberInput as UIPhoneNumberInput } from "@/components/primitives/phone-input";
 
 const meta: Meta<typeof UIPhoneNumberInput> = {
   title: "Primitives/Phone Input",
@@ -18,9 +18,11 @@ type Story = StoryObj<typeof UIPhoneNumberInput>;
 function PhoneNumberInput({
   initialValue = "",
   allowedCountries,
+  userCountryCode,
 }: {
   initialValue?: string;
   allowedCountries?: string[];
+  userCountryCode?: string;
 }) {
   const [value, setValue] = useState(initialValue);
   return (
@@ -29,6 +31,7 @@ function PhoneNumberInput({
         value={value}
         setValue={setValue}
         allowedCountries={allowedCountries}
+        userCountryCode={userCountryCode}
       />
     </div>
   );
@@ -47,4 +50,28 @@ export const AllowedCountries: Story = {
 
 export const SingleCountry: Story = {
   render: () => <PhoneNumberInput allowedCountries={["US"]} />,
+};
+
+export const UserCountryCode: Story = {
+  render: () => <PhoneNumberInput userCountryCode={"GB"} />,
+};
+
+export const UserCountryCodeAsync: Story = {
+  render: () => {
+    function AsyncUserCountryCode() {
+      const [userCountryCode, setUserCountryCode] = useState<
+        string | undefined
+      >(undefined);
+      useEffect(() => {
+        const id = setTimeout(() => setUserCountryCode("GB"), 1000);
+        return () => clearTimeout(id);
+      }, []);
+      return <PhoneNumberInput userCountryCode={userCountryCode} />;
+    }
+    return <AsyncUserCountryCode />;
+  },
+};
+
+export const UserCountryCodeInvalid: Story = {
+  render: () => <PhoneNumberInput userCountryCode={"UK"} />,
 };


### PR DESCRIPTION
* Use the controller's geo location to auto-detect country code for SMS sign-up
* Avoid black screen when policies fail to parse, logging to console.
