### PR TITLE
ci: increase Claude review max turns

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -28,4 +28,4 @@ jobs:
           allowed_tools: "Read,Glob,Grep"
           # CLAUDE.md is a symlink to AGENTS.md in this repo; keep repo rules there.
           claude_args: |
-            --max-turns 4
+            --max-turns 20


### PR DESCRIPTION
## Summary
- increase Claude Code Review max turns from 4 to 20

## Testing
- not run; workflow-only config change