### PR TITLE
fix(keychain): don't revert in-session `switchStarknetChain`

### DIFF
--- a/packages/keychain/src/hooks/connection.test.ts
+++ b/packages/keychain/src/hooks/connection.test.ts
@@ -549,6 +549,54 @@ describe("URL rpc_url priority over stored controller rpcUrl", () => {
       expect(shouldDisconnect).toBe(false);
     });
 
+    it("should NOT disconnect on an in-session switchStarknetChain once the initial controller reconciled", () => {
+      // Models the reconcile-once guard: only the INITIAL controller is reconciled
+      // against the URL's rpc_url; a later in-session switch must stick.
+      const urlRpcUrl = "https://rpc.sepolia.example.com"; // the iframe default chain
+      let reconciled = false;
+
+      const reconcile = (controllerRpcUrl: string): boolean => {
+        if (controllerRpcUrl === urlRpcUrl) {
+          reconciled = true;
+          return false; // matches -> no disconnect
+        }
+        if (reconciled) return false; // already reconciled -> don't revert the switch
+        reconciled = true;
+        return true; // initial mismatch -> disconnect/reauth
+      };
+
+      // 1. initial controller is on the URL's chain -> matches -> marks reconciled.
+      expect(reconcile(urlRpcUrl)).toBe(false);
+      expect(reconciled).toBe(true);
+
+      // 2. dapp switchStarknetChain -> controller on a DIFFERENT, configured chain.
+      const switchedRpcUrl = "https://api.cartridge.gg/x/my-appchain";
+      expect(switchedRpcUrl).not.toBe(urlRpcUrl);
+      // Must NOT disconnect, otherwise the switch is silently reverted.
+      expect(reconcile(switchedRpcUrl)).toBe(false);
+    });
+
+    it("should still disconnect when the INITIAL controller is on a different chain than the URL", () => {
+      // Reconcile-once still handles the original case: a persisted controller loaded
+      // on the wrong chain at start triggers re-auth on the URL's chain.
+      const urlRpcUrl = "https://api.cartridge.gg/x/starknet/mainnet";
+      let reconciled = false;
+
+      const reconcile = (controllerRpcUrl: string): boolean => {
+        if (controllerRpcUrl === urlRpcUrl) {
+          reconciled = true;
+          return false;
+        }
+        if (reconciled) return false;
+        reconciled = true;
+        return true;
+      };
+
+      const persistedRpcUrl = "https://rpc.sepolia.example.com";
+      expect(persistedRpcUrl).not.toBe(urlRpcUrl);
+      expect(reconcile(persistedRpcUrl)).toBe(true); // initial mismatch -> disconnect
+    });
+
     it("should NOT disconnect controller when controller is not set", () => {
       const controller = undefined;
       const urlRpcUrl = "https://api.cartridge.gg/x/starknet/mainnet";

--- a/packages/keychain/src/hooks/connection.ts
+++ b/packages/keychain/src/hooks/connection.ts
@@ -460,9 +460,22 @@ export function useConnectionValue() {
   // When URL provides an rpc_url that differs from the controller's, log the user
   // out so they re-authenticate on the correct chain. The account may not be deployed
   // on the target chain, so we can't simply recreate the controller.
+  //
+  // Only reconcile the INITIAL controller (e.g. a persisted controller loaded on a
+  // different chain than the URL asks for). An in-session `switchStarknetChain`
+  // legitimately moves the controller to another *configured* chain — a multichain
+  // dapp switches between chains per call — and reverting it here would pin every call
+  // back to the URL's chain, silently defeating the switch. Once we've seen a
+  // controller whose rpcUrl matches the URL, stop reconciling so switches stick.
+  const urlRpcReconciledRef = useRef(false);
   useEffect(() => {
     if (!controller || !urlRpcUrl) return;
-    if (controller.rpcUrl() === urlRpcUrl) return;
+    if (controller.rpcUrl() === urlRpcUrl) {
+      urlRpcReconciledRef.current = true;
+      return;
+    }
+    if (urlRpcReconciledRef.current) return;
+    urlRpcReconciledRef.current = true;
 
     setRpcUrl(urlRpcUrl);
 


### PR DESCRIPTION
## Problem

Fixes #2611.

The keychain's rpc_url/controller reconciliation effect in `connection.ts` **reverts an in-session `switchStarknetChain`**, which breaks multichain dapps. The iframe is loaded with `?rpc_url=<defaultChain>`, so after the dapp switches the controller to a second configured chain, this effect sees `controller.rpcUrl() !== urlRpcUrl` and disconnects / pins it back to the URL's chain. Every subsequent `execute` then runs on the default chain instead of the switched one.

```ts
// before — runs on EVERY controller change, including an in-session switch
useEffect(() => {
  if (!controller || !urlRpcUrl) return;
  if (controller.rpcUrl() === urlRpcUrl) return;
  setRpcUrl(urlRpcUrl);
  (async () => { await controller.disconnect(); setController(undefined); })();
}, [controller, urlRpcUrl, setController, setRpcUrl]);
```

`switchChain.ts` legitimately rebuilds `window.controller` on the new chain and calls `setController(next)`, which re-fires this effect and reverts the switch.

## Fix

Only reconcile the **initial** controller (e.g. a persisted controller loaded on a different chain than the URL asks for). Once we've seen a controller whose `rpcUrl` matches the URL, stop reconciling so an intentional in-session switch sticks. The original re-auth behavior for a wrong-chain controller at load is preserved.

## Tests

Extended `connection.test.ts` ("Controller disconnect on chain mismatch"):
- an in-session switch after the initial controller reconciled → **does not** disconnect (the regression);
- an initial controller on a different chain than the URL → still disconnects (unchanged).

## Context

Hit while building a demo where one Controller signs a settlement chain (Sepolia) and a local appchain. Appchain txs silently executed on the settlement chain and reverted with "contract not deployed". Repro + details in #2611.
