### PR TITLE
fix(keychain): re-estimate fees on chain switch + skip simulation for not-yet-deployed accounts

### DIFF
--- a/packages/keychain/src/components/ExecutionContainer.tsx
+++ b/packages/keychain/src/components/ExecutionContainer.tsx
@@ -58,13 +58,20 @@ export function ExecutionContainer({
   const [isEstimating, setIsEstimating] = useState(true);
   const [ctaState, setCTAState] = useState<"deploy" | "execute">("execute");
 
-  // Prevent unnecessary estimate fee calls.
+  // Prevent unnecessary estimate fee calls. Track the controller too: on a chain
+  // switch a *new* Controller instance is created (bound to the new RPC), and the
+  // React context updates a render after the synchronous window.controller swap.
+  // Without re-estimating on that change, the modal keeps a stale fee error from
+  // the previous chain (e.g. "Contract not found" when the prior chain lacks the
+  // target contract).
   const prevTransactionsRef = useRef<{
     transactions: Call[] | undefined;
     feeEstimate: FeeEstimate | undefined;
+    controller: typeof controller;
   }>({
     transactions: undefined,
     feeEstimate: undefined,
+    controller: undefined,
   });
 
   const estimateFees = useCallback(
@@ -108,20 +115,27 @@ export function ExecutionContainer({
       return;
     }
 
-    // Only estimate if transactions have changed
-    if (isEqual(prevTransactionsRef.current.transactions, transactions)) {
+    // Re-estimate when transactions change OR the controller (chain) changes.
+    if (
+      isEqual(prevTransactionsRef.current.transactions, transactions) &&
+      prevTransactionsRef.current.controller === controller
+    ) {
       return;
     }
 
     // Update ref with current values
-    prevTransactionsRef.current = { transactions, feeEstimate: maxFee };
+    prevTransactionsRef.current = {
+      transactions,
+      feeEstimate: maxFee,
+      controller,
+    };
 
     const estimateFeesAsync = async () => {
       await estimateFees(transactions);
     };
 
     estimateFeesAsync();
-  }, [transactions, estimateFees, maxFee]);
+  }, [transactions, estimateFees, maxFee, controller]);
 
   useEffect(() => {
     setCtrlError(executionError);

--- a/packages/keychain/src/components/simulation/use-simulate.ts
+++ b/packages/keychain/src/components/simulation/use-simulate.ts
@@ -55,7 +55,20 @@ export const useSimulateBalanceChanges = (
           setSimulationEvents(events);
           setIsError(false);
         })
-        .catch((error) => {
+        .catch(async (error) => {
+          // The preview simulates a tx FROM the controller. If the controller
+          // isn't deployed on this chain yet — it deploys on first execute, e.g.
+          // on an appchain — its sender account doesn't exist and the sim rejects
+          // with "Contract not found". That's a transient not-yet-deployed state,
+          // not a real failure: skip the preview rather than show a misleading
+          // "Simulation Error" (the actual execute deploys the controller first).
+          try {
+            await controller!.provider.getClassHashAt(controller!.address());
+          } catch {
+            setSimulationEvents([]);
+            setIsError(false);
+            return;
+          }
           console.error("simulateTransactions error:", error);
           setIsError(true);
         })


### PR DESCRIPTION
Two independent fixes to the keychain's transaction-review flow. Both are generic —
they apply to any chain switch and any account that deploys lazily — not specific to
a particular app.

## 1. Re-estimate fees when the connected chain changes (`ExecutionContainer`)

The fee-estimate effect was guarded only on `transactions`, so when the connected
chain changes without the calls changing it did not re-estimate. On a chain switch a
new `Controller` (bound to the new RPC) is created and the connection context updates
a render later, so the review screen kept a **stale fee error from the previous
chain** — e.g. "Contract not found" for a contract that exists on the new chain but
not the old one.

Fix: track the controller in the re-estimate guard and add it to the effect deps, so
the estimate always reflects the currently-selected chain.

## 2. Skip balance-change simulation when the account isn't deployed (`use-simulate`)

The balance-change preview simulates a transaction **from the controller account**.
For accounts that deploy **lazily on first execution**, the account may not exist on
the target chain yet at review time, so starknet.js rejects the simulation with
"Contract not found" (it cannot fetch the sender's class). The preview then renders a
red **"Simulation Error"** even though the real execution — which deploys the account
first — would succeed.

Fix: when the simulation fails, check whether the account is deployed; if it is not,
skip the preview instead of surfacing a misleading error. Genuine reverts (deployed
sender) still surface as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
