### PR TITLE
keychain: support starterpack purchase on chains without a price source

### DIFF
--- a/packages/keychain/src/components/provider/tokens.tsx
+++ b/packages/keychain/src/components/provider/tokens.tsx
@@ -18,6 +18,7 @@ import { useQuery } from "react-query";
 import { getChecksumAddress } from "starknet";
 import {
   fetchSwapQuoteInUsdc,
+  isQuoteChain,
   type ExtendedError,
   USDC_ADDRESSES,
   USDCE_ADDRESSES,
@@ -260,6 +261,13 @@ export function TokensProvider({
                   decimals: USDC_DECIMALS,
                   quote: "USDC",
                 };
+              }
+
+              // No USDC market on this chain (e.g. Katana): there is no USD
+              // price to fetch and fetchSwapQuoteInUsdc would just throw, so
+              // skip the Ekubo call and report no price for this token.
+              if (!isQuoteChain(chainId)) {
+                return null;
               }
 
               // Fetch quote from Ekubo: how many token base units = 1 USDC

--- a/packages/keychain/src/context/starterpack/onchain-purchase.tsx
+++ b/packages/keychain/src/context/starterpack/onchain-purchase.tsx
@@ -17,6 +17,7 @@ import { getCurrentReferral } from "@/utils/referral";
 import {
   prepareSwapCalls,
   fetchSwapQuote,
+  isQuoteChain,
   type SwapQuote,
 } from "@/utils/ekubo";
 import { Item } from "./types";
@@ -538,7 +539,11 @@ export const OnchainPurchaseProvider = ({
           ? selectedWallet.type
           : "controller";
 
+      // A swap goes through Ekubo (quote API + on-chain router), so it can only
+      // run on chains with a price source. Elsewhere (e.g. Katana) the bundle
+      // settles directly in its payment token — no swap, no Ekubo.
       const needsSwap =
+        isQuoteChain(controller.chainId()) &&
         selectedToken &&
         num.toHex(selectedToken.address) !== num.toHex(quote.paymentToken);
 

--- a/packages/keychain/src/hooks/starterpack/onchain.ts
+++ b/packages/keychain/src/hooks/starterpack/onchain.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState, useMemo } from "react";
 import { useController } from "@/hooks/controller";
 import { useConnection } from "@/hooks/connection";
 import { CairoByteArray, Call, getChecksumAddress, uint256 } from "starknet";
-import { fetchSwapQuote, USDC_ADDRESSES } from "@/utils/ekubo";
+import { fetchSwapQuote, USDC_ADDRESSES, isQuoteChain } from "@/utils/ekubo";
 import { getCurrentReferral } from "@/utils/referral";
 import { Quote } from "@/context";
 import {
@@ -227,10 +227,14 @@ export const useOnchainStarterpack = ({
           paymentTokenMetadata,
         };
 
-        // Convert price to target token if specified and different from payment token
+        // Convert price to target token if specified and different from payment
+        // token. Only attempt this on chains with a swap/price source (Ekubo
+        // liquidity); chains without one (e.g. a Katana dev chain) settle in the
+        // bundle's on-chain payment_token directly, so skip the conversion.
         const chainId = controller.chainId();
         const targetTokenAddress = targetToken || USDC_ADDRESSES[chainId];
         if (
+          isQuoteChain(chainId) &&
           targetTokenAddress &&
           paymentToken.toLowerCase() !== targetTokenAddress.toLowerCase() &&
           totalCost > 0n
@@ -265,9 +269,12 @@ export const useOnchainStarterpack = ({
 
         setQuote(quote);
       } catch (error) {
+        // A quote failure must NOT block the starterpack: metadata-driven
+        // rendering already populates the details, and a bundle can still be
+        // settled directly in its on-chain payment_token (e.g. on chains with
+        // no swap/fiat quote source). Surface for debugging only — do not set
+        // the blocking error state, matching the intent below.
         console.error("Failed to fetch quote:", error);
-        // Don't set error state for quote failures to allow metadata to still be shown
-        setError(new Error("Failed to fetch quote"));
       } finally {
         setIsQuoteLoading(false);
       }

--- a/packages/keychain/src/hooks/starterpack/token-fallback.ts
+++ b/packages/keychain/src/hooks/starterpack/token-fallback.ts
@@ -1,6 +1,11 @@
 import { useState, useEffect, useRef } from "react";
 import { num, uint256 } from "starknet";
-import { fetchSwapQuote, USDC_ADDRESSES, USDCE_ADDRESSES } from "@/utils/ekubo";
+import {
+  fetchSwapQuote,
+  USDC_ADDRESSES,
+  USDCE_ADDRESSES,
+  isQuoteChain,
+} from "@/utils/ekubo";
 import { isOnchainStarterpack } from "@/context/starterpack/types";
 import type { OnchainStarterpackDetails } from "@/context/starterpack/types";
 import type { TokenOption } from "./token-selection";
@@ -144,6 +149,11 @@ export function useTokenFallback({
             ) {
               // Same token or USDC ↔ USDC.e (1:1 pegged); no Ekubo quote needed.
               requiredAmount = totalCost;
+            } else if (!isQuoteChain(chainId)) {
+              // No swap/price source on this chain (e.g. Katana): a non-payment
+              // candidate can't be priced or swapped to, so it can't be a
+              // fallback. Skip it rather than calling Ekubo.
+              continue;
             } else {
               const swapResult = await fetchSwapQuote(
                 totalCost,

--- a/packages/keychain/src/hooks/starterpack/token-selection.ts
+++ b/packages/keychain/src/hooks/starterpack/token-selection.ts
@@ -420,6 +420,16 @@ export function useTokenSelection({
       return;
     }
 
+    // No swap/price source on this chain (e.g. Katana): a non-payment token
+    // can't be converted, so don't call Ekubo. availableTokens already restricts
+    // the choice to the payment token here, so this is a belt-and-suspenders bail.
+    if (!isQuoteChain(controller.chainId())) {
+      setConvertedPrice(null);
+      setSwapQuote(null);
+      setIsFetchingConversion(false);
+      return;
+    }
+
     // 2. Otherwise, fetch from Ekubo (if not already valid)
     if (
       convertedPrice &&

--- a/packages/keychain/src/hooks/starterpack/token-selection.ts
+++ b/packages/keychain/src/hooks/starterpack/token-selection.ts
@@ -1,10 +1,7 @@
 import { useState, useCallback, useEffect, useMemo } from "react";
 import { erc20Metadata, ExternalPlatform } from "@cartridge/controller";
-import { num, getChecksumAddress, constants } from "starknet";
-import {
-  ERC20Contract,
-  USDC_CONTRACT_ADDRESS,
-} from "@cartridge/controller-ui/utils";
+import { num, getChecksumAddress } from "starknet";
+import { ERC20Contract } from "@cartridge/controller-ui/utils";
 import {
   DEFAULT_TOKENS,
   type ERC20Metadata,
@@ -175,31 +172,34 @@ export function useTokenSelection({
   const availableTokens = useMemo(() => {
     if (!controller) return [];
 
-    // Start with default tokens (ETH, STRK, USDC, USDC.e)
-    const usdcAddress =
-      USDC_ADDRESSES[controller.chainId()] ||
-      USDC_ADDRESSES[constants.StarknetChainId.SN_MAIN];
+    // Start with default tokens (ETH, STRK). Add the stablecoins only on
+    // chains that actually have them — falling back to a mainnet USDC address
+    // on a chain without one (e.g. a Katana dev chain) would offer a token the
+    // user can never hold or swap to, breaking the purchase. On such chains the
+    // bundle's on-chain payment_token (added below) is the payable option.
+    const usdcAddress = USDC_ADDRESSES[controller.chainId()];
+    const usdceAddress = USDCE_ADDRESSES[controller.chainId()];
 
-    const usdceAddress =
-      USDCE_ADDRESSES[controller.chainId()] || USDC_CONTRACT_ADDRESS;
-
-    const tokens: ERC20Metadata[] = [
-      {
+    const tokens: ERC20Metadata[] = [];
+    if (usdcAddress) {
+      tokens.push({
         address: usdcAddress,
         name: "USD Coin",
         symbol: "USDC",
         decimals: 6,
         icon: "https://static.cartridge.gg/tokens/usdc.svg",
-      },
-      {
+      });
+    }
+    if (usdceAddress) {
+      tokens.push({
         address: usdceAddress,
         name: "Bridged USDC",
         symbol: "USDC.e",
         decimals: 6,
         icon: "https://static.cartridge.gg/tokens/usdc.svg",
-      },
-      ...DEFAULT_TOKENS,
-    ];
+      });
+    }
+    tokens.push(...DEFAULT_TOKENS);
 
     const isIncluded = (address: string) =>
       tokens.some(

--- a/packages/keychain/src/hooks/starterpack/token-selection.ts
+++ b/packages/keychain/src/hooks/starterpack/token-selection.ts
@@ -10,6 +10,7 @@ import {
   fetchSwapQuote,
   USDC_ADDRESSES,
   USDCE_ADDRESSES,
+  isQuoteChain,
   type SwapQuote,
 } from "@/utils/ekubo";
 import {
@@ -172,49 +173,55 @@ export function useTokenSelection({
   const availableTokens = useMemo(() => {
     if (!controller) return [];
 
-    // Start with default tokens (ETH, STRK). Add the stablecoins only on
-    // chains that actually have them — falling back to a mainnet USDC address
-    // on a chain without one (e.g. a Katana dev chain) would offer a token the
-    // user can never hold or swap to, breaking the purchase. On such chains the
-    // bundle's on-chain payment_token (added below) is the payable option.
-    const usdcAddress = USDC_ADDRESSES[controller.chainId()];
-    const usdceAddress = USDCE_ADDRESSES[controller.chainId()];
+    // On chains WITH a swap/price source (Ekubo liquidity), offer the usual set
+    // — the stablecoins where they exist, plus ETH/STRK — since the keychain can
+    // swap any of them to the bundle's payment token. On chains WITHOUT one
+    // (e.g. a Katana dev chain), a swap can never execute, so only the bundle's
+    // own payment_token (added below) is payable; offering ETH/USDC/etc. there
+    // would just dead-end at purchase. Note a mainnet-USDC fallback is avoided.
+    const hasQuoteSource = isQuoteChain(controller.chainId());
 
     const tokens: ERC20Metadata[] = [];
-    if (usdcAddress) {
-      tokens.push({
-        address: usdcAddress,
-        name: "USD Coin",
-        symbol: "USDC",
-        decimals: 6,
-        icon: "https://static.cartridge.gg/tokens/usdc.svg",
-      });
+    if (hasQuoteSource) {
+      const usdcAddress = USDC_ADDRESSES[controller.chainId()];
+      const usdceAddress = USDCE_ADDRESSES[controller.chainId()];
+      if (usdcAddress) {
+        tokens.push({
+          address: usdcAddress,
+          name: "USD Coin",
+          symbol: "USDC",
+          decimals: 6,
+          icon: "https://static.cartridge.gg/tokens/usdc.svg",
+        });
+      }
+      if (usdceAddress) {
+        tokens.push({
+          address: usdceAddress,
+          name: "Bridged USDC",
+          symbol: "USDC.e",
+          decimals: 6,
+          icon: "https://static.cartridge.gg/tokens/usdc.svg",
+        });
+      }
+      tokens.push(...DEFAULT_TOKENS);
     }
-    if (usdceAddress) {
-      tokens.push({
-        address: usdceAddress,
-        name: "Bridged USDC",
-        symbol: "USDC.e",
-        decimals: 6,
-        icon: "https://static.cartridge.gg/tokens/usdc.svg",
-      });
-    }
-    tokens.push(...DEFAULT_TOKENS);
 
     const isIncluded = (address: string) =>
       tokens.some(
         (t) => getChecksumAddress(t.address) === getChecksumAddress(address),
       );
 
-    // Add additional payment tokens from starterpack metadata
-    if (starterpackDetails?.additionalPaymentTokens?.length) {
+    // Add additional payment tokens from starterpack metadata. These need a
+    // swap to the payment token, so only offer them where swaps work.
+    if (hasQuoteSource && starterpackDetails?.additionalPaymentTokens?.length) {
       for (const address of starterpackDetails.additionalPaymentTokens) {
         if (!isIncluded(address)) {
           tokens.push(buildTokenMetadata(address));
         }
       }
     }
-    // Or add quote's payment token if no additional tokens specified
+    // Otherwise offer the bundle's on-chain payment token — the only entry on
+    // no-quote chains, and the no-swap default elsewhere.
     else if (
       starterpackDetails &&
       isOnchainStarterpack(starterpackDetails) &&

--- a/packages/keychain/src/utils/ekubo/index.ts
+++ b/packages/keychain/src/utils/ekubo/index.ts
@@ -47,6 +47,19 @@ export const USDCE_ADDRESSES: Record<string, string> = {
 };
 
 /**
+ * Whether the chain has a stablecoin price source (a known USDC market with
+ * Ekubo liquidity) that fiat/USD quoting and token swaps can rely on.
+ *
+ * Chains without one — e.g. a local/Slot Katana dev chain — cannot produce a
+ * swap or fiat quote. Callers should skip the Ekubo/USD conversion path on
+ * these and settle the starterpack directly in the bundle's on-chain
+ * payment_token instead of hard-failing with "Failed to fetch quote".
+ */
+export function isQuoteChain(chainId: string): boolean {
+  return !!USDC_ADDRESSES[chainId];
+}
+
+/**
  * Slippage buffer percentage for swap amounts
  */
 const SLIPPAGE_PERCENTAGE = 5n;


### PR DESCRIPTION
## Problem

On chains with no USDC market / Ekubo liquidity (e.g. a local or Slot **Katana** dev chain), **paid** starterpack bundles fail with `Failed to fetch quote` → "Unable to load starterpack". The purchase flow assumes a stablecoin price source for USD/swap quoting, which doesn't exist on these chains. Free bundles (price 0) work, since they skip the quote machinery.

## Changes

- **`utils/ekubo`**: add `isQuoteChain(chainId)` — `true` only when the chain has a known USDC market (i.e. an entry in `USDC_ADDRESSES`).
- **`hooks/starterpack/onchain.ts`**: gate the Ekubo price conversion on `isQuoteChain`, and make a quote-fetch failure **non-blocking**. The `catch` was calling `setError(...)` despite its own comment ("Don't set error state for quote failures to allow metadata to still be shown") — now it only logs, so metadata-driven rendering and direct `payment_token` settlement still proceed.
- **`hooks/starterpack/token-selection.ts`**: stop offering USDC/USDC.e via a mainnet-address fallback on chains that lack them (the user could never hold or swap to that token). The bundle's on-chain `payment_token` becomes the default payable option, so no swap is attempted.

## Result

Paid bundles on chains without a price source settle directly in their on-chain `payment_token` instead of dying on quote/swap machinery.

## Testing

- eslint + prettier clean on the three changed files.
- Repro context: a Slot Katana world (`WP_PUTTFALL_KATANA`) with a bundle priced in STRK; previously surfaced `Failed to fetch quote`.

## Scope / follow-up

This addresses the quote/swap fragility only. The "Unable to load starterpack" screen renders when `!details`, and `details` is populated as soon as **metadata** loads (the quote is optional). If the keychain's provider isn't pointed at the target chain's RPC in the purchase/deep-link context, metadata itself won't load — that's a separate RPC-routing issue not covered here.