### PR TITLE
fix: google sign-in error, retry, load optimization

### DIFF
--- a/packages/keychain/src/components/connect/create/social/index.ts
+++ b/packages/keychain/src/components/connect/create/social/index.ts
@@ -14,6 +14,7 @@ export const useSocialAuthentication = (
       socialProvider: SocialProvider,
       username: string,
       isSignup: boolean,
+      forceAccountSelection = false,
     ) => {
       if (!chainId) {
         throw new Error("No chainId");
@@ -25,7 +26,10 @@ export const useSocialAuthentication = (
         rpcUrl,
         socialProvider,
       );
-      const { account, error, success } = await turnkeyWallet.connect(isSignup);
+      const { account, error, success } = await turnkeyWallet.connect(
+        isSignup,
+        forceAccountSelection,
+      );
       if (error?.includes("Account mismatch")) {
         setChangeWallet?.(true);
         return;
@@ -57,9 +61,15 @@ export const useSocialAuthentication = (
   );
 
   return {
-    signup: (socialProvider: SocialProvider, username: string) =>
-      signup(socialProvider, username, true),
-    login: (socialProvider: SocialProvider, username: string) =>
-      signup(socialProvider, username, false),
+    signup: (
+      socialProvider: SocialProvider,
+      username: string,
+      forceAccountSelection = false,
+    ) => signup(socialProvider, username, true, forceAccountSelection),
+    login: (
+      socialProvider: SocialProvider,
+      username: string,
+      forceAccountSelection = false,
+    ) => signup(socialProvider, username, false, forceAccountSelection),
   };
 };

--- a/packages/keychain/src/components/connect/create/useCreateController.ts
+++ b/packages/keychain/src/components/connect/create/useCreateController.ts
@@ -584,7 +584,11 @@ export function useCreateController({
         }
         case "google":
         case "discord":
-          signupResponse = await signupWithSocial(authenticationMode, username);
+          signupResponse = await signupWithSocial(
+            authenticationMode,
+            username,
+            changeWallet,
+          );
           if (!signupResponse) {
             return;
           }
@@ -699,6 +703,7 @@ export function useCreateController({
       params,
       handleCompletion,
       searchParams,
+      changeWallet,
     ],
   );
 
@@ -948,7 +953,11 @@ export function useCreateController({
         case "google":
         case "discord": {
           setWaitingForConfirmation(true);
-          loginResponse = await loginWithSocial(authenticationMethod, username);
+          loginResponse = await loginWithSocial(
+            authenticationMethod,
+            username,
+            changeWallet,
+          );
           if (!loginResponse) {
             return;
           }
@@ -1058,6 +1067,7 @@ export function useCreateController({
       smsAuth,
       smsState,
       setWaitingForConfirmation,
+      changeWallet,
     ],
   );
 

--- a/packages/keychain/src/components/connect/create/useCreateController.ts
+++ b/packages/keychain/src/components/connect/create/useCreateController.ts
@@ -267,6 +267,11 @@ export function useCreateController({
   >(undefined);
   const signupStartedRef = useRef(false);
   const signupResolvedRef = useRef(false);
+  // The OAuth (Auth0/Turnkey) redirect callback consumes a single-use
+  // transaction. Guard against StrictMode double-invocation and dependency-
+  // driven re-runs so handleRedirectCallback runs exactly once — otherwise the
+  // second call throws "Invalid state" and the page loops on the login screen.
+  const redirectHandledRef = useRef(false);
   const signupStartTimeRef = useRef(performance.now());
   const authStepRef = useRef<AuthenticationStep>(AuthenticationStep.FillForm);
 
@@ -1058,10 +1063,22 @@ export function useCreateController({
 
   useEffect(() => {
     if (!chainId) return;
+    if (redirectHandledRef.current) return;
     if (
       window.location.search.includes("code") &&
       window.location.search.includes("state")
     ) {
+      redirectHandledRef.current = true;
+      const redirectUrl = window.location.href;
+      // Strip the single-use OAuth params from the address bar immediately.
+      // handleRedirect() consumes them from the captured `redirectUrl`, so a
+      // reload (or a remount that resets the guard) can't replay the already-
+      // consumed callback and fail with "Invalid state" — and the user is left
+      // on a clean URL from which a fresh login can be initiated.
+      const cleanUrl = new URL(redirectUrl);
+      cleanUrl.searchParams.delete("code");
+      cleanUrl.searchParams.delete("state");
+      window.history.replaceState({}, "", cleanUrl.toString());
       (async () => {
         setIsLoading(true);
         try {
@@ -1080,14 +1097,8 @@ export function useCreateController({
             searchParams,
             chainId,
             rpcUrl,
-          } = await turnkeyWallet.handleRedirect(
-            window.location.href,
-            setError,
-          );
+          } = await turnkeyWallet.handleRedirect(redirectUrl, setError);
 
-          if (error) {
-            throw error;
-          }
           if (
             !username ||
             isSignup === undefined ||
@@ -1173,7 +1184,6 @@ export function useCreateController({
       })();
     }
   }, [
-    error,
     setIsLoading,
     finishLogin,
     finishSignup,

--- a/packages/keychain/src/components/inventory/collection/collectible-listing.tsx
+++ b/packages/keychain/src/components/inventory/collection/collectible-listing.tsx
@@ -26,7 +26,7 @@ import {
   STRK_CONTRACT_ADDRESS,
   USDC_CONTRACT_ADDRESS,
 } from "@cartridge/controller-ui/utils";
-import { useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
 import placeholder from "/placeholder.svg?url";
 import { ListHeader } from "./send/header";
@@ -34,7 +34,7 @@ import { useTokens } from "@/hooks/token";
 import { useConnection } from "@/hooks/connection";
 import { AllowArray, cairo, Call, CallData, FeeEstimate } from "starknet";
 import { useToast } from "@/context/toast";
-import { ArcadeContext } from "@/context/arcade";
+import { useArcadeContext } from "@/context/arcade";
 import { useEntrypoints } from "@/hooks/entrypoints";
 import { useNavigation } from "@/context/navigation";
 import { useCollection } from "@/hooks/collection";
@@ -64,8 +64,7 @@ const EXPIRATIONS = [
 ];
 
 export function CollectibleListing() {
-  const arcadeContext = useContext(ArcadeContext);
-  const provider = arcadeContext?.provider;
+  const { marketplaceAddress } = useArcadeContext();
   const { controller } = useConnection();
   const { goBack } = useNavigation();
   const { address: contractAddress, tokenId } = useParams();
@@ -192,13 +191,6 @@ export function CollectibleListing() {
     },
     [setSelected],
   );
-
-  // Memoize marketplace address
-  const marketplaceAddress = useMemo(() => {
-    return provider?.manifest.contracts.find((c: { tag: string }) =>
-      c.tag?.includes("Marketplace"),
-    )?.address;
-  }, [provider?.manifest.contracts]);
 
   // Build transactions when validation is complete
   const buildTransactions = useMemo(() => {

--- a/packages/keychain/src/components/inventory/collection/collectible-purchase.tsx
+++ b/packages/keychain/src/components/inventory/collection/collectible-purchase.tsx
@@ -19,7 +19,7 @@ import {
   FeeEstimate,
 } from "starknet";
 import { useConnection } from "@/hooks/connection";
-import { useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useToriiCollection, useToriiCollections } from "@/hooks/collection";
 import { useToast } from "@/context/toast";
 import { useTokens } from "@/hooks/token";
@@ -37,7 +37,7 @@ import {
   useMarketplaceRoyaltyFee,
 } from "@cartridge/arcade/marketplace/react";
 import { StatusType } from "@cartridge/arcade";
-import { ArcadeContext } from "@/context/arcade";
+import { useArcadeContext } from "@/context/arcade";
 import { usePurchaseFeesData } from "./footer";
 import { formatUsdValue } from "@/utils/format-value";
 
@@ -48,8 +48,7 @@ export function CollectiblePurchase() {
   const { tokens } = useTokens();
   const [royalties, setRoyalties] = useState<{ [orderId: number]: bigint }>({});
   const [amount, setAmount] = useState<number>(0);
-  const arcadeContext = useContext(ArcadeContext);
-  const provider = arcadeContext?.provider;
+  const { marketplaceAddress } = useArcadeContext();
   const { toast } = useToast();
 
   const { data: marketplaceFeeConfig } = useMarketplaceFees();
@@ -243,13 +242,6 @@ export function CollectiblePurchase() {
     },
     [setRoyalties],
   );
-
-  // Memoize marketplace address
-  const marketplaceAddress = useMemo(() => {
-    return provider?.manifest.contracts.find((c: { tag: string }) =>
-      c.tag?.includes("Marketplace"),
-    )?.address;
-  }, [provider?.manifest.contracts]);
 
   // Build transactions
   const buildTransactions = useMemo(() => {

--- a/packages/keychain/src/components/inventory/collection/collection-listing.tsx
+++ b/packages/keychain/src/components/inventory/collection/collection-listing.tsx
@@ -23,7 +23,7 @@ import {
   STRK_CONTRACT_ADDRESS,
   USDC_CONTRACT_ADDRESS,
 } from "@cartridge/controller-ui/utils";
-import { useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
 import { useCollection } from "@/hooks/collection";
 import placeholder from "/placeholder.svg?url";
@@ -31,7 +31,7 @@ import { ListHeader } from "./send/header";
 import { useTokens } from "@/hooks/token";
 import { AllowArray, cairo, Call, CallData, FeeEstimate } from "starknet";
 import { useToast } from "@/context/toast";
-import { ArcadeContext } from "@/context/arcade";
+import { useArcadeContext } from "@/context/arcade";
 import { useEntrypoints } from "@/hooks/entrypoints";
 import { useConnection } from "@/hooks/connection";
 import { useNavigation } from "@/context/navigation";
@@ -61,8 +61,7 @@ const EXPIRATIONS = [
 ];
 
 export function CollectionListing() {
-  const arcadeContext = useContext(ArcadeContext);
-  const provider = arcadeContext?.provider;
+  const { marketplaceAddress } = useArcadeContext();
   const { controller } = useConnection();
   const { goBack } = useNavigation();
   const { address: contractAddress, tokenId } = useParams();
@@ -171,13 +170,6 @@ export function CollectionListing() {
     },
     [setSelected],
   );
-
-  // Memoize marketplace address to prevent infinite useEffect loop
-  const marketplaceAddress = useMemo(() => {
-    return provider?.manifest.contracts.find((c: { tag: string }) =>
-      c.tag?.includes("Marketplace"),
-    )?.address;
-  }, [provider?.manifest.contracts]);
 
   // Build transactions when validation is complete
   const buildTransactions = useMemo(() => {

--- a/packages/keychain/src/components/inventory/collection/collection-purchase.tsx
+++ b/packages/keychain/src/components/inventory/collection/collection-purchase.tsx
@@ -19,7 +19,7 @@ import {
   FeeEstimate,
 } from "starknet";
 import { useConnection } from "@/hooks/connection";
-import { useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useToriiCollection } from "@/hooks/collection";
 import { useToast } from "@/context/toast";
 import { useTokens } from "@/hooks/token";
@@ -37,7 +37,7 @@ import {
   useMarketplaceRoyaltyFee,
 } from "@cartridge/arcade/marketplace/react";
 import { StatusType } from "@cartridge/arcade";
-import { ArcadeContext } from "@/context/arcade";
+import { useArcadeContext } from "@/context/arcade";
 import { usePurchaseFeesData } from "./footer";
 import { formatUsdValue } from "@/utils/format-value";
 
@@ -48,8 +48,7 @@ export function CollectionPurchase() {
   const { tokens } = useTokens();
   const [royalties, setRoyalties] = useState<{ [orderId: number]: bigint }>({});
   const [amount, setAmount] = useState<number>(0);
-  const arcadeContext = useContext(ArcadeContext);
-  const provider = arcadeContext?.provider;
+  const { marketplaceAddress } = useArcadeContext();
   const { toast } = useToast();
 
   const [searchParams] = useSearchParams();
@@ -230,13 +229,6 @@ export function CollectionPurchase() {
     },
     [setRoyalties],
   );
-
-  // Memoize marketplace address
-  const marketplaceAddress = useMemo(() => {
-    return provider?.manifest.contracts.find((c: { tag: string }) =>
-      c.tag?.includes("Marketplace"),
-    )?.address;
-  }, [provider?.manifest.contracts]);
 
   // Build transactions
   const buildTransactions = useMemo(() => {

--- a/packages/keychain/src/components/provider/arcade.tsx
+++ b/packages/keychain/src/components/provider/arcade.tsx
@@ -89,57 +89,123 @@ export const ArcadeProvider = ({ children }: { children: ReactNode }) => {
     [setOrders],
   );
 
+  // TODO: The real fix belongs upstream in the @cartridge/arcade fetcher.
+  // `Marketplace.fetch` fetches and parses ALL entities (~14k) in a single
+  // query and hands them to this callback in one call, so the network/decode/
+  // parse cost is already paid synchronously before we get here — the chunking
+  // below only spreads the React state-update half. Add cursor-based pagination
+  // (withLimit + withCursor) to the arcade fetcher so it streams pages to this
+  // callback; then this handler can drop the manual chunking entirely.
   const handleMarketplaceEntities = useCallback(
-    (entities: MarketplaceModel[]) => {
+    async (entities: MarketplaceModel[]) => {
       const now = Date.now();
-      entities.forEach((entity: MarketplaceModel) => {
-        if (BookModel.isType(entity as BookModel)) {
-          const book = entity as BookModel;
-          if (book.version === 0) return;
-          setBook(book);
-        } else if (OrderModel.isType(entity as OrderModel)) {
-          const order = entity as OrderModel;
-          if (order.expiration * 1000 < now) return;
-          if (order.category.value !== CategoryType.Sell) return;
-          if (order.status.value === StatusType.Placed) {
-            addOrder(order);
-          } else {
-            removeOrder(order);
+      const CHUNK_SIZE = 250;
+
+      // Process the batch in chunks, yielding to the browser between each so a
+      // large initial fetch doesn't lock up the main thread. Within a chunk we
+      // accumulate locally and flush a single state update per type, instead of
+      // one (full-object-spreading) setState per entity.
+      for (let i = 0; i < entities.length; i += CHUNK_SIZE) {
+        const chunk = entities.slice(i, i + CHUNK_SIZE);
+
+        let nextBook: BookModel | null = null;
+        const orderOps: { type: "add" | "remove"; order: OrderModel }[] = [];
+        const saleEvents: SaleEvent[] = [];
+        const listingEvents: ListingEvent[] = [];
+
+        for (const entity of chunk) {
+          if (BookModel.isType(entity as BookModel)) {
+            const book = entity as BookModel;
+            if (book.version === 0) continue;
+            nextBook = book;
+          } else if (OrderModel.isType(entity as OrderModel)) {
+            const order = entity as OrderModel;
+            if (order.expiration * 1000 < now) continue;
+            if (order.category.value !== CategoryType.Sell) continue;
+            orderOps.push({
+              type: order.status.value === StatusType.Placed ? "add" : "remove",
+              order,
+            });
+          } else if (SaleEvent.isType(entity as SaleEvent)) {
+            saleEvents.push(entity as SaleEvent);
+          } else if (ListingEvent.isType(entity as ListingEvent)) {
+            listingEvents.push(entity as ListingEvent);
           }
-        } else if (SaleEvent.isType(entity as SaleEvent)) {
-          const sale = entity as SaleEvent;
-          const order = sale.order;
-          const collection = getChecksumAddress(order.collection);
-          const token = order.tokenId.toString();
-          setSales((prev) => ({
-            ...prev,
-            [collection]: {
-              ...(prev[collection] || {}),
-              [token]: {
-                ...(prev[collection]?.[token] || {}),
-                [order.id]: sale,
-              },
-            },
-          }));
-        } else if (ListingEvent.isType(entity as ListingEvent)) {
-          const listing = entity as ListingEvent;
-          const order = listing.order;
-          const collection = getChecksumAddress(order.collection);
-          const token = order.tokenId.toString();
-          setListings((prev) => ({
-            ...prev,
-            [collection]: {
-              ...(prev[collection] || {}),
-              [token]: {
-                ...(prev[collection]?.[token] || {}),
-                [order.id]: listing,
-              },
-            },
-          }));
         }
-      });
+
+        if (nextBook) setBook(nextBook);
+
+        if (orderOps.length) {
+          setOrders((prev) => {
+            const next = { ...prev };
+            for (const { type, order } of orderOps) {
+              const collection = getChecksumAddress(order.collection);
+              const token = order.tokenId.toString();
+              if (type === "add") {
+                next[collection] = {
+                  ...(next[collection] || {}),
+                  [token]: {
+                    ...(next[collection]?.[token] || {}),
+                    [order.id]: order,
+                  },
+                };
+              } else if (next[collection]?.[token]?.[order.id]) {
+                next[collection] = {
+                  ...next[collection],
+                  [token]: { ...next[collection][token] },
+                };
+                delete next[collection][token][order.id];
+              }
+            }
+            return next;
+          });
+        }
+
+        if (saleEvents.length) {
+          setSales((prev) => {
+            const next = { ...prev };
+            for (const sale of saleEvents) {
+              const order = sale.order;
+              const collection = getChecksumAddress(order.collection);
+              const token = order.tokenId.toString();
+              next[collection] = {
+                ...(next[collection] || {}),
+                [token]: {
+                  ...(next[collection]?.[token] || {}),
+                  [order.id]: sale,
+                },
+              };
+            }
+            return next;
+          });
+        }
+
+        if (listingEvents.length) {
+          setListings((prev) => {
+            const next = { ...prev };
+            for (const listing of listingEvents) {
+              const order = listing.order;
+              const collection = getChecksumAddress(order.collection);
+              const token = order.tokenId.toString();
+              next[collection] = {
+                ...(next[collection] || {}),
+                [token]: {
+                  ...(next[collection]?.[token] || {}),
+                  [order.id]: listing,
+                },
+              };
+            }
+            return next;
+          });
+        }
+
+        // Yield to the event loop between chunks so the UI stays responsive.
+        if (i + CHUNK_SIZE < entities.length) {
+          await new Promise<void>((resolve) => setTimeout(resolve, 0));
+        }
+      }
     },
-    [addOrder, removeOrder, setBook, setListings, setSales],
+    [setBook, setOrders, setListings, setSales],
   );
 
   useEffect(() => {
@@ -166,6 +232,12 @@ export const ArcadeProvider = ({ children }: { children: ReactNode }) => {
     };
   }, [initialized, handleMarketplaceEntities]);
 
+  const marketplaceAddress = useMemo<string | undefined>(() => {
+    return provider?.manifest.contracts.find((c: { tag: string }) =>
+      c.tag?.includes("Marketplace"),
+    )?.address as string;
+  }, [provider?.manifest.contracts]);
+
   return (
     <ArcadeContext.Provider
       value={{
@@ -179,6 +251,7 @@ export const ArcadeProvider = ({ children }: { children: ReactNode }) => {
         removeOrder,
         initializable,
         setInitializable,
+        marketplaceAddress,
       }}
     >
       {children}

--- a/packages/keychain/src/context/arcade.ts
+++ b/packages/keychain/src/context/arcade.ts
@@ -5,7 +5,7 @@ import {
   OrderModel,
   SaleEvent,
 } from "@cartridge/arcade";
-import { createContext } from "react";
+import { createContext, useContext } from "react";
 
 /**
  * Interface defining the shape of the Arcade context.
@@ -30,9 +30,18 @@ interface ArcadeContextType {
   removeOrder: (order: OrderModel) => void;
   initializable: boolean;
   setInitializable: (initializable: boolean) => void;
+  marketplaceAddress: string | undefined;
 }
 
 /**
  * React context for sharing Arcade-related data throughout the application.
  */
 export const ArcadeContext = createContext<ArcadeContextType | null>(null);
+
+export const useArcadeContext = () => {
+  const context = useContext(ArcadeContext);
+  if (!context) {
+    throw new Error("useArcadeContext must be used within an ArcadeProvider");
+  }
+  return context;
+};

--- a/packages/keychain/src/hooks/marketplace.ts
+++ b/packages/keychain/src/hooks/marketplace.ts
@@ -1,5 +1,5 @@
-import { useCallback, useContext, useEffect, useMemo, useState } from "react";
-import { ArcadeContext } from "@/context/arcade";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useArcadeContext } from "@/context/arcade";
 import { useParams } from "react-router-dom";
 import { cairo, getChecksumAddress } from "starknet";
 import { OrderModel, StatusType } from "@cartridge/arcade";
@@ -21,14 +21,6 @@ const FEE_ENTRYPOINT = "royalty_info";
  * @throws {Error} If used outside of a MarketplaceProvider context
  */
 export const useMarketplace = () => {
-  const context = useContext(ArcadeContext);
-
-  if (!context) {
-    throw new Error(
-      "The `useMarketplace` hook must be used within a `MarketplaceProvider`",
-    );
-  }
-
   const account = useAccount();
   const address = account?.address || "";
   const { address: contractAddress, tokenId } = useParams();
@@ -43,7 +35,7 @@ export const useMarketplace = () => {
     sales,
     book,
     setInitializable,
-  } = context;
+  } = useArcadeContext();
   const [amount, setAmount] = useState<number>(0);
 
   useEffect(() => {

--- a/packages/keychain/src/wallets/social/turnkey.ts
+++ b/packages/keychain/src/wallets/social/turnkey.ts
@@ -109,7 +109,10 @@ export class TurnkeyWallet {
     };
   }
 
-  async connect(isSignup: boolean): Promise<ExternalWalletResponse> {
+  async connect(
+    isSignup: boolean,
+    forceAccountSelection = false,
+  ): Promise<ExternalWalletResponse> {
     try {
       if (!this.socialProvider) {
         throw new Error("Social provider not set");
@@ -127,8 +130,19 @@ export class TurnkeyWallet {
 
       const auth0Client = await this.getAuth0Client(10_000);
 
+      if (forceAccountSelection) {
+        // Drop any cached Auth0 session so the upstream provider shows its
+        // account chooser and the previously selected account isn't silently
+        // reused (e.g. after a "Wrong Signer" mismatch).
+        await auth0Client.logout({ openUrl: false });
+      }
+
       // For login flows, try to use cached Auth0 session if available
-      if (!isSignup && (await auth0Client.isAuthenticated())) {
+      if (
+        !isSignup &&
+        !forceAccountSelection &&
+        (await auth0Client.isAuthenticated())
+      ) {
         const tokenClaims = await auth0Client.getIdTokenClaims();
         const cachedNonce = tokenClaims?.tknonce as string | undefined;
 
@@ -192,6 +206,7 @@ export class TurnkeyWallet {
             redirect_uri: redirectUri,
             nonce,
             tknonce: nonce,
+            ...(forceAccountSelection ? { prompt: "select_account" } : {}),
           },
           appState: {
             nonce,
@@ -235,6 +250,7 @@ export class TurnkeyWallet {
             nonce,
             display: "touch",
             tknonce: nonce,
+            ...(forceAccountSelection ? { prompt: "select_account" } : {}),
           },
         },
         { popup },


### PR DESCRIPTION
- **Fix `Invalid state` infinite loop on Google/Discord sign-in via SessionConnector:** The OAuth redirect-callback effect in `useCreateController.ts` had no idempotency guard and kept `error` in its deps, so any re-entry (StrictMode double-invoke or a dependency change) replayed Auth0's single-use `handleRedirectCallback`, threw `Invalid state`, set the error, and re-ran — looping forever. Added a one-shot guard, strip `code`/`state` from the URL immediately after capturing it, and removed the dead `if (error) throw error` check plus the `error` dependency.

- **Let users pick a different account after a "Wrong Signer" mismatch:** Picking a Google/Discord account whose signer isn't registered showed "Wrong Signer" but silently reused the cached SSO session on retry, forcing a manual cookie clear. Threaded the existing `changeWallet` state down to `TurnkeyWallet.connect`, which now clears the cached Auth0 session and sends `prompt: "select_account"` so the account chooser reappears — only on retry, leaving the first-login UX untouched.

- **Optimized marketplace entity processing to keep the UI responsive on large fetches.** `Marketplace.fetch` returns the entire marketplace dataset (~14k entities) in a single callback, and `handleMarketplaceEntities` previously called `setState` once per entity — each call spreading the whole accumulated object (O(N²) work) and triggering a separate re-render — which froze the main thread on load. The handler now processes entities in chunks of 250, accumulates locally and flushes a **single batched state update per type** (orders/sales/listings) per chunk, and yields to the browser (`setTimeout(0)`) between chunks so input and paint can run. Also removed leftover `console.warn` debug lines. Added a `TODO` noting the real fix belongs upstream: adding cursor-based pagination to the `@cartridge/arcade` fetcher so it streams pages instead of parsing all 14k entities synchronously before the callback runs — at which point the manual chunking can be dropped.
