### PR TITLE
fix(keychain): verify origin in popup auth (/auth) flow

### DIFF
--- a/packages/keychain/src/hooks/connection.test.ts
+++ b/packages/keychain/src/hooks/connection.test.ts
@@ -1,10 +1,10 @@
 import {
   getStandaloneAppOrigin,
   getStandaloneRedirectUrl,
-  getStandaloneVerificationOrigin,
   isNestedIframe,
   isOriginVerified,
   resolvePolicies,
+  verifyStandaloneOrigin,
 } from "./connection";
 import { vi } from "vitest";
 
@@ -119,58 +119,54 @@ describe("getStandaloneRedirectUrl", () => {
   });
 });
 
-describe("getStandaloneVerificationOrigin", () => {
-  it("prefers the explicit origin param (popup auth flow)", () => {
-    const searchParams = new URLSearchParams({
-      origin: encodeURIComponent("https://www.deathmountain.gg"),
-      redirect_url: "https://example.com/callback",
-    });
+describe("verifyStandaloneOrigin", () => {
+  const allowed = ["*.deathmountain.gg", "deathmountain.gg"];
 
-    expect(getStandaloneVerificationOrigin(searchParams)).toBe(
-      "https://www.deathmountain.gg",
-    );
-  });
-
-  it("falls back to the redirect target when no origin param is present", () => {
-    const searchParams = new URLSearchParams({
-      redirect_url: "https://example.com/callback",
-    });
-
-    expect(getStandaloneVerificationOrigin(searchParams)).toBe(
-      "https://example.com/callback",
-    );
-  });
-
-  it("falls back to the current origin when no params are present", () => {
+  it("verifies the redirect target in the redirect flow", () => {
     expect(
-      getStandaloneVerificationOrigin(
-        new URLSearchParams(),
-        "https://www.deathmountain.gg",
+      verifyStandaloneOrigin(
+        undefined,
+        "https://www.deathmountain.gg/callback",
+        allowed,
       ),
-    ).toBe("https://www.deathmountain.gg");
-  });
-
-  it("returns null when nothing is available", () => {
-    expect(getStandaloneVerificationOrigin(new URLSearchParams())).toBeNull();
-  });
-
-  it("resolves an origin the preset wildcard verifies (regression)", () => {
-    // Popup auth (/auth) sends the app origin via `origin`, not `redirect_url`.
-    // The death-mountain preset allows `*.deathmountain.gg`, so the resolved
-    // origin must verify against the wildcard.
-    const searchParams = new URLSearchParams({
-      origin: encodeURIComponent("https://www.deathmountain.gg"),
-    });
-
-    const resolved = getStandaloneVerificationOrigin(searchParams);
-    expect(resolved).toBe("https://www.deathmountain.gg");
-    expect(
-      isOriginVerified(resolved as string, [
-        "*.deathmountain.gg",
-        "deathmountain.gg",
-        "connect.provable.games",
-      ]),
     ).toBe(true);
+  });
+
+  it("verifies the handshake origin in the popup flow (no redirect target)", () => {
+    // Popup auth has no redirect_url; the trusted origin arrives via the opener
+    // handshake and is passed as currentOrigin.
+    expect(
+      verifyStandaloneOrigin("https://www.deathmountain.gg", null, allowed),
+    ).toBe(true);
+  });
+
+  it("binds trust to the redirect target, not a spoofable claim (regression)", () => {
+    // An attacker cannot pass verification by claiming a trusted origin while
+    // the session is actually delivered elsewhere: trust follows redirect_url
+    // (the delivery target), so a mismatched currentOrigin is ignored.
+    expect(
+      verifyStandaloneOrigin(
+        "https://www.deathmountain.gg", // spoofed claim
+        "https://evil.com/callback", // real delivery target
+        allowed,
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for a non-allowlisted origin", () => {
+    expect(verifyStandaloneOrigin("https://evil.com", null, allowed)).toBe(
+      false,
+    );
+  });
+
+  it("returns false when no origin is available", () => {
+    expect(verifyStandaloneOrigin(undefined, null, allowed)).toBe(false);
+  });
+
+  it("treats localhost as verified", () => {
+    expect(verifyStandaloneOrigin("http://localhost:3000", null, allowed)).toBe(
+      true,
+    );
   });
 });
 

--- a/packages/keychain/src/hooks/connection.test.ts
+++ b/packages/keychain/src/hooks/connection.test.ts
@@ -1,6 +1,7 @@
 import {
   getStandaloneAppOrigin,
   getStandaloneRedirectUrl,
+  getStandaloneVerificationOrigin,
   isNestedIframe,
   isOriginVerified,
   resolvePolicies,
@@ -115,6 +116,61 @@ describe("getStandaloneRedirectUrl", () => {
 
   it("returns null when no standalone redirect target is present", () => {
     expect(getStandaloneRedirectUrl(new URLSearchParams())).toBeNull();
+  });
+});
+
+describe("getStandaloneVerificationOrigin", () => {
+  it("prefers the explicit origin param (popup auth flow)", () => {
+    const searchParams = new URLSearchParams({
+      origin: encodeURIComponent("https://www.deathmountain.gg"),
+      redirect_url: "https://example.com/callback",
+    });
+
+    expect(getStandaloneVerificationOrigin(searchParams)).toBe(
+      "https://www.deathmountain.gg",
+    );
+  });
+
+  it("falls back to the redirect target when no origin param is present", () => {
+    const searchParams = new URLSearchParams({
+      redirect_url: "https://example.com/callback",
+    });
+
+    expect(getStandaloneVerificationOrigin(searchParams)).toBe(
+      "https://example.com/callback",
+    );
+  });
+
+  it("falls back to the current origin when no params are present", () => {
+    expect(
+      getStandaloneVerificationOrigin(
+        new URLSearchParams(),
+        "https://www.deathmountain.gg",
+      ),
+    ).toBe("https://www.deathmountain.gg");
+  });
+
+  it("returns null when nothing is available", () => {
+    expect(getStandaloneVerificationOrigin(new URLSearchParams())).toBeNull();
+  });
+
+  it("resolves an origin the preset wildcard verifies (regression)", () => {
+    // Popup auth (/auth) sends the app origin via `origin`, not `redirect_url`.
+    // The death-mountain preset allows `*.deathmountain.gg`, so the resolved
+    // origin must verify against the wildcard.
+    const searchParams = new URLSearchParams({
+      origin: encodeURIComponent("https://www.deathmountain.gg"),
+    });
+
+    const resolved = getStandaloneVerificationOrigin(searchParams);
+    expect(resolved).toBe("https://www.deathmountain.gg");
+    expect(
+      isOriginVerified(resolved as string, [
+        "*.deathmountain.gg",
+        "deathmountain.gg",
+        "connect.provable.games",
+      ]),
+    ).toBe(true);
   });
 });
 

--- a/packages/keychain/src/hooks/connection.ts
+++ b/packages/keychain/src/hooks/connection.ts
@@ -276,19 +276,25 @@ function computeVerifiedState(
 
   if (!isIframe()) {
     const searchParams = new URLSearchParams(window.location.search);
-    const redirectUrl = getStandaloneRedirectUrl(searchParams);
+    const standaloneOrigin = getStandaloneVerificationOrigin(
+      searchParams,
+      currentOrigin,
+    );
 
-    if (redirectUrl) {
+    if (standaloneOrigin) {
       try {
-        const redirectUrlObj = new URL(redirectUrl);
-        const redirectOrigin = redirectUrlObj.origin;
+        const originObj = new URL(standaloneOrigin);
+        const originHost = originObj.origin;
         const isLocalhost =
-          redirectOrigin.includes("localhost") ||
-          redirectOrigin === "capacitor://localhost";
-        const isOriginAllowed = isOriginVerified(redirectUrl, allowedOrigins);
+          originHost.includes("localhost") ||
+          originHost === "capacitor://localhost";
+        const isOriginAllowed = isOriginVerified(
+          standaloneOrigin,
+          allowedOrigins,
+        );
         return isLocalhost || isOriginAllowed;
       } catch (error) {
-        console.error("Failed to parse standalone redirect target:", error);
+        console.error("Failed to parse standalone verification origin:", error);
       }
     }
 
@@ -332,6 +338,30 @@ export function getStandaloneRedirectUrl(
   searchParams: URLSearchParams,
 ): string | null {
   return searchParams.get("redirect_url") || searchParams.get("redirect_uri");
+}
+
+/**
+ * Resolve the application origin to verify against the preset allowlist when
+ * the keychain runs standalone (not in an iframe).
+ *
+ * Different standalone entrypoints carry the app origin differently:
+ * - The popup auth flow (`/auth`) passes it as an explicit `origin` param.
+ * - The redirect flow passes a `redirect_url`/`redirect_uri` to return to.
+ *
+ * We honor the explicit `origin` param first, then the redirect target, and
+ * finally fall back to the already-resolved current origin. Without this, the
+ * popup auth flow (which only sends `origin`) would always read as unverified.
+ */
+export function getStandaloneVerificationOrigin(
+  searchParams: URLSearchParams,
+  currentOrigin?: string,
+): string | null {
+  const originParam = searchParams.get("origin");
+  if (originParam) {
+    return decodeURIComponent(originParam);
+  }
+
+  return getStandaloneRedirectUrl(searchParams) ?? currentOrigin ?? null;
 }
 
 export function getStandaloneAppOrigin(redirectUrl: string): string {

--- a/packages/keychain/src/hooks/connection.ts
+++ b/packages/keychain/src/hooks/connection.ts
@@ -7,6 +7,7 @@ import {
 import { useNavigation } from "@/context/navigation";
 import { connectToController } from "@/utils/connection";
 import type { HeadlessConnectionState } from "@/utils/connection/headless";
+import { requestPopupAuthOrigin } from "@/utils/connection/popup";
 import { TurnkeyWallet } from "@/wallets/social/turnkey";
 import { WalletConnectWallet } from "@/wallets/wallet-connect";
 import {
@@ -276,29 +277,11 @@ function computeVerifiedState(
 
   if (!isIframe()) {
     const searchParams = new URLSearchParams(window.location.search);
-    const standaloneOrigin = getStandaloneVerificationOrigin(
-      searchParams,
+    return verifyStandaloneOrigin(
       currentOrigin,
+      getStandaloneRedirectUrl(searchParams),
+      allowedOrigins,
     );
-
-    if (standaloneOrigin) {
-      try {
-        const originObj = new URL(standaloneOrigin);
-        const originHost = originObj.origin;
-        const isLocalhost =
-          originHost.includes("localhost") ||
-          originHost === "capacitor://localhost";
-        const isOriginAllowed = isOriginVerified(
-          standaloneOrigin,
-          allowedOrigins,
-        );
-        return isLocalhost || isOriginAllowed;
-      } catch (error) {
-        console.error("Failed to parse standalone verification origin:", error);
-      }
-    }
-
-    return false;
   }
 
   if (!configData.origin) {
@@ -341,27 +324,42 @@ export function getStandaloneRedirectUrl(
 }
 
 /**
- * Resolve the application origin to verify against the preset allowlist when
- * the keychain runs standalone (not in an iframe).
+ * Decide whether a standalone (non-iframe) keychain context is verified against
+ * the preset's allowed origins.
  *
- * Different standalone entrypoints carry the app origin differently:
- * - The popup auth flow (`/auth`) passes it as an explicit `origin` param.
- * - The redirect flow passes a `redirect_url`/`redirect_uri` to return to.
+ * Verification must be rooted in something the caller cannot forge:
+ * - Redirect flow: `redirect_url` IS the delivery target (the keychain navigates
+ *   back to it), so the claimed origin and the recipient are guaranteed the same
+ *   — it cannot be spoofed to point elsewhere.
+ * - Popup auth flow: there is no redirect target; `currentOrigin` is the origin
+ *   established via the opener handshake, rooted in the browser-enforced penpal
+ *   parent origin.
  *
- * We honor the explicit `origin` param first, then the redirect target, and
- * finally fall back to the already-resolved current origin. Without this, the
- * popup auth flow (which only sends `origin`) would always read as unverified.
+ * The caller-supplied `origin` query param is deliberately NOT consulted here:
+ * it can be set to any value by whoever opens the page, so trusting it would let
+ * an attacker suppress the unverified warning and auto-approve policies (e.g.
+ * `origin=<trusted game>` while delivering the session to an attacker URL).
  */
-export function getStandaloneVerificationOrigin(
-  searchParams: URLSearchParams,
-  currentOrigin?: string,
-): string | null {
-  const originParam = searchParams.get("origin");
-  if (originParam) {
-    return decodeURIComponent(originParam);
+export function verifyStandaloneOrigin(
+  currentOrigin: string | undefined,
+  redirectUrl: string | null,
+  allowedOrigins: string[],
+): boolean {
+  const candidate = redirectUrl ?? currentOrigin;
+  if (!candidate) {
+    return false;
   }
 
-  return getStandaloneRedirectUrl(searchParams) ?? currentOrigin ?? null;
+  try {
+    const candidateOrigin = new URL(candidate).origin;
+    const isLocalhost =
+      candidateOrigin.includes("localhost") ||
+      candidateOrigin === "capacitor://localhost";
+    return isLocalhost || isOriginVerified(candidate, allowedOrigins);
+  } catch (error) {
+    console.error("Failed to parse standalone verification origin:", error);
+    return false;
+  }
 }
 
 export function getStandaloneAppOrigin(redirectUrl: string): string {
@@ -962,25 +960,42 @@ export function useConnectionValue() {
       const localWalletBridge = new WalletBridge();
       const iframeMethods = localWalletBridge.getIFrameMethods();
 
-      // In standalone mode, use explicit origin param (popup auth), redirect URI's origin,
-      // or fall back to window.location.origin
       const searchParams = new URLSearchParams(window.location.search);
-      const originParam = searchParams.get("origin");
+      const channelId = searchParams.get("channel_id");
       const redirectUrl = getStandaloneRedirectUrl(searchParams);
+
+      // Default to the keychain's own origin, which is never in a preset's
+      // allowlist, so the context reads as unverified until a trusted origin is
+      // established below.
       let appOrigin = window.location.origin;
+      let cleanupOriginHandshake: (() => void) | undefined;
 
-      if (originParam) {
-        appOrigin = decodeURIComponent(originParam);
-      } else if (redirectUrl) {
-        try {
-          appOrigin = getStandaloneAppOrigin(redirectUrl);
-        } catch (error) {
-          console.error("Failed to parse standalone redirect target:", error);
+      if (channelId && window.opener) {
+        // Popup auth (`/auth`): the app origin is NOT read from the URL — the
+        // `origin` param is caller-supplied and spoofable. It is delivered by
+        // the opener (keychain iframe) over a same-origin-validated postMessage
+        // handshake, rooted in the browser-enforced penpal parent origin.
+        cleanupOriginHandshake = requestPopupAuthOrigin(
+          channelId,
+          (trustedOrigin) => {
+            originRef.current = trustedOrigin;
+            setOrigin(trustedOrigin);
+          },
+        );
+      } else {
+        // Redirect flow: trust is bound to the delivery target — the keychain
+        // navigates back to `redirect_url`, so its origin cannot be spoofed to
+        // point somewhere the session is not actually delivered.
+        if (redirectUrl) {
+          try {
+            appOrigin = getStandaloneAppOrigin(redirectUrl);
+          } catch (error) {
+            console.error("Failed to parse standalone redirect target:", error);
+          }
         }
+        originRef.current = appOrigin;
+        setOrigin(appOrigin);
       }
-
-      originRef.current = appOrigin;
-      setOrigin(appOrigin);
 
       setParent({
         open: async () => {},
@@ -997,6 +1012,10 @@ export function useConnectionValue() {
         externalWaitForTransaction:
           iframeMethods.externalWaitForTransaction(appOrigin),
       });
+
+      return () => {
+        cleanupOriginHandshake?.();
+      };
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/keychain/src/utils/connection/popup.test.ts
+++ b/packages/keychain/src/utils/connection/popup.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { parseTrustedAuthContext } from "./popup";
+
+const KEYCHAIN_ORIGIN = "https://x.cartridge.gg";
+const CHANNEL = "channel-123";
+
+// Stand-in window references; parseTrustedAuthContext only compares identity.
+const opener = {} as Window;
+const other = {} as Window;
+
+function authContextEvent(
+  overrides: Partial<MessageEvent> & { data?: unknown } = {},
+): MessageEvent {
+  return {
+    origin: KEYCHAIN_ORIGIN,
+    source: opener,
+    data: {
+      type: "auth-context",
+      channelId: CHANNEL,
+      origin: "https://www.deathmountain.gg",
+    },
+    ...overrides,
+  } as MessageEvent;
+}
+
+describe("parseTrustedAuthContext", () => {
+  const opts = {
+    channelId: CHANNEL,
+    expectedOrigin: KEYCHAIN_ORIGIN,
+    opener,
+  };
+
+  it("accepts a trusted auth-context from the opener and returns its origin", () => {
+    expect(parseTrustedAuthContext(authContextEvent(), opts)).toBe(
+      "https://www.deathmountain.gg",
+    );
+  });
+
+  it("rejects a message from a cross-origin sender", () => {
+    // A page that opens /auth directly is cross-origin; its messages must not be
+    // trusted to supply the app origin.
+    expect(
+      parseTrustedAuthContext(
+        authContextEvent({ origin: "https://evil.com" }),
+        opts,
+      ),
+    ).toBeNull();
+  });
+
+  it("rejects a message whose source is not the opener", () => {
+    expect(
+      parseTrustedAuthContext(authContextEvent({ source: other }), opts),
+    ).toBeNull();
+  });
+
+  it("rejects a message for a different channel", () => {
+    expect(
+      parseTrustedAuthContext(
+        authContextEvent({
+          data: {
+            type: "auth-context",
+            channelId: "other-channel",
+            origin: "https://www.deathmountain.gg",
+          },
+        }),
+        opts,
+      ),
+    ).toBeNull();
+  });
+
+  it("rejects a message of the wrong type", () => {
+    expect(
+      parseTrustedAuthContext(
+        authContextEvent({
+          data: { type: "auth-ack", channelId: CHANNEL },
+        }),
+        opts,
+      ),
+    ).toBeNull();
+  });
+
+  it("rejects a message with a missing or empty origin", () => {
+    expect(
+      parseTrustedAuthContext(
+        authContextEvent({
+          data: { type: "auth-context", channelId: CHANNEL, origin: "" },
+        }),
+        opts,
+      ),
+    ).toBeNull();
+  });
+
+  it("rejects when there is no opener", () => {
+    expect(
+      parseTrustedAuthContext(authContextEvent(), { ...opts, opener: null }),
+    ).toBeNull();
+  });
+});

--- a/packages/keychain/src/utils/connection/popup.ts
+++ b/packages/keychain/src/utils/connection/popup.ts
@@ -3,10 +3,16 @@ import type { ImportedControllerState } from "@/utils/controller";
 const POPUP_WIDTH = 432;
 const POPUP_HEIGHT = 700;
 const POPUP_POLL_INTERVAL_MS = 500;
+const POPUP_HANDSHAKE_RETRY_MS = 150;
+const POPUP_HANDSHAKE_TIMEOUT_MS = 5000;
 
 export type PopupAuthAction = "signup" | "login";
 
 type PopupMessage =
+  | {
+      type: "auth-ready";
+      channelId: string;
+    }
   | {
       type: "auth-complete";
       channelId: string;
@@ -134,6 +140,19 @@ export function openPopupAuth(
         return;
       }
 
+      // The popup asks the opener for the verified app origin. We answer with the
+      // penpal-enforced origin the opener holds (never a value the popup itself
+      // could derive from its URL), over this same-origin-validated channel.
+      if (data.type === "auth-ready") {
+        if (options.origin) {
+          popup.postMessage(
+            { type: "auth-context", channelId, origin: options.origin },
+            window.location.origin,
+          );
+        }
+        return;
+      }
+
       handleAuthMessage(data);
     };
 
@@ -147,4 +166,100 @@ export function openPopupAuth(
       }
     }, POPUP_POLL_INTERVAL_MS);
   });
+}
+
+/**
+ * Validate an `auth-context` message received by the popup and extract the app
+ * origin it carries.
+ *
+ * This is the trust boundary for popup-auth origin verification: the message is
+ * accepted ONLY if it comes from the opener (the keychain iframe) and is
+ * same-origin with the keychain. A page that opens `/auth` directly has a
+ * cross-origin opener, so its messages are rejected here and it can never supply
+ * a trusted origin. Returns the origin string, or null if the message is not a
+ * trusted `auth-context`.
+ */
+export function parseTrustedAuthContext(
+  event: MessageEvent,
+  opts: { channelId: string; expectedOrigin: string; opener: Window | null },
+): string | null {
+  if (event.origin !== opts.expectedOrigin) {
+    return null;
+  }
+  if (!opts.opener || event.source !== opts.opener) {
+    return null;
+  }
+
+  const data = event.data as
+    | { type?: string; channelId?: string; origin?: unknown }
+    | undefined;
+  if (
+    !data ||
+    data.type !== "auth-context" ||
+    data.channelId !== opts.channelId
+  ) {
+    return null;
+  }
+  if (typeof data.origin !== "string" || data.origin.length === 0) {
+    return null;
+  }
+
+  return data.origin;
+}
+
+/**
+ * Called from the popup (`/auth`). Asks the opener for the verified app origin
+ * over a same-origin postMessage handshake and invokes `onOrigin` once a trusted
+ * `auth-context` arrives. The app origin is intentionally taken from this
+ * handshake rather than the URL `origin` param, which is caller-supplied and
+ * spoofable. Returns a cleanup function.
+ */
+export function requestPopupAuthOrigin(
+  channelId: string,
+  onOrigin: (origin: string) => void,
+): () => void {
+  if (typeof window === "undefined" || !window.opener) {
+    return () => {};
+  }
+
+  const expectedOrigin = window.location.origin;
+  const opener = window.opener as Window;
+  let done = false;
+
+  const cleanup = () => {
+    if (done) return;
+    done = true;
+    clearInterval(retry);
+    clearTimeout(timeout);
+    window.removeEventListener("message", handler);
+  };
+
+  const handler = (event: MessageEvent) => {
+    if (done) return;
+    const origin = parseTrustedAuthContext(event, {
+      channelId,
+      expectedOrigin,
+      opener,
+    });
+    if (!origin) return;
+    cleanup();
+    onOrigin(origin);
+  };
+
+  const post = () => {
+    try {
+      opener.postMessage({ type: "auth-ready", channelId }, expectedOrigin);
+    } catch {
+      // Opener may be cross-origin or gone; the timeout will clean up.
+    }
+  };
+
+  window.addEventListener("message", handler);
+  // Retry until the opener answers: its message listener may register slightly
+  // after the popup mounts.
+  const retry = setInterval(post, POPUP_HANDSHAKE_RETRY_MS);
+  const timeout = setTimeout(cleanup, POPUP_HANDSHAKE_TIMEOUT_MS);
+  post();
+
+  return cleanup;
 }


### PR DESCRIPTION
## Problem

On **iOS** (every browser — all WebKit, incl. iOS Chrome), signing into a Controller preset navigates to the `x.cartridge.gg/auth` popup flow (introduced in #2583 for Safari, because WebAuthn + cookies can't run in a cross-origin iframe under ITP). On that path users get a spurious **"This application is not verified"** warning **and** are forced to manually approve session policies — even though the policies are identical to the working desktop/Android version and the app origin is whitelisted in the preset. Android/desktop Chrome stay in the iframe and are unaffected.

## Root cause

The popup `/auth` flow conveys the app origin via the `origin` query param and sends **no `redirect_url`**. `computeVerifiedState()` (standalone/`!isIframe()` branch) only verified `redirect_url`, so it returned `false` for popup auth regardless of the preset. That single `verified=false` flag drives both symptoms: the warning, and (via `requiresSessionApproval`) the forced policy approval.

## Why not just trust the `origin` param

A first cut verified the `origin` query param — but that's **caller-supplied and spoofable**, and it breaks the property the redirect flow relied on: trust must be bound to the **delivery target**. An attacker could pass `origin=<trusted game>` with `redirect_url=<attacker>` and get an auto-approved session delivered to themselves. So that approach was dropped.

## Fix: root verification in sources the caller cannot forge

- **Redirect flow** → verify `redirect_url` (the keychain navigates back to it, so the claimed origin and the recipient are the same — can't be pointed elsewhere).
- **Popup `/auth` flow** → the opener (keychain iframe, which holds the **penpal-enforced** parent origin) pushes that origin to the popup over a **same-origin-validated `postMessage` handshake** (`auth-ready` → `auth-context`). The popup no longer derives its verified origin from the URL. This rides the same opener↔popup channel #2583 already uses to deliver the session, so it's as reliable as the shipping completion path.

`computeVerifiedState` now delegates to `verifyStandaloneOrigin(currentOrigin, redirectUrl, allowedOrigins)`, and the standalone connection effect no longer reads the spoofable `origin` param for the origin state. The URL `origin` param is retained only for the pre-existing WebAuthn appId / username-prefill use (not verification).

## Why the handshake can't be spoofed

The popup accepts an `auth-context` **only if** `event.origin === x.cartridge.gg` **and** `event.source === window.opener` **and** the `channelId` matches.

| Attack | Why it fails |
|---|---|
| Open `/auth?…&origin=<trusted>` directly from `evil.com` | Popup posts `auth-ready` to `window.opener` with `targetOrigin=x.cartridge.gg`; an `evil.com` opener never receives it. A guessed `auth-context` has `event.origin=evil.com` → rejected. The result `postMessage` is likewise locked to `x.cartridge.gg`, so `evil.com` can't receive the session either. |
| Embed the **real** keychain iframe in `evil.com` | The iframe's origin from penpal is `evil.com` (browser-enforced); it forwards *that* → popup correctly reads **unverified**. It cannot be made to report a different origin. |
| Inject / race an `auth-context` from another window | Fails `event.source === window.opener` (identity) and/or `event.origin === x.cartridge.gg`. |

Assumptions (all standard, none new): browser-enforced `postMessage` `targetOrigin`/`event.origin`/`event.source`; the popup's `window.opener` is the keychain iframe (already relied on by #2583); penpal's parent origin is browser-enforced (the same origin already gating all parent↔iframe RPC); no XSS on `x.cartridge.gg`. If `window.opener` is ever null (COOP), the popup **fails safe** — warning shown, manual approval required — rather than failing open.

## Scope note

This affects **iOS only** (WebKit) — not game-specific, and not Android/desktop. The `origin` URL param is left in place for the pre-existing appId path; happy to harden that separately if desired.

## Tests

- `verifyStandaloneOrigin` — incl. a **spoof regression**: `origin=<trusted>` + `redirect_url=<attacker>` stays unverified.
- `parseTrustedAuthContext` — cross-origin sender / wrong source / wrong channel / bad payload all rejected.

Full `connection.test.ts` + new `popup.test.ts` green; eslint, prettier, and `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
