### PR TITLE
fix: avoid prompt undeployed accounts to upgrade

### DIFF
--- a/examples/next/.env.live
+++ b/examples/next/.env.live
@@ -1,5 +1,7 @@
 NEXT_PUBLIC_RPC_MAINNET="https://api.cartridge.gg/x/starknet/mainnet/rpc/v0_9"
 NEXT_PUBLIC_RPC_SEPOLIA="https://api.cartridge.gg/x/starknet/sepolia/rpc/v0_9"
 NEXT_PUBLIC_RPC_LOCAL=
+NEXT_PUBLIC_LOCAL_CHAIN_ID=
+NEXT_PUBLIC_LOCAL_CHAIN_ENABLED=
 NEXT_PUBLIC_KEYCHAIN_FRAME_URL="http://localhost:3001"
 NEXT_PUBLIC_CARTRIDGE_API_URL="https://api.cartridge.gg"

--- a/examples/next/src/components/Header.tsx
+++ b/examples/next/src/components/Header.tsx
@@ -108,7 +108,7 @@ const Header = () => {
 
   return (
     <>
-      <div className="w-full absolute top-0 left-0 p-5 flex items-center space-x-2">
+      <div className="w-full p-0 flex flex-wrap items-center gap-2">
         <div className="flex-1" />
 
         {status === "connected" && (
@@ -161,7 +161,7 @@ const Header = () => {
           </>
         )}
         {address ? (
-          <div ref={profileRef}>
+          <div className="relative" ref={profileRef}>
             <Button
               onClick={() => {
                 setProfileOpen(!profileOpen);
@@ -202,7 +202,7 @@ const Header = () => {
             )}
           </div>
         ) : (
-          <div className="flex gap-2">
+          <div className="flex flex-wrap gap-2">
             <Button
               onClick={() => {
                 controllerConnector.controller.open({
@@ -280,7 +280,7 @@ const Header = () => {
       </div>
 
       {!address && (
-        <div className="w-full p-5 flex items-center space-x-2">
+        <div className="w-full p-0 flex flex-wrap items-center gap-2">
           <div className="flex-grow" />
           <h1>Connect options:</h1>
           <Button

--- a/examples/next/src/components/Transfer.tsx
+++ b/examples/next/src/components/Transfer.tsx
@@ -22,11 +22,15 @@ export const Transfer = () => {
 
       account
         .execute([
-          {
-            contractAddress: STRK_CONTRACT_ADDRESS,
-            entrypoint: "approve",
-            calldata: [account?.address, amount, "0x0"],
-          },
+          ...(amount != "0x0"
+            ? [
+                {
+                  contractAddress: STRK_CONTRACT_ADDRESS,
+                  entrypoint: "approve",
+                  calldata: [account?.address, amount, "0x0"],
+                },
+              ]
+            : []),
           {
             contractAddress: STRK_CONTRACT_ADDRESS,
             entrypoint: "transfer",

--- a/examples/next/src/components/providers/StarknetProvider.tsx
+++ b/examples/next/src/components/providers/StarknetProvider.tsx
@@ -16,6 +16,12 @@ import {
   STRK_CONTRACT_ADDRESS,
 } from "@cartridge/controller-ui/utils";
 
+// enable local katana with NEXT_PUBLIC_LOCAL_ENABLED=1
+const KATANA_ENABLED = Boolean(process.env.NEXT_PUBLIC_LOCAL_ENABLED ?? false);
+const KATANA_RPC = process.env.NEXT_PUBLIC_RPC_LOCAL ?? "http://localhost:5050";
+const KATANA_CHAIN_ID =
+  process.env.NEXT_PUBLIC_LOCAL_CHAIN_ID ?? "KATANA_LOCAL";
+
 export enum ConnectOptions {
   OverridePolicies = "connect-override-policies",
   Preset = "connect-preset",
@@ -113,17 +119,17 @@ const policies: SessionPolicies = {
 };
 
 let localKatanaChain: Chain | undefined = undefined;
-if (process.env.NEXT_PUBLIC_RPC_LOCAL) {
+if (KATANA_ENABLED && KATANA_RPC) {
   localKatanaChain = {
-    id: num.toBigInt(shortString.encodeShortString("WP_SLOT")),
-    network: "Slot",
-    name: "Slot",
+    id: num.toBigInt(shortString.encodeShortString(KATANA_CHAIN_ID)),
+    network: KATANA_CHAIN_ID,
+    name: KATANA_CHAIN_ID,
     rpcUrls: {
       default: {
-        http: [process.env.NEXT_PUBLIC_RPC_LOCAL],
+        http: [KATANA_RPC],
       },
       public: {
-        http: [process.env.NEXT_PUBLIC_RPC_LOCAL],
+        http: [KATANA_RPC],
       },
     },
     nativeCurrency: {
@@ -134,7 +140,10 @@ if (process.env.NEXT_PUBLIC_RPC_LOCAL) {
     },
     paymasterRpcUrls: {
       default: {
-        http: [],
+        http: [KATANA_RPC],
+      },
+      avnu: {
+        http: [KATANA_RPC],
       },
     },
   };
@@ -148,12 +157,8 @@ const provider = jsonRpcProvider({
     if (chain.id === sepolia.id && process.env.NEXT_PUBLIC_RPC_SEPOLIA) {
       return { nodeUrl: process.env.NEXT_PUBLIC_RPC_SEPOLIA };
     }
-    if (
-      localKatanaChain &&
-      chain.id === localKatanaChain.id &&
-      process.env.NEXT_PUBLIC_RPC_LOCAL
-    ) {
-      return { nodeUrl: process.env.NEXT_PUBLIC_RPC_LOCAL };
+    if (chain.id === localKatanaChain?.id) {
+      return { nodeUrl: KATANA_RPC };
     }
     return null;
   },
@@ -186,27 +191,28 @@ const getKeychainUrl = () => {
   }
 };
 
-const starknetConfigChains = [mainnet, sepolia].filter(Boolean) as Chain[];
+const starknetConfigChains: Chain[] = [];
+const controllerConnectorChains: { rpcUrl: string }[] = [];
+
 if (localKatanaChain) {
   starknetConfigChains.push(localKatanaChain);
-}
-
-const controllerConnectorChains: { rpcUrl: string }[] = [];
-if (process.env.NEXT_PUBLIC_RPC_SEPOLIA) {
   controllerConnectorChains.push({
-    rpcUrl: process.env.NEXT_PUBLIC_RPC_SEPOLIA,
+    rpcUrl: KATANA_RPC,
   });
+} else {
+  starknetConfigChains.push(mainnet);
+  starknetConfigChains.push(sepolia);
+  if (process.env.NEXT_PUBLIC_RPC_SEPOLIA) {
+    controllerConnectorChains.push({
+      rpcUrl: process.env.NEXT_PUBLIC_RPC_SEPOLIA,
+    });
+  }
+  if (process.env.NEXT_PUBLIC_RPC_MAINNET) {
+    controllerConnectorChains.push({
+      rpcUrl: process.env.NEXT_PUBLIC_RPC_MAINNET,
+    });
+  }
 }
-if (process.env.NEXT_PUBLIC_RPC_MAINNET) {
-  controllerConnectorChains.push({
-    rpcUrl: process.env.NEXT_PUBLIC_RPC_MAINNET,
-  });
-}
-// if (process.env.NEXT_PUBLIC_RPC_LOCAL) {
-//   controllerConnectorChains.unshift({
-//     rpcUrl: process.env.NEXT_PUBLIC_RPC_LOCAL,
-//   });
-// }
 
 const signupOptions: AuthOptions = [
   "google",
@@ -228,7 +234,7 @@ export const presets = {
     namespace: "NUMS",
     preset: "nums",
   },
-  lootSurvivor: {
+  "loot-survivor": {
     // Loot Survivor (no achievements, no quests)
     namespace: "ls_0_0_9",
     slot: "pg-mainnet-10",
@@ -250,6 +256,10 @@ export const presets = {
     // slot: "cagecalls-mainnet",
     // namespace: "cagecalls",
     preset: "cage-calls",
+  },
+  "jokers-of-neon": {
+    namespace: "jokers_of_neon_core",
+    preset: "jokers-of-neon",
   },
 };
 
@@ -275,21 +285,31 @@ export const controllerConnector = new ControllerConnector({
 });
 
 const session = new SessionConnector({
+  shouldOverridePresetPolicies: overridePolicies,
   policies: overridePolicies ? policies : {},
   rpc: process.env.NEXT_PUBLIC_RPC_MAINNET!,
   chainId: constants.StarknetChainId.SN_MAIN,
   redirectUrl: typeof window !== "undefined" ? window.location.origin : "",
-  disconnectRedirectUrl: "whatsapp://",
+  disconnectRedirectUrl: "redirect://",
   keychainUrl: getKeychainUrl(),
   apiUrl: process.env.NEXT_PUBLIC_CARTRIDGE_API_URL,
   signupOptions,
+  ...(controllerPreset ? presets[controllerPreset] : {}),
 });
+
+console.log(
+  `[starknet chains]:`,
+  starknetConfigChains
+    .map((c) => shortString.decodeShortString(num.toHex(c.id)))
+    .join(", "),
+  starknetConfigChains,
+);
 
 export function StarknetProvider({ children }: PropsWithChildren) {
   return (
     <StarknetConfig
       autoConnect
-      defaultChainId={mainnet.id}
+      defaultChainId={starknetConfigChains[0].id}
       chains={starknetConfigChains}
       connectors={[controllerConnector, session]}
       explorer={cartridge}

--- a/packages/keychain/src/components/provider/upgrade.test.tsx
+++ b/packages/keychain/src/components/provider/upgrade.test.tsx
@@ -167,7 +167,11 @@ describe("UpgradeProvider", () => {
     expect(result.current.isBeta).toBe(false);
   });
 
-  it("should handle contract not found error", async () => {
+  it("should not offer an upgrade for an account that isn't deployed on the chain", async () => {
+    // A counterfactual account's address is bound to its creation class, so it can
+    // only deploy as that class and upgrade in place — it can't be upgraded before it
+    // exists on-chain. So a "Contract not found" must NOT be reported as outdated,
+    // even though the mock's creation class (CONTROLLER_VERSIONS[3]) is behind latest.
     mockController.provider.getClassHashAt.mockRejectedValueOnce(
       new Error("Contract not found"),
     );
@@ -191,8 +195,8 @@ describe("UpgradeProvider", () => {
       );
     });
 
-    expect(result.current.available).toBe(true);
-    expect(result.current.current).toBe(CONTROLLER_VERSIONS[3]);
+    expect(result.current.available).toBe(false);
+    expect(result.current.current).toBeUndefined();
     expect(result.current.latest).toBe(STABLE_CONTROLLER);
   });
 

--- a/packages/keychain/src/components/provider/upgrade.tsx
+++ b/packages/keychain/src/components/provider/upgrade.tsx
@@ -76,18 +76,25 @@ const findVersion = (classHash: string): ControllerVersionInfo | undefined =>
     (v) => addAddressPadding(v.hash) === addAddressPadding(classHash),
   );
 
-/** The controller version deployed at `address` on a chain — or, when not deployed
- *  there yet, the version it would counterfactually deploy as (its creation class). */
+/** The controller version actually deployed at `address` on a chain, or `undefined`
+ *  when the account isn't deployed there yet.
+ *
+ *  A counterfactual account's address is bound to its creation class, so it can only
+ *  ever deploy *as* that class and then upgrade in place — there's no way to upgrade it
+ *  before it exists on-chain (the upgrade runs via `execute_from_outside`, which needs a
+ *  deployed contract). So we deliberately do NOT report the creation class here: a not-
+ *  yet-deployed account must not be flagged as "outdated", or we'd offer a premature
+ *  upgrade that can't execute. It deploys at its creation class on first use, and the
+ *  upgrade is offered then — once `getClassHashAt` returns a real, deployed class. */
 async function deployedVersion(
   provider: Pick<RpcProvider, "getClassHashAt">,
   address: string,
-  creationClassHash: string,
 ): Promise<ControllerVersionInfo | undefined> {
   try {
     return findVersion(await provider.getClassHashAt(address));
   } catch (e) {
     if ((e as Error).message?.includes("Contract not found")) {
-      return findVersion(creationClassHash);
+      return undefined;
     }
     throw e;
   }
@@ -195,14 +202,10 @@ export const UpgradeProvider: React.FC<UpgradeProviderProps> = ({
     (async () => {
       try {
         const address = controller.address();
-        const creationClassHash = controller.classHash();
+        // const creationClassHash = controller.classHash();
         const activeRpcUrl = controller.rpcUrl();
 
-        const active = await deployedVersion(
-          controller.provider,
-          address,
-          creationClassHash,
-        );
+        const active = await deployedVersion(controller.provider, address);
 
         const others = await Promise.all(
           (chains ?? [])
@@ -213,11 +216,7 @@ export const UpgradeProvider: React.FC<UpgradeProviderProps> = ({
                 const provider = new RpcProvider({ nodeUrl: rpcUrl });
                 return {
                   rpcUrl,
-                  version: await deployedVersion(
-                    provider,
-                    address,
-                    creationClassHash,
-                  ),
+                  version: await deployedVersion(provider, address),
                 };
               } catch {
                 // A single unreachable chain must not block the upgrade gate.

--- a/packages/keychain/src/utils/api/generated.ts
+++ b/packages/keychain/src/utils/api/generated.ts
@@ -40,6 +40,13 @@ export type Account = Node & {
   createdAt: Scalars["Time"];
   credentials: Credentials;
   credits: Credits;
+  /**
+   * This account's credit ledger — deposits (credits bought or granted) and spends
+   * (credits used) — most recent first by default. Private: only ever returns rows
+   * for the authenticated caller's own account; requesting it for any other account
+   * yields an empty connection.
+   */
+  creditsHistory: CreditsHistoryConnection;
   creditsPlain: Scalars["Int"];
   email?: Maybe<Scalars["String"]>;
   id: Scalars["ID"];
@@ -79,6 +86,15 @@ export type AccountControllersArgs = {
   last?: InputMaybe<Scalars["Int"]>;
   orderBy?: InputMaybe<ControllerOrder>;
   where?: InputMaybe<ControllerWhereInput>;
+};
+
+export type AccountCreditsHistoryArgs = {
+  after?: InputMaybe<Scalars["Cursor"]>;
+  before?: InputMaybe<Scalars["Cursor"]>;
+  first?: InputMaybe<Scalars["Int"]>;
+  last?: InputMaybe<Scalars["Int"]>;
+  orderBy?: InputMaybe<CreditsHistoryOrder>;
+  where?: InputMaybe<CreditsHistoryWhereInput>;
 };
 
 export type AccountMembershipArgs = {
@@ -1029,6 +1045,20 @@ export type BroadcastNotificationInput = {
   title: Scalars["String"];
 };
 
+export type BundleCreditsQuote = {
+  __typename?: "BundleCreditsQuote";
+  /** USDC cost in 6-decimal wei (includes swap slippage for non-USDC bundles). */
+  costInUsdc: Scalars["Long"];
+  /** True when the bundle is priced in a non-USDC token; the executor re-quotes the swap at execution time, so the final cost may drift slightly from this quote. */
+  needsSwap: Scalars["Boolean"];
+  /** The registry's payment token address — what the bundle is priced in. */
+  paymentToken: Scalars["String"];
+  /** Bundle price in the registry's payment token units. */
+  paymentTokenAmount: Scalars["Long"];
+  /** Credit units that will be debited (1 credit unit = 1e-8 USD; 100 credits = $1). */
+  requiredCredits: Scalars["Long"];
+};
+
 export type CoinbaseAmount = {
   __typename?: "CoinbaseAmount";
   /** The amount value as a string. */
@@ -1692,11 +1722,38 @@ export type CreditsHistory = Node & {
   comment?: Maybe<Scalars["String"]>;
   createdAt: Scalars["Time"];
   id: Scalars["ID"];
+  /**
+   * How the credits in this entry moved: for deposits (transactionType CREDIT) it is
+   * how they were acquired — CARD, CRYPTO, or FREE; for spends (transactionType DEBIT)
+   * it is always CREDITS, debited from the balance. The reason for a spend (bundle
+   * purchase, transaction fee, team transfer) is carried by `comment`.
+   */
+  paymentMethod: CreditsPaymentMethod;
   /** Transaction hash for debit transactions */
   transactionHash?: Maybe<Scalars["String"]>;
   /** Type of transaction: credit or debit */
   transactionType: CreditsHistoryTransactionType;
   updatedAt: Scalars["Time"];
+};
+
+/** A connection to a list of items. */
+export type CreditsHistoryConnection = {
+  __typename?: "CreditsHistoryConnection";
+  /** A list of edges. */
+  edges?: Maybe<Array<Maybe<CreditsHistoryEdge>>>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Identifies the total count of items in the connection. */
+  totalCount: Scalars["Int"];
+};
+
+/** An edge in a connection. */
+export type CreditsHistoryEdge = {
+  __typename?: "CreditsHistoryEdge";
+  /** A cursor for use in pagination. */
+  cursor: Scalars["Cursor"];
+  /** The item at the end of the edge. */
+  node?: Maybe<CreditsHistory>;
 };
 
 /** Ordering options for CreditsHistory connections */
@@ -1821,6 +1878,17 @@ export type CreditsInput = {
   amount: Scalars["Int"];
   decimals: Scalars["Int"];
 };
+
+export enum CreditsPaymentMethod {
+  /** Deposit paid by card (Stripe). */
+  Card = "CARD",
+  /** Spend debited from the account's credit balance. */
+  Credits = "CREDITS",
+  /** Deposit paid with crypto — onramp (Coinbase/Layerswap) or a direct transfer. */
+  Crypto = "CRYPTO",
+  /** Deposit granted at no cost (e.g. a booster-pack claim). */
+  Free = "FREE",
+}
 
 export type CryptoPayment = {
   __typename?: "CryptoPayment";
@@ -3195,6 +3263,16 @@ export type Mutation = {
   finalizeLogin: Scalars["String"];
   finalizeRegistration: Account;
   increaseBudget: Paymaster;
+  /**
+   * Spend the authenticated account's off-chain credit balance to purchase a
+   * starterpack bundle. Mirrors createCoinflowStarterpackIntent's pricing and
+   * fulfillment creation, but replaces the external card payment with a synchronous,
+   * in-transaction credit debit: the bundle is created directly at QUEUED and issued
+   * by the same operator-paid on-chain flow as the card rails. The credits are debited
+   * upfront and refunded automatically if fulfillment terminally fails. Returns the
+   * PurchaseFulfillment for status polling.
+   */
+  purchaseBundleWithCredits: PurchaseFulfillment;
   register: Account;
   registerNotificationDevice: NotificationDevice;
   removeAllPolicies: Scalars["Boolean"];
@@ -3421,6 +3499,10 @@ export type MutationIncreaseBudgetArgs = {
   paymasterName: Scalars["ID"];
   reason?: InputMaybe<AdminBudgetReason>;
   unit: FeeUnit;
+};
+
+export type MutationPurchaseBundleWithCreditsArgs = {
+  input: PurchaseBundleWithCreditsInput;
 };
 
 export type MutationRegisterArgs = {
@@ -4750,6 +4832,16 @@ export type Project = {
   project: Scalars["String"];
 };
 
+export type PurchaseBundleWithCreditsInput = {
+  clientPercentage?: InputMaybe<Scalars["Int"]>;
+  isMainnet?: InputMaybe<Scalars["Boolean"]>;
+  quantity: Scalars["Int"];
+  referral?: InputMaybe<Scalars["String"]>;
+  referralGroup?: InputMaybe<Scalars["String"]>;
+  registryAddress: Scalars["String"];
+  starterpackId: Scalars["String"];
+};
+
 export type PurchaseFulfillment = {
   __typename?: "PurchaseFulfillment";
   id: Scalars["ID"];
@@ -4777,6 +4869,13 @@ export type Query = {
   activities: ActivityResult;
   balance: Balance;
   balances: BalanceConnection;
+  /**
+   * Quote a bundle purchase paid from the account's credit balance. Reuses the exact
+   * pricing path as purchaseBundleWithCredits, so the credit cost shown to the user
+   * matches what will be debited. Call this before purchasing to display the price — the
+   * bundle's payment token and amount, plus the credit cost — and to pre-check the balance.
+   */
+  bundleCreditsQuote: BundleCreditsQuote;
   /**
    * Get the authenticated user's current Coinbase onramp spending limits along
    * with any available limits-upgrade option. Clients should only show the
@@ -4850,6 +4949,16 @@ export type Query = {
   price: Array<Price>;
   priceByAddresses: Array<Price>;
   pricePeriodByAddresses: Array<Price>;
+  /**
+   * Fetch a purchase fulfillment by id for status polling (owner only). Every
+   * starterpack purchase — paid by card, crypto, or credits — creates a
+   * PurchaseFulfillment that is issued on-chain asynchronously; this lets the client
+   * re-fetch it to track status, tx hash, and any failure (refund) message until it
+   * reaches CONFIRMED/FAILED. Card and crypto purchases can also reach their
+   * fulfillment via stripePayment/coinflowPayment, but credits purchases have no
+   * payment row, so this is the only path for them.
+   */
+  purchaseFulfillment: PurchaseFulfillment;
   rpcApiKeys?: Maybe<RpcApiKeyConnection>;
   rpcCorsDomains?: Maybe<RpcCorsDomainConnection>;
   rpcLogs?: Maybe<RpcLogConnection>;
@@ -4902,6 +5011,10 @@ export type QueryBalancesArgs = {
   limit?: InputMaybe<Scalars["Int"]>;
   offset?: InputMaybe<Scalars["Int"]>;
   projects?: InputMaybe<Array<Scalars["String"]>>;
+};
+
+export type QueryBundleCreditsQuoteArgs = {
+  input: PurchaseBundleWithCreditsInput;
 };
 
 export type QueryCoinbaseOnrampOrderArgs = {
@@ -5114,6 +5227,10 @@ export type QueryPricePeriodByAddressesArgs = {
   addresses: Array<Scalars["String"]>;
   end: Scalars["Int"];
   start: Scalars["Int"];
+};
+
+export type QueryPurchaseFulfillmentArgs = {
+  id: Scalars["ID"];
 };
 
 export type QueryRpcApiKeysArgs = {

--- a/packages/ui/src/utils/api/cartridge/generated.ts
+++ b/packages/ui/src/utils/api/cartridge/generated.ts
@@ -29,6 +29,13 @@ export type Account = Node & {
   createdAt: Scalars['Time'];
   credentials: Credentials;
   credits: Credits;
+  /**
+   * This account's credit ledger — deposits (credits bought or granted) and spends
+   * (credits used) — most recent first by default. Private: only ever returns rows
+   * for the authenticated caller's own account; requesting it for any other account
+   * yields an empty connection.
+   */
+  creditsHistory: CreditsHistoryConnection;
   creditsPlain: Scalars['Int'];
   email?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
@@ -71,6 +78,16 @@ export type AccountControllersArgs = {
   last?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<ControllerOrder>;
   where?: InputMaybe<ControllerWhereInput>;
+};
+
+
+export type AccountCreditsHistoryArgs = {
+  after?: InputMaybe<Scalars['Cursor']>;
+  before?: InputMaybe<Scalars['Cursor']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<CreditsHistoryOrder>;
+  where?: InputMaybe<CreditsHistoryWhereInput>;
 };
 
 
@@ -1024,6 +1041,20 @@ export type BroadcastNotificationInput = {
   title: Scalars['String'];
 };
 
+export type BundleCreditsQuote = {
+  __typename?: 'BundleCreditsQuote';
+  /** USDC cost in 6-decimal wei (includes swap slippage for non-USDC bundles). */
+  costInUsdc: Scalars['Long'];
+  /** True when the bundle is priced in a non-USDC token; the executor re-quotes the swap at execution time, so the final cost may drift slightly from this quote. */
+  needsSwap: Scalars['Boolean'];
+  /** The registry's payment token address — what the bundle is priced in. */
+  paymentToken: Scalars['String'];
+  /** Bundle price in the registry's payment token units. */
+  paymentTokenAmount: Scalars['Long'];
+  /** Credit units that will be debited (1 credit unit = 1e-8 USD; 100 credits = $1). */
+  requiredCredits: Scalars['Long'];
+};
+
 export type CoinbaseAmount = {
   __typename?: 'CoinbaseAmount';
   /** The amount value as a string. */
@@ -1683,11 +1714,38 @@ export type CreditsHistory = Node & {
   comment?: Maybe<Scalars['String']>;
   createdAt: Scalars['Time'];
   id: Scalars['ID'];
+  /**
+   * How the credits in this entry moved: for deposits (transactionType CREDIT) it is
+   * how they were acquired — CARD, CRYPTO, or FREE; for spends (transactionType DEBIT)
+   * it is always CREDITS, debited from the balance. The reason for a spend (bundle
+   * purchase, transaction fee, team transfer) is carried by `comment`.
+   */
+  paymentMethod: CreditsPaymentMethod;
   /** Transaction hash for debit transactions */
   transactionHash?: Maybe<Scalars['String']>;
   /** Type of transaction: credit or debit */
   transactionType: CreditsHistoryTransactionType;
   updatedAt: Scalars['Time'];
+};
+
+/** A connection to a list of items. */
+export type CreditsHistoryConnection = {
+  __typename?: 'CreditsHistoryConnection';
+  /** A list of edges. */
+  edges?: Maybe<Array<Maybe<CreditsHistoryEdge>>>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Identifies the total count of items in the connection. */
+  totalCount: Scalars['Int'];
+};
+
+/** An edge in a connection. */
+export type CreditsHistoryEdge = {
+  __typename?: 'CreditsHistoryEdge';
+  /** A cursor for use in pagination. */
+  cursor: Scalars['Cursor'];
+  /** The item at the end of the edge. */
+  node?: Maybe<CreditsHistory>;
 };
 
 /** Ordering options for CreditsHistory connections */
@@ -1812,6 +1870,17 @@ export type CreditsInput = {
   amount: Scalars['Int'];
   decimals: Scalars['Int'];
 };
+
+export enum CreditsPaymentMethod {
+  /** Deposit paid by card (Stripe). */
+  Card = 'CARD',
+  /** Spend debited from the account's credit balance. */
+  Credits = 'CREDITS',
+  /** Deposit paid with crypto — onramp (Coinbase/Layerswap) or a direct transfer. */
+  Crypto = 'CRYPTO',
+  /** Deposit granted at no cost (e.g. a booster-pack claim). */
+  Free = 'FREE'
+}
 
 export type CryptoPayment = {
   __typename?: 'CryptoPayment';
@@ -3189,6 +3258,16 @@ export type Mutation = {
   finalizeLogin: Scalars['String'];
   finalizeRegistration: Account;
   increaseBudget: Paymaster;
+  /**
+   * Spend the authenticated account's off-chain credit balance to purchase a
+   * starterpack bundle. Mirrors createCoinflowStarterpackIntent's pricing and
+   * fulfillment creation, but replaces the external card payment with a synchronous,
+   * in-transaction credit debit: the bundle is created directly at QUEUED and issued
+   * by the same operator-paid on-chain flow as the card rails. The credits are debited
+   * upfront and refunded automatically if fulfillment terminally fails. Returns the
+   * PurchaseFulfillment for status polling.
+   */
+  purchaseBundleWithCredits: PurchaseFulfillment;
   register: Account;
   registerNotificationDevice: NotificationDevice;
   removeAllPolicies: Scalars['Boolean'];
@@ -3449,6 +3528,11 @@ export type MutationIncreaseBudgetArgs = {
   paymasterName: Scalars['ID'];
   reason?: InputMaybe<AdminBudgetReason>;
   unit: FeeUnit;
+};
+
+
+export type MutationPurchaseBundleWithCreditsArgs = {
+  input: PurchaseBundleWithCreditsInput;
 };
 
 
@@ -4805,6 +4889,16 @@ export type Project = {
   project: Scalars['String'];
 };
 
+export type PurchaseBundleWithCreditsInput = {
+  clientPercentage?: InputMaybe<Scalars['Int']>;
+  isMainnet?: InputMaybe<Scalars['Boolean']>;
+  quantity: Scalars['Int'];
+  referral?: InputMaybe<Scalars['String']>;
+  referralGroup?: InputMaybe<Scalars['String']>;
+  registryAddress: Scalars['String'];
+  starterpackId: Scalars['String'];
+};
+
 export type PurchaseFulfillment = {
   __typename?: 'PurchaseFulfillment';
   id: Scalars['ID'];
@@ -4832,6 +4926,13 @@ export type Query = {
   activities: ActivityResult;
   balance: Balance;
   balances: BalanceConnection;
+  /**
+   * Quote a bundle purchase paid from the account's credit balance. Reuses the exact
+   * pricing path as purchaseBundleWithCredits, so the credit cost shown to the user
+   * matches what will be debited. Call this before purchasing to display the price — the
+   * bundle's payment token and amount, plus the credit cost — and to pre-check the balance.
+   */
+  bundleCreditsQuote: BundleCreditsQuote;
   /**
    * Get the authenticated user's current Coinbase onramp spending limits along
    * with any available limits-upgrade option. Clients should only show the
@@ -4905,6 +5006,16 @@ export type Query = {
   price: Array<Price>;
   priceByAddresses: Array<Price>;
   pricePeriodByAddresses: Array<Price>;
+  /**
+   * Fetch a purchase fulfillment by id for status polling (owner only). Every
+   * starterpack purchase — paid by card, crypto, or credits — creates a
+   * PurchaseFulfillment that is issued on-chain asynchronously; this lets the client
+   * re-fetch it to track status, tx hash, and any failure (refund) message until it
+   * reaches CONFIRMED/FAILED. Card and crypto purchases can also reach their
+   * fulfillment via stripePayment/coinflowPayment, but credits purchases have no
+   * payment row, so this is the only path for them.
+   */
+  purchaseFulfillment: PurchaseFulfillment;
   rpcApiKeys?: Maybe<RpcApiKeyConnection>;
   rpcCorsDomains?: Maybe<RpcCorsDomainConnection>;
   rpcLogs?: Maybe<RpcLogConnection>;
@@ -4963,6 +5074,11 @@ export type QueryBalancesArgs = {
   limit?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
   projects?: InputMaybe<Array<Scalars['String']>>;
+};
+
+
+export type QueryBundleCreditsQuoteArgs = {
+  input: PurchaseBundleWithCreditsInput;
 };
 
 
@@ -5214,6 +5330,11 @@ export type QueryPricePeriodByAddressesArgs = {
   addresses: Array<Scalars['String']>;
   end: Scalars['Int'];
   start: Scalars['Int'];
+};
+
+
+export type QueryPurchaseFulfillmentArgs = {
+  id: Scalars['ID'];
 };
 
 


### PR DESCRIPTION
## Don't prompt undeployed accounts to upgrade

### Problem
On a fresh chain (e.g. a new Katana), legacy accounts with an older creation class (notably passkey accounts) were shown an upgrade prompt — with a disabled, dead-end button. A counterfactual account's address is bound to its creation class, so it can't be upgraded before it's deployed: the upgrade runs via `execute_from_outside`, which needs a contract that exists on-chain.

### Fix
`deployedVersion` no longer falls back to the creation class when an account isn't deployed on a chain. A not-yet-deployed account is no longer flagged as outdated, so no premature upgrade is offered. The account deploys at its creation class on first use, and the upgrade is offered then — once it actually exists on-chain and the upgrade can execute.

### Scope
- `packages/keychain/src/components/provider/upgrade.tsx`
- Updated unit test to assert undeployed accounts aren't offered an upgrade.
