### PR TITLE
fix: re-connect black screen

### DIFF
--- a/examples/next/src/components/providers/StarknetProvider.tsx
+++ b/examples/next/src/components/providers/StarknetProvider.tsx
@@ -246,6 +246,11 @@ export const presets = {
     namespace: "pistols",
     preset: "pistols",
   },
+  cagecalls: {
+    // slot: "cagecalls-mainnet",
+    // namespace: "cagecalls",
+    preset: "cage-calls",
+  },
 };
 
 export const controllerConnector = new ControllerConnector({

--- a/packages/keychain/src/utils/api/generated.ts
+++ b/packages/keychain/src/utils/api/generated.ts
@@ -220,10 +220,8 @@ export type AccountUpdateInput = {
 export type AccountVerifyInput = {
   /** Date of birth in YYYY-MM-DD format. */
   dob?: InputMaybe<Scalars["String"]>;
-  emailAddress?: InputMaybe<Scalars["String"]>;
   firstName?: InputMaybe<Scalars["String"]>;
   lastName?: InputMaybe<Scalars["String"]>;
-  phoneNumber?: InputMaybe<Scalars["String"]>;
   /** Use the UAT sandbox environment instead of production. */
   sandbox?: InputMaybe<Scalars["Boolean"]>;
 };
@@ -2376,6 +2374,7 @@ export type Erc1155Metadata = {
 export type Eip191Credential = {
   __typename?: "Eip191Credential";
   ethAddress: Scalars["String"];
+  phoneLast4?: Maybe<Scalars["String"]>;
   provider: Scalars["String"];
 };
 
@@ -3183,7 +3182,10 @@ export type Mutation = {
   createTeam: Team;
   decreaseBudget: Paymaster;
   deleteDeployment: Scalars["Boolean"];
+  deleteEmailAddress: Scalars["Boolean"];
   deleteMe: Scalars["Boolean"];
+  deletePhoneNumber: Scalars["Boolean"];
+  deleteProveIdentity: Scalars["Boolean"];
   deleteRpcApiKey: Scalars["Boolean"];
   deleteRpcCorsDomain: Scalars["Boolean"];
   deleteTeam: Scalars["Boolean"];

--- a/packages/keychain/src/utils/connection/callbacks.test.ts
+++ b/packages/keychain/src/utils/connection/callbacks.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach } from "vitest";
+import { describe, expect, it, beforeEach, vi } from "vitest";
 import {
   storeCallbacks,
   getCallbacks,
@@ -14,19 +14,69 @@ describe("callbacks", () => {
   });
 
   describe("generateCallbackId", () => {
-    it("should generate incremental IDs", () => {
-      const id1 = generateCallbackId();
-      const id2 = generateCallbackId();
-      const id3 = generateCallbackId();
-
-      expect(parseInt(id1)).toBeLessThan(parseInt(id2));
-      expect(parseInt(id2)).toBeLessThan(parseInt(id3));
-    });
-
-    it("should generate string IDs", () => {
+    it("should generate non-empty string IDs", () => {
       const id = generateCallbackId();
       expect(typeof id).toBe("string");
-      expect(id).toMatch(/^\d+$/);
+      expect(id.length).toBeGreaterThan(0);
+    });
+
+    it("should generate unique IDs", () => {
+      const ids = new Set<string>();
+      for (let i = 0; i < 1000; i++) {
+        ids.add(generateCallbackId());
+      }
+      // Every generated id must be distinct.
+      expect(ids.size).toBe(1000);
+    });
+
+    // Regression guard for the connect bug: callback ids are stored in the
+    // keychain `window`, which reloads on disconnect/logout. A plain counter
+    // reset back to "1" on reload, so a subsequent connect reused an old id,
+    // navigated to the same `/connect?id=1` URL, and the stale callback state
+    // left the parent's `keychain.connect()` unresolved. Ids must stay unique
+    // even when the counter base is wiped (i.e. across an iframe reload).
+    it("should not reuse IDs after the id counter is reset (iframe reload)", () => {
+      const before = generateCallbackId();
+
+      // Simulate the iframe reload clearing the counter on `window`.
+      delete (
+        window as typeof window & {
+          __cartridge_controller_callback_counter?: number;
+        }
+      ).__cartridge_controller_callback_counter;
+
+      const after = generateCallbackId();
+      expect(after).not.toBe(before);
+    });
+
+    // Same guarantee on the fallback path used when crypto.randomUUID is
+    // unavailable: the counter+random suffix must stay unique even when the
+    // counter base resets (as it does on iframe reload).
+    it("stays unique on the fallback path when crypto.randomUUID is unavailable", () => {
+      vi.stubGlobal("crypto", {});
+      try {
+        const before = generateCallbackId();
+
+        // Simulate the iframe reload clearing the counter on `window`.
+        delete (
+          window as typeof window & {
+            __cartridge_controller_callback_counter?: number;
+          }
+        ).__cartridge_controller_callback_counter;
+
+        const after = generateCallbackId();
+        // Confirms the fallback branch ran (counter+suffix, not a UUID).
+        expect(before).toMatch(/^\d+-[a-z0-9]+$/);
+        expect(after).not.toBe(before);
+
+        const ids = new Set<string>([before, after]);
+        for (let i = 0; i < 100; i++) {
+          ids.add(generateCallbackId());
+        }
+        expect(ids.size).toBe(102);
+      } finally {
+        vi.unstubAllGlobals();
+      }
     });
   });
 

--- a/packages/keychain/src/utils/connection/callbacks.ts
+++ b/packages/keychain/src/utils/connection/callbacks.ts
@@ -42,14 +42,32 @@ export function cleanupCallbacks(id: string) {
 }
 
 export function generateCallbackId(): string {
+  // Callback ids MUST be globally unique and never reused. The keychain iframe
+  // is persistent and can reload (disconnect/logout), which would reset a plain
+  // counter back to "1" and cause collisions: a new connect would navigate to
+  // the same `/connect?id=1` URL, so `useSearchParams` wouldn't change and the
+  // connect UI would keep a stale `params` (whose `resolve` was already cleaned
+  // up) instead of picking up the freshly-stored callback — and would then
+  // delete the live callback via the reused id. Result: the parent's
+  // `keychain.connect()` never resolves. A UUID guarantees a distinct URL per
+  // connect, forcing a re-parse and preventing stale-id cleanup collisions.
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
+    return crypto.randomUUID();
+  }
+
+  // Fallback for environments without crypto.randomUUID: counter + random
+  // suffix so ids stay unique even if the counter base resets on reload.
   if (typeof window !== "undefined") {
     const globalWindow = window as typeof window & {
       [CALLBACK_COUNTER_KEY]?: number;
     };
     const next = (globalWindow[CALLBACK_COUNTER_KEY] ?? 0) + 1;
     globalWindow[CALLBACK_COUNTER_KEY] = next;
-    return `${next}`;
+    return `${next}-${Math.random().toString(36).slice(2, 10)}`;
   }
 
-  return `${++callbackIdCounter}`;
+  return `${++callbackIdCounter}-${Math.random().toString(36).slice(2, 10)}`;
 }

--- a/packages/ui/src/utils/api/cartridge/generated.ts
+++ b/packages/ui/src/utils/api/cartridge/generated.ts
@@ -215,10 +215,8 @@ export type AccountUpdateInput = {
 export type AccountVerifyInput = {
   /** Date of birth in YYYY-MM-DD format. */
   dob?: InputMaybe<Scalars['String']>;
-  emailAddress?: InputMaybe<Scalars['String']>;
   firstName?: InputMaybe<Scalars['String']>;
   lastName?: InputMaybe<Scalars['String']>;
-  phoneNumber?: InputMaybe<Scalars['String']>;
   /** Use the UAT sandbox environment instead of production. */
   sandbox?: InputMaybe<Scalars['Boolean']>;
 };
@@ -2369,6 +2367,7 @@ export type Erc1155Metadata = {
 export type Eip191Credential = {
   __typename?: 'Eip191Credential';
   ethAddress: Scalars['String'];
+  phoneLast4?: Maybe<Scalars['String']>;
   provider: Scalars['String'];
 };
 
@@ -3177,7 +3176,10 @@ export type Mutation = {
   createTeam: Team;
   decreaseBudget: Paymaster;
   deleteDeployment: Scalars['Boolean'];
+  deleteEmailAddress: Scalars['Boolean'];
   deleteMe: Scalars['Boolean'];
+  deletePhoneNumber: Scalars['Boolean'];
+  deleteProveIdentity: Scalars['Boolean'];
   deleteRpcApiKey: Scalars['Boolean'];
   deleteRpcCorsDomain: Scalars['Boolean'];
   deleteTeam: Scalars['Boolean'];


### PR DESCRIPTION
* fix black screen on re-connection

## Problem
Connecting intermittently left the dapp disconnected (CONNECT stayed enabled);
retrying eventually worked. The connect succeeded in the keychain but the
parent's `keychain.connect()` never resolved.

## Cause
Connect callback ids came from a counter on the keychain `window`. The keychain
iframe reloads on disconnect/logout, resetting that counter to `1`. Because the
parent page persists, a reused id produced the same `/connect?id=1` URL —
`useSearchParams` didn't change, the connect UI kept stale `params` whose
`resolve` was already cleaned up, and it then deleted the freshly-stored
callback by the reused id. Result: the parent promise hung.

## Fix
`generateCallbackId()` now returns `crypto.randomUUID()` (counter+random
fallback). Unique ids → a distinct URL per connect → params re-parse and the
live callback is always found; a stale cleanup can't hit a new connect.

## Tests
Updated callback tests to the correct contract (string + unique) and added
regression guards: no id reuse across a counter reset (iframe reload), incl. the
fallback path.
