### PR TITLE
fix(keychain): float→BigInt crash in token send + HMR provider exports

### DIFF
--- a/packages/keychain/.storybook/mock.tsx
+++ b/packages/keychain/.storybook/mock.tsx
@@ -10,7 +10,7 @@ import {
   UpgradeContext,
   UpgradeInterface,
   UpgradeProviderProps,
-} from "../src/components/provider/upgrade";
+} from "../src/components/provider/upgrade-context";
 import { ConnectCtx, ConnectionCtx } from "../src/utils/connection/types";
 import { SemVer } from "semver";
 

--- a/packages/keychain/eslint.config.js
+++ b/packages/keychain/eslint.config.js
@@ -2,4 +2,13 @@ import config from "@cartridge/eslint";
 export default [
   ...config,
   { ignores: ["public/**", "src/utils/api/generated.ts"] },
+  {
+    files: ["**/*.{ts,tsx}"],
+    rules: {
+      "react-refresh/only-export-components": [
+        "warn",
+        { allowConstantExport: true },
+      ],
+    },
+  },
 ];

--- a/packages/keychain/src/components/app.tsx
+++ b/packages/keychain/src/components/app.tsx
@@ -52,7 +52,7 @@ import { DeployController } from "./DeployController";
 import { useConnection } from "@/hooks/connection";
 import { CreateController, Upgrade } from "./connect";
 import { HeadlessApprovalRoute } from "./connect/HeadlessApprovalRoute";
-import { useUpgrade } from "./provider/upgrade";
+import { useUpgrade } from "./provider/use-upgrade";
 import { Layout } from "@/components/layout";
 import { Disconnect } from "./disconnect";
 import { OnchainCheckout } from "./purchase/checkout/onchain";

--- a/packages/keychain/src/components/connect/Upgrade.tsx
+++ b/packages/keychain/src/components/connect/Upgrade.tsx
@@ -1,7 +1,7 @@
 import { LayoutContent, BoltIcon, CircleIcon } from "@cartridge/controller-ui";
 import { ExecutionContainer } from "@/components/ExecutionContainer";
 import { useConnection } from "@/hooks/connection";
-import { useUpgrade } from "../provider/upgrade";
+import { useUpgrade } from "../provider/use-upgrade";
 
 export const Upgrade = () => {
   const { controller } = useConnection();

--- a/packages/keychain/src/components/connect/buttons/auth-button.tsx
+++ b/packages/keychain/src/components/connect/buttons/auth-button.tsx
@@ -1,4 +1,4 @@
-import { useWallets } from "@/hooks/wallets";
+import { useWallets } from "@/hooks/use-wallets";
 import { AUTH_METHODS_LABELS } from "@/utils/connection/constants";
 import { allUseSameAuth } from "@/utils/controller";
 import { AuthOption } from "@cartridge/controller";

--- a/packages/keychain/src/components/connect/buttons/change-wallet.tsx
+++ b/packages/keychain/src/components/connect/buttons/change-wallet.tsx
@@ -1,5 +1,5 @@
 import { ErrorAlert } from "@/components/ErrorAlert";
-import { useWallets } from "@/hooks/wallets";
+import { useWallets } from "@/hooks/use-wallets";
 import { AUTH_METHODS_LABELS } from "@/utils/connection/constants";
 import { AuthOption } from "@cartridge/controller";
 import { formatAddress } from "@cartridge/controller-ui/utils";

--- a/packages/keychain/src/components/connect/create/ChooseSignupMethodForm.tsx
+++ b/packages/keychain/src/components/connect/create/ChooseSignupMethodForm.tsx
@@ -15,7 +15,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { SignupButton } from "../buttons/signup-button";
 import { credentialToAuth } from "../types";
 import { useUsernameValidation } from "./useUsernameValidation";
-import { useWallets } from "@/hooks/wallets";
+import { useWallets } from "@/hooks/use-wallets";
 
 export const INITIAL_OPTIONS: AuthOption[] = ["sms", "webauthn"];
 export const WALLET_OPTIONS: AuthOption[] = [

--- a/packages/keychain/src/components/connect/create/CreateController.test.tsx
+++ b/packages/keychain/src/components/connect/create/CreateController.test.tsx
@@ -58,7 +58,7 @@ vi.mock("@/hooks/connection", () => ({
   useControllerTheme: () => mockUseControllerTheme(),
 }));
 
-vi.mock("@/hooks/wallets", () => ({
+vi.mock("@/hooks/use-wallets", () => ({
   useWallets: () => mockUseWallets(),
 }));
 

--- a/packages/keychain/src/components/connect/create/external-wallet/index.ts
+++ b/packages/keychain/src/components/connect/create/external-wallet/index.ts
@@ -1,5 +1,5 @@
 import { useConnection } from "@/hooks/connection";
-import { useWallets } from "@/hooks/wallets";
+import { useWallets } from "@/hooks/use-wallets";
 import {
   AuthOption,
   ExternalWalletResponse,

--- a/packages/keychain/src/components/connect/create/useCreateController.ts
+++ b/packages/keychain/src/components/connect/create/useCreateController.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { STABLE_CONTROLLER } from "@/components/provider/upgrade";
+import { STABLE_CONTROLLER } from "@/components/provider/upgrade-context";
 import { DEFAULT_SESSION_DURATION, now } from "@/constants";
 import { useConnection } from "@/hooks/connection";
-import { useWallets } from "@/hooks/wallets";
+import { useWallets } from "@/hooks/use-wallets";
 import Controller from "@/utils/controller";
 import { TurnkeyWallet } from "@/wallets/social/turnkey";
 import {

--- a/packages/keychain/src/components/inventory/token/send/amount.tsx
+++ b/packages/keychain/src/components/inventory/token/send/amount.tsx
@@ -8,12 +8,14 @@ export function SendAmount({
   amount,
   submitted,
   setAmount,
+  setAmountInput,
   setError,
 }: {
   token: Token;
   amount: number | undefined;
   submitted: boolean;
   setAmount: (amount: number | undefined) => void;
+  setAmountInput: (amount: string | undefined) => void;
   setError: (error: Error | undefined) => void;
 }) {
   const conversion = useMemo(() => {
@@ -28,17 +30,20 @@ export function SendAmount({
     (e: React.MouseEvent<HTMLDivElement | HTMLButtonElement>) => {
       e.preventDefault();
       if (!token) return;
-      setAmount(parseFloat(token.balance.amount.toString()));
+      const max = token.balance.amount.toString();
+      setAmount(parseFloat(max));
+      setAmountInput(max);
     },
-    [token, setAmount],
+    [token, setAmount, setAmountInput],
   );
 
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const value = e.target.value;
       setAmount(value === "" ? undefined : Number(value));
+      setAmountInput(value === "" ? undefined : value);
     },
-    [setAmount],
+    [setAmount, setAmountInput],
   );
 
   if (!token) {

--- a/packages/keychain/src/components/inventory/token/send/send-drawer.tsx
+++ b/packages/keychain/src/components/inventory/token/send/send-drawer.tsx
@@ -15,6 +15,7 @@ import { Link, useSearchParams } from "react-router-dom";
 import { SendRecipient } from "@/components/modules/recipient";
 import { SendAmount } from "./amount";
 import { Disclosure } from "@cartridge/controller-ui";
+import { parseTokenAmount } from "@/utils/token-amount";
 
 export function SendTokenDrawer({
   disclosure,
@@ -35,6 +36,7 @@ export function SendTokenDrawer({
 
   const [to, setTo] = useState("");
   const [amount, setAmount] = useState<number | undefined>();
+  const [amountInput, setAmountInput] = useState<string | undefined>();
   const [amountError, setAmountError] = useState<Error | undefined>();
   const [toError, setToError] = useState<Error | undefined>();
   const [selectedToken, setSelectedToken] = useState<Token | undefined>(token);
@@ -52,13 +54,18 @@ export function SendTokenDrawer({
     ) {
       return "";
     } else {
+      const baseUnitAmount = parseTokenAmount(
+        amountInput,
+        selectedToken.metadata.decimals,
+      );
+      if (baseUnitAmount === undefined) {
+        return "";
+      }
+
       const sendParams = new URLSearchParams(searchParams);
       sendParams.set("tokenAddress", tokenAddress);
       sendParams.set("recipient", to);
-      sendParams.set(
-        "amount",
-        BigInt(amount * 10 ** selectedToken.metadata.decimals).toString(),
-      );
+      sendParams.set("amount", baseUnitAmount.toString());
       return `send?${sendParams.toString()}`;
     }
   }, [
@@ -68,6 +75,7 @@ export function SendTokenDrawer({
     toError,
     recipientLoading,
     amount,
+    amountInput,
     to,
     searchParams,
     tokenAddress,
@@ -88,9 +96,10 @@ export function SendTokenDrawer({
     (token: Token) => {
       setSelectedToken(token);
       setAmount(undefined);
+      setAmountInput(undefined);
       userSelectedToken.current = true;
     },
-    [setSelectedToken, setAmount],
+    [setSelectedToken, setAmount, setAmountInput],
   );
 
   if (!token) {
@@ -133,6 +142,7 @@ export function SendTokenDrawer({
             amount={amount}
             submitted={false}
             setAmount={setAmount}
+            setAmountInput={setAmountInput}
             setError={setAmountError}
           />
         )}

--- a/packages/keychain/src/components/provider/upgrade-context.ts
+++ b/packages/keychain/src/components/provider/upgrade-context.ts
@@ -1,0 +1,128 @@
+import { createContext, ReactNode } from "react";
+import { addAddressPadding, Call } from "starknet";
+import type { Chain } from "@cartridge/controller";
+import { ControllerError } from "@/utils/connection";
+import Controller from "@/utils/controller";
+
+export enum OutsideExecutionVersion {
+  V2,
+  V3,
+}
+
+export type ControllerVersionInfo = {
+  version: string;
+  hash: string;
+  outsideExecutionVersion: OutsideExecutionVersion;
+  changes: string[];
+};
+
+export const CONTROLLER_VERSIONS: ControllerVersionInfo[] = [
+  {
+    version: "1.0.4",
+    hash: "0x24a9edbfa7082accfceabf6a92d7160086f346d622f28741bf1c651c412c9ab",
+    outsideExecutionVersion: OutsideExecutionVersion.V2,
+    changes: [],
+  },
+  {
+    version: "1.0.5",
+    hash: "0x32e17891b6cc89e0c3595a3df7cee760b5993744dc8dfef2bd4d443e65c0f40",
+    outsideExecutionVersion: OutsideExecutionVersion.V2,
+    changes: ["Improved session token implementation"],
+  },
+  {
+    version: "1.0.6",
+    hash: "0x59e4405accdf565112fe5bf9058b51ab0b0e63665d280b816f9fe4119554b77",
+    outsideExecutionVersion: OutsideExecutionVersion.V3,
+    changes: [
+      "Support session key message signing",
+      "Support session guardians",
+      "Improve paymaster nonce management",
+    ],
+  },
+  {
+    version: "1.0.7",
+    hash: "0x3e0a04bab386eaa51a41abe93d8035dccc96bd9d216d44201266fe0b8ea1115",
+    outsideExecutionVersion: OutsideExecutionVersion.V3,
+    changes: ["Unified message signature verification"],
+  },
+  {
+    version: "1.0.8",
+    hash: "0x511dd75da368f5311134dee2356356ac4da1538d2ad18aa66d57c47e3757d59",
+    outsideExecutionVersion: OutsideExecutionVersion.V3,
+    changes: ["Improved session message signature"],
+  },
+  {
+    version: "1.0.9",
+    hash: "0x743c83c41ce99ad470aa308823f417b2141e02e04571f5c0004e743556e7faf",
+    outsideExecutionVersion: OutsideExecutionVersion.V3,
+    changes: ["Wildcard session support"],
+  },
+];
+
+export const STABLE_CONTROLLER = CONTROLLER_VERSIONS[5];
+export const BETA_CONTROLLER = CONTROLLER_VERSIONS[5];
+
+export const findVersion = (
+  classHash: string,
+): ControllerVersionInfo | undefined =>
+  CONTROLLER_VERSIONS.find(
+    (v) => addAddressPadding(v.hash) === addAddressPadding(classHash),
+  );
+
+/**
+ * Determines if an upgrade is available and returns the appropriate controller version
+ * @param currentVersion The current controller version
+ * @param isBeta Whether beta features are enabled
+ * @returns An object containing whether an upgrade is available and the target controller version
+ */
+export function determineUpgradePath(
+  currentVersion: ControllerVersionInfo | undefined,
+  isBeta: boolean,
+): { available: boolean; targetVersion: ControllerVersionInfo } {
+  const targetVersion = isBeta ? BETA_CONTROLLER : STABLE_CONTROLLER;
+
+  if (!currentVersion) {
+    return { available: false, targetVersion };
+  }
+
+  // Find the indices of the current and target versions in the CONTROLLER_VERSIONS array
+  const currentIndex = CONTROLLER_VERSIONS.findIndex(
+    (v) => v === currentVersion,
+  );
+  const targetIndex = CONTROLLER_VERSIONS.findIndex((v) => v === targetVersion);
+
+  // Only set available to true if the target controller is newer than the current one
+  const available = currentIndex !== -1 && targetIndex > currentIndex;
+
+  return { available, targetVersion };
+}
+
+export interface UpgradeInterface {
+  available: boolean;
+  current?: ControllerVersionInfo;
+  latest: ControllerVersionInfo;
+  calls: Call[];
+  isSynced: boolean;
+  isUpgrading: boolean;
+  error?: ControllerError;
+  onUpgrade: () => Promise<void>;
+  isBeta: boolean;
+}
+
+export const UpgradeContext = createContext<UpgradeInterface | undefined>(
+  undefined,
+);
+
+export interface UpgradeProviderProps {
+  controller?: Controller;
+  /** Chains the dapp explicitly configured (see
+   *  `ConnectionContextValue.configuredChains`). The account's class is checked on
+   *  each of them - not just the controller's active chain - so an upgrade is offered
+   *  for e.g. an appchain still on a pre-wildcard class while the account is already
+   *  up to date on the settlement chain. */
+  chains?: Chain[];
+  children: ReactNode;
+}
+
+/** A chain whose account is behind the target version. */
+export type OutdatedChain = { rpcUrl: string; version: ControllerVersionInfo };

--- a/packages/keychain/src/components/provider/upgrade.test.tsx
+++ b/packages/keychain/src/components/provider/upgrade.test.tsx
@@ -8,10 +8,10 @@ import {
   ControllerVersionInfo,
   OutsideExecutionVersion,
   STABLE_CONTROLLER,
-  UpgradeProvider,
   determineUpgradePath,
-  useUpgrade,
-} from "./upgrade";
+} from "./upgrade-context";
+import { UpgradeProvider } from "./upgrade";
+import { useUpgrade } from "./use-upgrade";
 import { ReactNode } from "react";
 import { PostHogContext, PostHogWrapper } from "@cartridge/controller-ui/utils";
 import Controller from "@/utils/controller";

--- a/packages/keychain/src/components/provider/upgrade.tsx
+++ b/packages/keychain/src/components/provider/upgrade.tsx
@@ -1,80 +1,21 @@
-import React, {
-  createContext,
-  useContext,
-  useState,
-  useEffect,
-  useMemo,
-  useCallback,
-} from "react";
+import React, { useState, useEffect, useMemo, useCallback } from "react";
 import { JsCall } from "@cartridge/controller-wasm";
-import { addAddressPadding, Call, RpcProvider } from "starknet";
-import type { Chain } from "@cartridge/controller";
+import { RpcProvider } from "starknet";
 import { ControllerError } from "@/utils/connection";
 import Controller from "@/utils/controller";
 import { usePostHog } from "./posthog";
-
-export enum OutsideExecutionVersion {
-  V2,
-  V3,
-}
-
-export type ControllerVersionInfo = {
-  version: string;
-  hash: string;
-  outsideExecutionVersion: OutsideExecutionVersion;
-  changes: string[];
-};
-
-export const CONTROLLER_VERSIONS: ControllerVersionInfo[] = [
-  {
-    version: "1.0.4",
-    hash: "0x24a9edbfa7082accfceabf6a92d7160086f346d622f28741bf1c651c412c9ab",
-    outsideExecutionVersion: OutsideExecutionVersion.V2,
-    changes: [],
-  },
-  {
-    version: "1.0.5",
-    hash: "0x32e17891b6cc89e0c3595a3df7cee760b5993744dc8dfef2bd4d443e65c0f40",
-    outsideExecutionVersion: OutsideExecutionVersion.V2,
-    changes: ["Improved session token implementation"],
-  },
-  {
-    version: "1.0.6",
-    hash: "0x59e4405accdf565112fe5bf9058b51ab0b0e63665d280b816f9fe4119554b77",
-    outsideExecutionVersion: OutsideExecutionVersion.V3,
-    changes: [
-      "Support session key message signing",
-      "Support session guardians",
-      "Improve paymaster nonce management",
-    ],
-  },
-  {
-    version: "1.0.7",
-    hash: "0x3e0a04bab386eaa51a41abe93d8035dccc96bd9d216d44201266fe0b8ea1115",
-    outsideExecutionVersion: OutsideExecutionVersion.V3,
-    changes: ["Unified message signature verification"],
-  },
-  {
-    version: "1.0.8",
-    hash: "0x511dd75da368f5311134dee2356356ac4da1538d2ad18aa66d57c47e3757d59",
-    outsideExecutionVersion: OutsideExecutionVersion.V3,
-    changes: ["Improved session message signature"],
-  },
-  {
-    version: "1.0.9",
-    hash: "0x743c83c41ce99ad470aa308823f417b2141e02e04571f5c0004e743556e7faf",
-    outsideExecutionVersion: OutsideExecutionVersion.V3,
-    changes: ["Wildcard session support"],
-  },
-];
-
-export const STABLE_CONTROLLER = CONTROLLER_VERSIONS[5];
-export const BETA_CONTROLLER = CONTROLLER_VERSIONS[5];
-
-const findVersion = (classHash: string): ControllerVersionInfo | undefined =>
-  CONTROLLER_VERSIONS.find(
-    (v) => addAddressPadding(v.hash) === addAddressPadding(classHash),
-  );
+import {
+  BETA_CONTROLLER,
+  ControllerVersionInfo,
+  determineUpgradePath,
+  findVersion,
+  OutdatedChain,
+  OutsideExecutionVersion,
+  STABLE_CONTROLLER,
+  UpgradeContext,
+  UpgradeInterface,
+  UpgradeProviderProps,
+} from "./upgrade-context";
 
 /** The controller version deployed at `address` on a chain — or, when not deployed
  *  there yet, the version it would counterfactually deploy as (its creation class). */
@@ -91,64 +32,6 @@ async function deployedVersion(
     }
     throw e;
   }
-}
-
-/** A chain whose account is behind the target version. */
-type OutdatedChain = { rpcUrl: string; version: ControllerVersionInfo };
-
-/**
- * Determines if an upgrade is available and returns the appropriate controller version
- * @param currentVersion The current controller version
- * @param isBeta Whether beta features are enabled
- * @returns An object containing whether an upgrade is available and the target controller version
- */
-export function determineUpgradePath(
-  currentVersion: ControllerVersionInfo | undefined,
-  isBeta: boolean,
-): { available: boolean; targetVersion: ControllerVersionInfo } {
-  const targetVersion = isBeta ? BETA_CONTROLLER : STABLE_CONTROLLER;
-
-  if (!currentVersion) {
-    return { available: false, targetVersion };
-  }
-
-  // Find the indices of the current and target versions in the CONTROLLER_VERSIONS array
-  const currentIndex = CONTROLLER_VERSIONS.findIndex(
-    (v) => v === currentVersion,
-  );
-  const targetIndex = CONTROLLER_VERSIONS.findIndex((v) => v === targetVersion);
-
-  // Only set available to true if the target controller is newer than the current one
-  const available = currentIndex !== -1 && targetIndex > currentIndex;
-
-  return { available, targetVersion };
-}
-
-export interface UpgradeInterface {
-  available: boolean;
-  current?: ControllerVersionInfo;
-  latest: ControllerVersionInfo;
-  calls: Call[];
-  isSynced: boolean;
-  isUpgrading: boolean;
-  error?: ControllerError;
-  onUpgrade: () => Promise<void>;
-  isBeta: boolean;
-}
-
-export const UpgradeContext = createContext<UpgradeInterface | undefined>(
-  undefined,
-);
-
-export interface UpgradeProviderProps {
-  controller?: Controller;
-  /** Chains the dapp explicitly configured (see
-   *  `ConnectionContextValue.configuredChains`). The account's class is checked on
-   *  each of them — not just the controller's active chain — so an upgrade is offered
-   *  for e.g. an appchain still on a pre-wildcard class while the account is already
-   *  up to date on the settlement chain. */
-  chains?: Chain[];
-  children: React.ReactNode;
 }
 
 export const UpgradeProvider: React.FC<UpgradeProviderProps> = ({
@@ -331,12 +214,4 @@ export const UpgradeProvider: React.FC<UpgradeProviderProps> = ({
   return (
     <UpgradeContext.Provider value={value}>{children}</UpgradeContext.Provider>
   );
-};
-
-export const useUpgrade = (): UpgradeInterface => {
-  const context = useContext(UpgradeContext);
-  if (!context) {
-    throw new Error("useUpgrade must be used within an UpgradeProvider");
-  }
-  return context;
 };

--- a/packages/keychain/src/components/provider/use-upgrade.ts
+++ b/packages/keychain/src/components/provider/use-upgrade.ts
@@ -1,0 +1,10 @@
+import { useContext } from "react";
+import { UpgradeContext, UpgradeInterface } from "./upgrade-context";
+
+export const useUpgrade = (): UpgradeInterface => {
+  const context = useContext(UpgradeContext);
+  if (!context) {
+    throw new Error("useUpgrade must be used within an UpgradeProvider");
+  }
+  return context;
+};

--- a/packages/keychain/src/components/purchase/review/onchain-cost.stories.tsx
+++ b/packages/keychain/src/components/purchase/review/onchain-cost.stories.tsx
@@ -4,7 +4,7 @@ import {
   OnchainPurchaseContext,
   OnchainPurchaseContextType,
   TokenOption,
-} from "@/context/starterpack/onchain-purchase";
+} from "@/context/starterpack/onchain-purchase-context";
 import { ReactNode } from "react";
 
 // USDC address with leading zeros (tests normalization)

--- a/packages/keychain/src/components/purchase/wallet/wallet.stories.tsx
+++ b/packages/keychain/src/components/purchase/wallet/wallet.stories.tsx
@@ -2,12 +2,12 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { SelectWallet } from "./wallet";
 import { ReactNode, useEffect } from "react";
 import { Routes, Route, useNavigate } from "react-router-dom";
-import { StarterpackContext } from "@/context/starterpack/starterpack";
+import { StarterpackContext } from "@/context/starterpack/starterpack-context";
 import {
   OnchainPurchaseContext,
   OnchainPurchaseContextType,
   TokenOption,
-} from "@/context/starterpack/onchain-purchase";
+} from "@/context/starterpack/onchain-purchase-context";
 
 // Mock starterpack context
 const mockStarterpackValue = {

--- a/packages/keychain/src/components/settings/signers/add-signer/add-signer.tsx
+++ b/packages/keychain/src/components/settings/signers/add-signer/add-signer.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useController } from "@/hooks/controller";
-import { useWallets } from "@/hooks/wallets";
+import { useWallets } from "@/hooks/use-wallets";
 import {
   credentialToAddress,
   credentialToAuth,

--- a/packages/keychain/src/components/slot/crypto-fund.test.ts
+++ b/packages/keychain/src/components/slot/crypto-fund.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseTokenAmount } from "./crypto-fund";
+import { parseTokenAmount } from "@/utils/token-amount";
 
 describe("parseTokenAmount", () => {
   it("parses whole token amounts", () => {
@@ -10,6 +10,7 @@ describe("parseTokenAmount", () => {
   it("parses fractional token amounts", () => {
     expect(parseTokenAmount("10.25", 6)).toBe(10_250_000n);
     expect(parseTokenAmount("0.000001", 6)).toBe(1n);
+    expect(parseTokenAmount("0.0045", 18)).toBe(4_500_000_000_000_000n);
   });
 
   it("rejects invalid precision", () => {

--- a/packages/keychain/src/components/slot/crypto-fund.tsx
+++ b/packages/keychain/src/components/slot/crypto-fund.tsx
@@ -48,6 +48,7 @@ import { STRK_CONTRACT_ADDRESS } from "@cartridge/controller-ui/utils";
 import { ErrorAlert } from "@/components/ErrorAlert";
 import { createStarknetCryptoPayment } from "@/hooks/payments/crypto";
 import { Team } from "./teams";
+import { parseTokenAmount } from "@/utils/token-amount";
 
 type SlotFundingToken = {
   key: "USDC" | "STRK";
@@ -491,26 +492,6 @@ function ExternalWalletProvider({ children }: PropsWithChildren) {
       {children}
     </StarknetConfig>
   );
-}
-
-export function parseTokenAmount(
-  value: string,
-  decimals: number,
-): bigint | undefined {
-  const trimmed = value.trim();
-  if (!trimmed || !/^\d+(\.\d*)?$/.test(trimmed)) {
-    return undefined;
-  }
-
-  const [whole, fractional = ""] = trimmed.split(".");
-  if (fractional.length > decimals) {
-    return undefined;
-  }
-
-  const base = 10n ** BigInt(decimals);
-  const wholeAmount = BigInt(whole) * base;
-  const fractionalAmount = BigInt(fractional.padEnd(decimals, "0") || "0");
-  return wholeAmount + fractionalAmount;
 }
 
 async function fetchTokenBalance(

--- a/packages/keychain/src/components/transaction/ConfirmTransaction.test.tsx
+++ b/packages/keychain/src/components/transaction/ConfirmTransaction.test.tsx
@@ -24,7 +24,7 @@ vi.mock("@/hooks/tokens", () => ({
 }));
 
 // Mock the upgrade provider hook
-vi.mock("@/components/provider/upgrade", () => ({
+vi.mock("@/components/provider/use-upgrade", () => ({
   useUpgrade: vi.fn(() => ({
     isUpgradeAvailable: false,
     isUpgrading: false,

--- a/packages/keychain/src/context/starterpack/credit-purchase-context.ts
+++ b/packages/keychain/src/context/starterpack/credit-purchase-context.ts
@@ -1,0 +1,29 @@
+import { createContext, ReactNode } from "react";
+import {
+  CoinflowStarterpackIntent,
+  CoinflowStarterpackQuote,
+} from "@/hooks/payments/coinflow";
+
+export interface CreditPurchaseContextType {
+  // USD amount selection
+  usdAmount: number;
+  setUsdAmount: (amount: number) => void;
+
+  // Coinflow state
+  coinflowIntent: CoinflowStarterpackIntent | undefined;
+  coinflowQuote: CoinflowStarterpackQuote | undefined;
+  isCoinflowQuoteLoading: boolean;
+  coinflowEnv: "prod" | "sandbox";
+  isCoinflowLoading: boolean;
+
+  // Actions
+  onCreditCardPurchase: () => Promise<void>;
+}
+
+export const CreditPurchaseContext = createContext<
+  CreditPurchaseContextType | undefined
+>(undefined);
+
+export interface CreditPurchaseProviderProps {
+  children: ReactNode;
+}

--- a/packages/keychain/src/context/starterpack/credit-purchase.tsx
+++ b/packages/keychain/src/context/starterpack/credit-purchase.tsx
@@ -1,46 +1,19 @@
-import {
-  createContext,
-  useContext,
-  useState,
-  useCallback,
-  useEffect,
-  ReactNode,
-} from "react";
+import { useState, useCallback, useEffect } from "react";
 import { useConnection } from "@/hooks/connection";
 import useCoinflowPayment, {
   CoinflowStarterpackIntent,
-  CoinflowStarterpackQuote,
   useCoinflowStarterpackQuote,
 } from "@/hooks/payments/coinflow";
 import { USD_AMOUNTS } from "@/components/funding/AmountSelection";
-import { useStarterpackContext } from "./starterpack";
-import { useOnchainPurchaseContext } from "./onchain-purchase";
+import { useStarterpackContext } from "./use-starterpack-context";
+import { useOnchainPurchaseContext } from "./use-onchain-purchase-context";
 import { getCurrentReferral } from "@/utils/referral";
 import { isOnchainStarterpack } from "./types";
-
-export interface CreditPurchaseContextType {
-  // USD amount selection
-  usdAmount: number;
-  setUsdAmount: (amount: number) => void;
-
-  // Coinflow state
-  coinflowIntent: CoinflowStarterpackIntent | undefined;
-  coinflowQuote: CoinflowStarterpackQuote | undefined;
-  isCoinflowQuoteLoading: boolean;
-  coinflowEnv: "prod" | "sandbox";
-  isCoinflowLoading: boolean;
-
-  // Actions
-  onCreditCardPurchase: () => Promise<void>;
-}
-
-export const CreditPurchaseContext = createContext<
-  CreditPurchaseContextType | undefined
->(undefined);
-
-export interface CreditPurchaseProviderProps {
-  children: ReactNode;
-}
+import {
+  CreditPurchaseContext,
+  CreditPurchaseContextType,
+  CreditPurchaseProviderProps,
+} from "./credit-purchase-context";
 
 export const CreditPurchaseProvider = ({
   children,
@@ -149,14 +122,4 @@ export const CreditPurchaseProvider = ({
       {children}
     </CreditPurchaseContext.Provider>
   );
-};
-
-export const useCreditPurchaseContext = () => {
-  const context = useContext(CreditPurchaseContext);
-  if (!context) {
-    throw new Error(
-      "useCreditPurchaseContext must be used within CreditPurchaseProvider",
-    );
-  }
-  return context;
 };

--- a/packages/keychain/src/context/starterpack/index.tsx
+++ b/packages/keychain/src/context/starterpack/index.tsx
@@ -18,25 +18,22 @@ export {
 } from "./types";
 
 // Starterpack context (shared base)
-export { StarterpackProvider, useStarterpackContext } from "./starterpack";
-export type { StarterpackContextType } from "./starterpack";
+export { StarterpackProvider } from "./starterpack";
+export { useStarterpackContext } from "./use-starterpack-context";
+export type { StarterpackContextType } from "./starterpack-context";
 
 // Onchain purchase context
-export {
-  OnchainPurchaseProvider,
-  useOnchainPurchaseContext,
-} from "./onchain-purchase";
+export { OnchainPurchaseProvider } from "./onchain-purchase";
+export { useOnchainPurchaseContext } from "./use-onchain-purchase-context";
 export type {
   OnchainPurchaseContextType,
   TokenOption,
-} from "./onchain-purchase";
+} from "./onchain-purchase-context";
 
 // Credit purchase context
-export {
-  CreditPurchaseProvider,
-  useCreditPurchaseContext,
-} from "./credit-purchase";
-export type { CreditPurchaseContextType } from "./credit-purchase";
+export { CreditPurchaseProvider } from "./credit-purchase";
+export { useCreditPurchaseContext } from "./use-credit-purchase-context";
+export type { CreditPurchaseContextType } from "./credit-purchase-context";
 
 // Composed provider for all starterpack contexts
 import { ReactNode } from "react";

--- a/packages/keychain/src/context/starterpack/onchain-purchase-context.ts
+++ b/packages/keychain/src/context/starterpack/onchain-purchase-context.ts
@@ -1,0 +1,122 @@
+import { createContext, ReactNode } from "react";
+import { ExternalPlatform, ExternalWallet } from "@cartridge/controller";
+import { CoinbaseOnrampStatus } from "@/utils/api";
+import { SubmitCoinbaseLimitsUpgradeInput } from "@/utils/api";
+import { Explorer } from "@/hooks/starterpack/layerswap";
+import {
+  COINBASE_APPLE_PAY_MIN_USD,
+  type TokenOption,
+  type CoinbaseOrderResult,
+  type CoinbaseTransactionResult,
+  type CoinbaseQuoteResult,
+  type CoinbaseLimitsResult,
+} from "@/hooks/starterpack";
+import { SwapQuote } from "@/utils/ekubo";
+import { Item } from "./types";
+
+export type { TokenOption } from "@/hooks/starterpack";
+export { COINBASE_APPLE_PAY_MIN_USD };
+
+export interface OnchainPurchaseContextType {
+  // Purchase items
+  purchaseItems: Item[];
+  purchaseDescription: string | undefined;
+
+  // Quantity management
+  quantity: number;
+  incrementQuantity: () => void;
+  decrementQuantity: () => void;
+
+  // Conditional bundles / social claim
+  setIssueSignature: (signature: string[] | undefined) => void;
+
+  // Wallet state
+  selectedWallet: ExternalWallet | undefined;
+  selectedPlatform: ExternalPlatform | undefined;
+  walletAddress: string | undefined;
+  clearSelectedWallet: () => void;
+
+  // Token selection
+  availableTokens: TokenOption[];
+  selectedToken: TokenOption | undefined;
+  setSelectedToken: (token: TokenOption | undefined) => void;
+  convertedPrice: {
+    amount: bigint;
+    quantity: number;
+    tokenMetadata: { symbol: string; decimals: number };
+  } | null;
+  swapQuote: SwapQuote | null;
+  isFetchingConversion: boolean;
+  isTokenSelectionLocked: boolean;
+  conversionError: Error | null;
+
+  // USD amount (derived from quote)
+  usdAmount: number;
+
+  // Layerswap state (for future use)
+  layerswapFees: string | undefined;
+  isFetchingFees: boolean;
+  isSendingDeposit: boolean;
+  swapId: string | undefined;
+  explorer: Explorer | undefined;
+  requestedAmount: number | undefined;
+  depositAmount: number | undefined; // Computed: requestedAmount + fees
+  setRequestedAmount: (amount: number) => void;
+  feeEstimationError: Error | null;
+
+  // Coinbase / Apple Pay state
+  isApplePaySelected: boolean;
+  isCoinflowSelected: boolean;
+  paymentLink: string | undefined;
+  isCreatingOrder: boolean;
+  coinbaseQuote: CoinbaseQuoteResult | undefined;
+  isFetchingCoinbaseQuote: boolean;
+  orderId: string | undefined;
+  orderStatus: CoinbaseOnrampStatus | undefined;
+  orderTxHash: string | undefined;
+  popupClosed: boolean;
+  paymentSuccess: boolean;
+  coinbaseLsSwapId: string | undefined;
+  /** Quantity we auto-bumped to so Apple Pay's per-transaction minimum is met. Undefined when no bump is active. */
+  applePayMinQuantity: number | undefined;
+
+  // Coinbase limits-upgrade state
+  coinbaseLimits: CoinbaseLimitsResult | undefined;
+  isFetchingCoinbaseLimits: boolean;
+  isSubmittingLimitsUpgrade: boolean;
+
+  // Actions
+  onOnchainPurchase: () => Promise<void>;
+  onExternalConnect: (
+    wallet: ExternalWallet,
+    platform: ExternalPlatform,
+    chainId?: string,
+  ) => Promise<string | undefined>;
+  onSendDeposit: () => Promise<void>;
+  waitForDeposit: (swapId: string) => Promise<string>;
+  onApplePaySelect: () => void;
+  onCoinflowSelect: () => void;
+  onCreateCoinbaseOrder: (opts?: {
+    force?: boolean;
+  }) => Promise<CoinbaseOrderResult | undefined>;
+  openPaymentPopup: (opts?: {
+    paymentLink?: string;
+    orderId?: string;
+    preOpenedPopup?: Window | null;
+  }) => void;
+  closePaymentPopup: () => void;
+  resetCoinbasePurchase: () => void;
+  getTransactions: (username: string) => Promise<CoinbaseTransactionResult[]>;
+  fetchCoinbaseLimits: () => Promise<CoinbaseLimitsResult | undefined>;
+  submitCoinbaseLimitsUpgrade: (
+    input: SubmitCoinbaseLimitsUpgradeInput,
+  ) => Promise<CoinbaseLimitsResult | undefined>;
+}
+
+export const OnchainPurchaseContext = createContext<
+  OnchainPurchaseContextType | undefined
+>(undefined);
+
+export interface OnchainPurchaseProviderProps {
+  children: ReactNode;
+}

--- a/packages/keychain/src/context/starterpack/onchain-purchase.tsx
+++ b/packages/keychain/src/context/starterpack/onchain-purchase.tsx
@@ -1,12 +1,4 @@
-import {
-  createContext,
-  useContext,
-  useState,
-  useCallback,
-  useEffect,
-  useMemo,
-  ReactNode,
-} from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import { useLocation } from "react-router-dom";
 import { ExternalPlatform, ExternalWallet } from "@cartridge/controller";
 import { useConnection } from "@/hooks/connection";
@@ -14,19 +6,11 @@ import { usdcToUsd } from "@/utils/starterpack";
 import { uint256, Call, num, cairo, hash, shortString } from "starknet";
 import { isOnchainStarterpack } from "./types";
 import { getCurrentReferral } from "@/utils/referral";
-import {
-  prepareSwapCalls,
-  fetchSwapQuote,
-  isQuoteChain,
-  type SwapQuote,
-} from "@/utils/ekubo";
+import { prepareSwapCalls, fetchSwapQuote, isQuoteChain } from "@/utils/ekubo";
 import { Item } from "./types";
-import { useStarterpackContext } from "./starterpack";
+import { useStarterpackContext } from "./use-starterpack-context";
 import { ExternalWalletError } from "@/utils/errors";
-import {
-  CoinbaseOnrampStatus,
-  type SubmitCoinbaseLimitsUpgradeInput,
-} from "@/utils/api";
+import { CoinbaseOnrampStatus } from "@/utils/api";
 import {
   useQuantity,
   useExternalWallet,
@@ -34,120 +18,13 @@ import {
   useTokenSelection,
   useCoinbase,
   COINBASE_APPLE_PAY_MIN_USD,
-  type TokenOption,
-  type CoinbaseOrderResult,
-  type CoinbaseTransactionResult,
-  type CoinbaseQuoteResult,
-  type CoinbaseLimitsResult,
 } from "@/hooks/starterpack";
 import { useSocialClaimConnection } from "@/hooks/starterpack/social";
-import { Explorer } from "@/hooks/starterpack/layerswap";
-
-export type { TokenOption } from "@/hooks/starterpack";
-
-export interface OnchainPurchaseContextType {
-  // Purchase items
-  purchaseItems: Item[];
-  purchaseDescription: string | undefined;
-
-  // Quantity management
-  quantity: number;
-  incrementQuantity: () => void;
-  decrementQuantity: () => void;
-
-  // Conditional bundles / social claim
-  setIssueSignature: (signature: string[] | undefined) => void;
-
-  // Wallet state
-  selectedWallet: ExternalWallet | undefined;
-  selectedPlatform: ExternalPlatform | undefined;
-  walletAddress: string | undefined;
-  clearSelectedWallet: () => void;
-
-  // Token selection
-  availableTokens: TokenOption[];
-  selectedToken: TokenOption | undefined;
-  setSelectedToken: (token: TokenOption | undefined) => void;
-  convertedPrice: {
-    amount: bigint;
-    quantity: number;
-    tokenMetadata: { symbol: string; decimals: number };
-  } | null;
-  swapQuote: SwapQuote | null;
-  isFetchingConversion: boolean;
-  isTokenSelectionLocked: boolean;
-  conversionError: Error | null;
-
-  // USD amount (derived from quote)
-  usdAmount: number;
-
-  // Layerswap state (for future use)
-  layerswapFees: string | undefined;
-  isFetchingFees: boolean;
-  isSendingDeposit: boolean;
-  swapId: string | undefined;
-  explorer: Explorer | undefined;
-  requestedAmount: number | undefined;
-  depositAmount: number | undefined; // Computed: requestedAmount + fees
-  setRequestedAmount: (amount: number) => void;
-  feeEstimationError: Error | null;
-
-  // Coinbase / Apple Pay state
-  isApplePaySelected: boolean;
-  isCoinflowSelected: boolean;
-  paymentLink: string | undefined;
-  isCreatingOrder: boolean;
-  coinbaseQuote: CoinbaseQuoteResult | undefined;
-  isFetchingCoinbaseQuote: boolean;
-  orderId: string | undefined;
-  orderStatus: CoinbaseOnrampStatus | undefined;
-  orderTxHash: string | undefined;
-  popupClosed: boolean;
-  paymentSuccess: boolean;
-  coinbaseLsSwapId: string | undefined;
-  /** Quantity we auto-bumped to so Apple Pay's per-transaction minimum is met. Undefined when no bump is active. */
-  applePayMinQuantity: number | undefined;
-
-  // Coinbase limits-upgrade state
-  coinbaseLimits: CoinbaseLimitsResult | undefined;
-  isFetchingCoinbaseLimits: boolean;
-  isSubmittingLimitsUpgrade: boolean;
-
-  // Actions
-  onOnchainPurchase: () => Promise<void>;
-  onExternalConnect: (
-    wallet: ExternalWallet,
-    platform: ExternalPlatform,
-    chainId?: string,
-  ) => Promise<string | undefined>;
-  onSendDeposit: () => Promise<void>;
-  waitForDeposit: (swapId: string) => Promise<string>;
-  onApplePaySelect: () => void;
-  onCoinflowSelect: () => void;
-  onCreateCoinbaseOrder: (opts?: {
-    force?: boolean;
-  }) => Promise<CoinbaseOrderResult | undefined>;
-  openPaymentPopup: (opts?: {
-    paymentLink?: string;
-    orderId?: string;
-    preOpenedPopup?: Window | null;
-  }) => void;
-  closePaymentPopup: () => void;
-  resetCoinbasePurchase: () => void;
-  getTransactions: (username: string) => Promise<CoinbaseTransactionResult[]>;
-  fetchCoinbaseLimits: () => Promise<CoinbaseLimitsResult | undefined>;
-  submitCoinbaseLimitsUpgrade: (
-    input: SubmitCoinbaseLimitsUpgradeInput,
-  ) => Promise<CoinbaseLimitsResult | undefined>;
-}
-
-export const OnchainPurchaseContext = createContext<
-  OnchainPurchaseContextType | undefined
->(undefined);
-
-export interface OnchainPurchaseProviderProps {
-  children: ReactNode;
-}
+import {
+  OnchainPurchaseContext,
+  OnchainPurchaseContextType,
+  OnchainPurchaseProviderProps,
+} from "./onchain-purchase-context";
 
 export const OnchainPurchaseProvider = ({
   children,
@@ -841,14 +718,4 @@ export const OnchainPurchaseProvider = ({
       {children}
     </OnchainPurchaseContext.Provider>
   );
-};
-
-export const useOnchainPurchaseContext = () => {
-  const context = useContext(OnchainPurchaseContext);
-  if (!context) {
-    throw new Error(
-      "useOnchainPurchaseContext must be used within OnchainPurchaseProvider",
-    );
-  }
-  return context;
 };

--- a/packages/keychain/src/context/starterpack/starterpack-context.ts
+++ b/packages/keychain/src/context/starterpack/starterpack-context.ts
@@ -1,0 +1,55 @@
+import { createContext, ReactNode } from "react";
+import { MerkleDropDisplayOptions } from "@/hooks/starterpack";
+import { SocialClaimConditions } from "@/hooks/starterpack/bundle";
+import { SocialClaimOptions } from "@cartridge/controller";
+import { StarterpackDetails, Item } from "./types";
+
+export interface StarterpackContextType {
+  // Registry contract address
+  registryAddress: string | undefined;
+
+  // Bundle identification (starterpack V2)
+  bundleId: number | undefined;
+  setBundle: (
+    id: number,
+    registryAddress: string,
+    socialClaimOptions?: SocialClaimOptions,
+  ) => void;
+
+  // Starterpack identification
+  starterpackId: string | number | undefined;
+  setStarterpack: (id: string | number, registryAddress: string) => void;
+
+  // Merkle drop identification
+  merkleDropKeys: string[] | undefined;
+  setMerkleDrops: (keys: string[], options?: MerkleDropDisplayOptions) => void;
+
+  // Starterpack details (loaded from backend or onchain)
+  starterpackDetails: StarterpackDetails | undefined;
+  isStarterpackLoading: boolean;
+
+  // Claim items (can be enriched with quantities for display)
+  claimItems: Item[];
+  setClaimItems: (items: Item[]) => void;
+
+  // Transaction state
+  transactionHash: string | undefined;
+  setTransactionHash: (hash: string) => void;
+
+  // Error handling
+  displayError: Error | undefined;
+  setDisplayError: (error: Error | undefined) => void;
+  clearError: () => void;
+
+  // Conditional bundles info
+  socialClaimOptions: SocialClaimOptions | undefined;
+  socialClaimConditions: SocialClaimConditions | undefined;
+}
+
+export const StarterpackContext = createContext<
+  StarterpackContextType | undefined
+>(undefined);
+
+export interface StarterpackProviderProps {
+  children: ReactNode;
+}

--- a/packages/keychain/src/context/starterpack/starterpack.tsx
+++ b/packages/keychain/src/context/starterpack/starterpack.tsx
@@ -1,11 +1,4 @@
-import {
-  createContext,
-  useContext,
-  useState,
-  useCallback,
-  useEffect,
-  ReactNode,
-} from "react";
+import { useState, useCallback, useEffect } from "react";
 import {
   MerkleDropDisplayOptions,
   useClaimMerkleDrops,
@@ -17,61 +10,13 @@ import {
   Item,
   ItemType,
 } from "./types";
-import {
-  useBundleConditions,
-  SocialClaimConditions,
-} from "@/hooks/starterpack/bundle";
+import { useBundleConditions } from "@/hooks/starterpack/bundle";
 import { SocialClaimOptions } from "@cartridge/controller";
-
-export interface StarterpackContextType {
-  // Registry contract address
-  registryAddress: string | undefined;
-
-  // Bundle identification (starterpack V2)
-  bundleId: number | undefined;
-  setBundle: (
-    id: number,
-    registryAddress: string,
-    socialClaimOptions?: SocialClaimOptions,
-  ) => void;
-
-  // Starterpack identification
-  starterpackId: string | number | undefined;
-  setStarterpack: (id: string | number, registryAddress: string) => void;
-
-  // Merkle drop identification
-  merkleDropKeys: string[] | undefined;
-  setMerkleDrops: (keys: string[], options?: MerkleDropDisplayOptions) => void;
-
-  // Starterpack details (loaded from backend or onchain)
-  starterpackDetails: StarterpackDetails | undefined;
-  isStarterpackLoading: boolean;
-
-  // Claim items (can be enriched with quantities for display)
-  claimItems: Item[];
-  setClaimItems: (items: Item[]) => void;
-
-  // Transaction state
-  transactionHash: string | undefined;
-  setTransactionHash: (hash: string) => void;
-
-  // Error handling
-  displayError: Error | undefined;
-  setDisplayError: (error: Error | undefined) => void;
-  clearError: () => void;
-
-  // Conditional bundles info
-  socialClaimOptions: SocialClaimOptions | undefined;
-  socialClaimConditions: SocialClaimConditions | undefined;
-}
-
-export const StarterpackContext = createContext<
-  StarterpackContextType | undefined
->(undefined);
-
-export interface StarterpackProviderProps {
-  children: ReactNode;
-}
+import {
+  StarterpackContext,
+  StarterpackContextType,
+  StarterpackProviderProps,
+} from "./starterpack-context";
 
 export const StarterpackProvider = ({ children }: StarterpackProviderProps) => {
   const [registryAddress, setRegistryAddress] = useState<string | undefined>();
@@ -271,14 +216,4 @@ export const StarterpackProvider = ({ children }: StarterpackProviderProps) => {
       {children}
     </StarterpackContext.Provider>
   );
-};
-
-export const useStarterpackContext = () => {
-  const context = useContext(StarterpackContext);
-  if (!context) {
-    throw new Error(
-      "useStarterpackContext must be used within StarterpackProvider",
-    );
-  }
-  return context;
 };

--- a/packages/keychain/src/context/starterpack/use-credit-purchase-context.ts
+++ b/packages/keychain/src/context/starterpack/use-credit-purchase-context.ts
@@ -1,0 +1,12 @@
+import { useContext } from "react";
+import { CreditPurchaseContext } from "./credit-purchase-context";
+
+export const useCreditPurchaseContext = () => {
+  const context = useContext(CreditPurchaseContext);
+  if (!context) {
+    throw new Error(
+      "useCreditPurchaseContext must be used within CreditPurchaseProvider",
+    );
+  }
+  return context;
+};

--- a/packages/keychain/src/context/starterpack/use-onchain-purchase-context.ts
+++ b/packages/keychain/src/context/starterpack/use-onchain-purchase-context.ts
@@ -1,0 +1,12 @@
+import { useContext } from "react";
+import { OnchainPurchaseContext } from "./onchain-purchase-context";
+
+export const useOnchainPurchaseContext = () => {
+  const context = useContext(OnchainPurchaseContext);
+  if (!context) {
+    throw new Error(
+      "useOnchainPurchaseContext must be used within OnchainPurchaseProvider",
+    );
+  }
+  return context;
+};

--- a/packages/keychain/src/context/starterpack/use-starterpack-context.ts
+++ b/packages/keychain/src/context/starterpack/use-starterpack-context.ts
@@ -1,0 +1,12 @@
+import { useContext } from "react";
+import { StarterpackContext } from "./starterpack-context";
+
+export const useStarterpackContext = () => {
+  const context = useContext(StarterpackContext);
+  if (!context) {
+    throw new Error(
+      "useStarterpackContext must be used within StarterpackProvider",
+    );
+  }
+  return context;
+};

--- a/packages/keychain/src/hooks/keychain-wallets.ts
+++ b/packages/keychain/src/hooks/keychain-wallets.ts
@@ -1,0 +1,113 @@
+import { ExternalWalletResponse, WalletAdapter } from "@cartridge/controller";
+import { getAddress } from "ethers/address";
+import { ParentMethods } from "./connection";
+import { ExternalWalletError } from "@/utils/errors";
+
+/**
+ * Service running in the keychain iframe to handle signing requests.
+ * It decides whether to use an embedded wallet or delegate to the
+ * external WalletBridge in the parent controller window via penpal.
+ */
+export class KeychainWallets {
+  private parent: ParentMethods;
+  private embeddedWalletsByAddress: Map<string, WalletAdapter> = new Map();
+
+  // Method to set the parent connection once established
+  constructor(parent: ParentMethods) {
+    this.parent = parent;
+  }
+
+  /**
+   * Adds an embedded wallet to the map of embedded wallets.
+   * @param address - The address of the embedded wallet.
+   * @param wallet - The wallet adapter instance.
+   */
+  addEmbeddedWallet(address: string, wallet: WalletAdapter) {
+    this.embeddedWalletsByAddress.set(getAddress(address), wallet);
+  }
+
+  /**
+   * Gets an embedded wallet from the map of embedded wallets.
+   * @param address - The address of the embedded wallet.
+   * @returns The wallet adapter instance or undefined if not found.
+   */
+  getEmbeddedWallet(address: string): WalletAdapter | undefined {
+    return this.embeddedWalletsByAddress.get(getAddress(address));
+  }
+
+  /**
+   * Signs a message using either an embedded wallet or the external bridge.
+   * @param identifier - The identifier (e.g., address) of the wallet.
+   * @param message - The message hex string to sign.
+   * @returns Promise resolving to the signature hex string.
+   * @throws Error if signing fails or the connection isn't ready.
+   */
+  async signMessage(
+    identifier: string,
+    message: string,
+  ): Promise<ExternalWalletResponse> {
+    // --- Decision Logic ---
+    const embeddedWallet = this.getEmbeddedWallet(identifier);
+
+    if (embeddedWallet) {
+      // --- Embedded Wallet Path ---
+      const response = await embeddedWallet.signMessage?.(message);
+      if (!response?.success) {
+        throw new ExternalWalletError(
+          `Failed to sign message with embedded wallet. ${response?.error}`,
+        );
+      }
+      return response;
+    } else {
+      // --- External Wallet Path ---
+      if (!this.parent) {
+        console.error("KeychainWallets: Parent connection not available.");
+        throw new Error("Wallet connection not ready.");
+      }
+
+      try {
+        // Call the parent window's bridge method via penpal
+        // Note: Parent's externalSignMessage now expects identifier string
+        const response = await this.parent.externalSignMessage(
+          identifier.startsWith("0x") ? getAddress(identifier) : identifier,
+          message,
+        );
+
+        if (response.success && response.result) {
+          // Assuming response.result is the signature string
+          // Ensure it's actually a string before returning
+          if (typeof response.result === "string") {
+            return response;
+          } else {
+            console.error(
+              "KeychainWallets: Parent response result is not a string:",
+              response.result,
+            );
+            throw new ExternalWalletError(
+              "Invalid signature format received from wallet bridge.",
+            );
+          }
+        } else {
+          const errorMsg =
+            response.error || "Unknown error from external wallet bridge.";
+          console.error(
+            `KeychainWallets: Error from parent bridge: ${errorMsg}`,
+          );
+          throw new ExternalWalletError(errorMsg);
+        }
+      } catch (error) {
+        console.error(
+          "KeychainWallets: Failed to call externalSignMessage:",
+          error,
+        );
+        // Re-throw the error to be caught by the WASM caller
+        if (error instanceof ExternalWalletError) {
+          throw error;
+        }
+        throw error instanceof Error
+          ? new ExternalWalletError(error.message)
+          : new ExternalWalletError(String(error));
+      }
+    }
+  }
+}

--- a/packages/keychain/src/hooks/starterpack/external-wallet.ts
+++ b/packages/keychain/src/hooks/starterpack/external-wallet.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback } from "react";
 import { ExternalPlatform, ExternalWallet } from "@cartridge/controller";
-import { useWallets } from "@/hooks/wallets";
+import { useWallets } from "@/hooks/use-wallets";
 import { useConnection } from "../connection";
 
 export interface UseExternalWalletOptions {

--- a/packages/keychain/src/hooks/use-wallets.ts
+++ b/packages/keychain/src/hooks/use-wallets.ts
@@ -1,0 +1,10 @@
+import { useContext } from "react";
+import { WalletsContext, WalletsContextValue } from "./wallets-context";
+
+export const useWallets = (): WalletsContextValue => {
+  const context = useContext(WalletsContext);
+  if (context === undefined) {
+    throw new Error("useWallets must be used within a WalletsProvider");
+  }
+  return context;
+};

--- a/packages/keychain/src/hooks/wallets-context.ts
+++ b/packages/keychain/src/hooks/wallets-context.ts
@@ -1,0 +1,37 @@
+import { createContext } from "react";
+import {
+  AuthExternalWallet,
+  ExternalWallet,
+  ExternalWalletResponse,
+  ExternalWalletType,
+} from "@cartridge/controller";
+import { CredentialMetadata } from "@cartridge/controller-ui/utils/api/cartridge";
+import { KeychainWallets } from "./keychain-wallets";
+
+export interface WalletsContextValue {
+  wallets: ExternalWallet[];
+  supportedWalletsForAuth: AuthExternalWallet[];
+  isLoading: boolean;
+  isConnecting: boolean;
+  error: Error | null;
+  detectWallets: () => Promise<void>;
+  connectWallet: (
+    type: ExternalWalletType,
+  ) => Promise<ExternalWalletResponse | null>;
+  isExtensionMissing: (signer: CredentialMetadata) => boolean;
+  switchChain: (
+    identifier: ExternalWalletType,
+    chainId: string,
+  ) => Promise<boolean>;
+  availableWallets: ExternalWalletType[];
+}
+
+declare global {
+  interface Window {
+    keychain_wallets?: KeychainWallets;
+  }
+}
+
+export const WalletsContext = createContext<WalletsContextValue | undefined>(
+  undefined,
+);

--- a/packages/keychain/src/hooks/wallets.tsx
+++ b/packages/keychain/src/hooks/wallets.tsx
@@ -5,49 +5,19 @@ import {
   ExternalWallet,
   ExternalWalletResponse,
   ExternalWalletType,
-  WalletAdapter,
 } from "@cartridge/controller";
 import { CredentialMetadata } from "@cartridge/controller-ui/utils/api/cartridge";
-import { getAddress } from "ethers/address";
 import { ExternalWalletError } from "@/utils/errors";
 import React, {
-  createContext,
   PropsWithChildren,
   useCallback,
-  useContext,
   useEffect,
   useMemo,
   useState,
 } from "react";
-import { ParentMethods, useConnection } from "./connection";
-
-interface WalletsContextValue {
-  wallets: ExternalWallet[];
-  supportedWalletsForAuth: AuthExternalWallet[];
-  isLoading: boolean;
-  isConnecting: boolean;
-  error: Error | null;
-  detectWallets: () => Promise<void>;
-  connectWallet: (
-    type: ExternalWalletType,
-  ) => Promise<ExternalWalletResponse | null>;
-  isExtensionMissing: (signer: CredentialMetadata) => boolean;
-  switchChain: (
-    identifier: ExternalWalletType,
-    chainId: string,
-  ) => Promise<boolean>;
-  availableWallets: ExternalWalletType[];
-}
-
-declare global {
-  interface Window {
-    keychain_wallets?: KeychainWallets;
-  }
-}
-
-const WalletsContext = createContext<WalletsContextValue | undefined>(
-  undefined,
-);
+import { useConnection } from "./connection";
+import { KeychainWallets } from "./keychain-wallets";
+import { WalletsContext } from "./wallets-context";
 
 export const WalletsProvider: React.FC<PropsWithChildren> = ({ children }) => {
   const { parent } = useConnection();
@@ -241,120 +211,3 @@ export const WalletsProvider: React.FC<PropsWithChildren> = ({ children }) => {
     <WalletsContext.Provider value={value}>{children}</WalletsContext.Provider>
   );
 };
-
-export const useWallets = (): WalletsContextValue => {
-  const context = useContext(WalletsContext);
-  if (context === undefined) {
-    throw new Error("useWallets must be used within a WalletsProvider");
-  }
-  return context;
-};
-
-/**
- * Service running in the keychain iframe to handle signing requests.
- * It decides whether to use an embedded wallet or delegate to the
- * external WalletBridge in the parent controller window via penpal.
- */
-export class KeychainWallets {
-  private parent: ParentMethods;
-  private embeddedWalletsByAddress: Map<string, WalletAdapter> = new Map();
-
-  // Method to set the parent connection once established
-  constructor(parent: ParentMethods) {
-    this.parent = parent;
-  }
-
-  /**
-   * Adds an embedded wallet to the map of embedded wallets.
-   * @param address - The address of the embedded wallet.
-   * @param wallet - The wallet adapter instance.
-   */
-  addEmbeddedWallet(address: string, wallet: WalletAdapter) {
-    this.embeddedWalletsByAddress.set(getAddress(address), wallet);
-  }
-
-  /**
-   * Gets an embedded wallet from the map of embedded wallets.
-   * @param address - The address of the embedded wallet.
-   * @returns The wallet adapter instance or undefined if not found.
-   */
-  getEmbeddedWallet(address: string): WalletAdapter | undefined {
-    return this.embeddedWalletsByAddress.get(getAddress(address));
-  }
-
-  /**
-   * Signs a message using either an embedded wallet or the external bridge.
-   * @param identifier - The identifier (e.g., address) of the wallet.
-   * @param message - The message hex string to sign.
-   * @returns Promise resolving to the signature hex string.
-   * @throws Error if signing fails or the connection isn't ready.
-   */
-  async signMessage(
-    identifier: string,
-    message: string,
-  ): Promise<ExternalWalletResponse> {
-    // --- Decision Logic ---
-    const embeddedWallet = this.getEmbeddedWallet(identifier);
-
-    if (embeddedWallet) {
-      // --- Embedded Wallet Path ---
-      const response = await embeddedWallet.signMessage?.(message);
-      if (!response?.success) {
-        throw new ExternalWalletError(
-          `Failed to sign message with embedded wallet. ${response?.error}`,
-        );
-      }
-      return response;
-    } else {
-      // --- External Wallet Path ---
-      if (!this.parent) {
-        console.error("KeychainWallets: Parent connection not available.");
-        throw new Error("Wallet connection not ready.");
-      }
-
-      try {
-        // Call the parent window's bridge method via penpal
-        // Note: Parent's externalSignMessage now expects identifier string
-        const response = await this.parent.externalSignMessage(
-          identifier.startsWith("0x") ? getAddress(identifier) : identifier,
-          message,
-        );
-
-        if (response.success && response.result) {
-          // Assuming response.result is the signature string
-          // Ensure it's actually a string before returning
-          if (typeof response.result === "string") {
-            return response;
-          } else {
-            console.error(
-              "KeychainWallets: Parent response result is not a string:",
-              response.result,
-            );
-            throw new ExternalWalletError(
-              "Invalid signature format received from wallet bridge.",
-            );
-          }
-        } else {
-          const errorMsg =
-            response.error || "Unknown error from external wallet bridge.";
-          console.error(
-            `KeychainWallets: Error from parent bridge: ${errorMsg}`,
-          );
-          throw new ExternalWalletError(errorMsg);
-        }
-      } catch (error) {
-        console.error(
-          "KeychainWallets: Failed to call externalSignMessage:",
-          error,
-        );
-        // Re-throw the error to be caught by the WASM caller
-        if (error instanceof ExternalWalletError) {
-          throw error;
-        }
-        throw error instanceof Error
-          ? new ExternalWalletError(error.message)
-          : new ExternalWalletError(String(error));
-      }
-    }
-  }
-}

--- a/packages/keychain/src/utils/connection/headless.test.ts
+++ b/packages/keychain/src/utils/connection/headless.test.ts
@@ -17,7 +17,7 @@ vi.mock("@/components/connect/create/password/crypto", () => ({
   generateStarknetKeypair: () => mockGenerateStarknetKeypair(),
 }));
 
-vi.mock("@/components/provider/upgrade", () => ({
+vi.mock("@/components/provider/upgrade-context", () => ({
   STABLE_CONTROLLER: { hash: "0xclasshash" },
 }));
 

--- a/packages/keychain/src/utils/connection/headless.ts
+++ b/packages/keychain/src/utils/connection/headless.ts
@@ -1,4 +1,4 @@
-import { STABLE_CONTROLLER } from "@/components/provider/upgrade";
+import { STABLE_CONTROLLER } from "@/components/provider/upgrade-context";
 import { doSignup } from "@/hooks/account";
 import { fetchController } from "@/components/connect/create/utils";
 import {

--- a/packages/keychain/src/utils/token-amount.ts
+++ b/packages/keychain/src/utils/token-amount.ts
@@ -1,0 +1,19 @@
+export function parseTokenAmount(
+  value: string | undefined,
+  decimals: number,
+): bigint | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || !/^\d+(\.\d*)?$/.test(trimmed)) {
+    return undefined;
+  }
+
+  const [whole, fractional = ""] = trimmed.split(".");
+  if (fractional.length > decimals) {
+    return undefined;
+  }
+
+  const base = 10n ** BigInt(decimals);
+  const wholeAmount = BigInt(whole) * base;
+  const fractionalAmount = BigInt(fractional.padEnd(decimals, "0") || "0");
+  return wholeAmount + fractionalAmount;
+}


### PR DESCRIPTION
From a PostHog error triage of the Controller. Two fixes:

## C1 — real prod bug: float passed to `BigInt()` in token send
`SendTokenDrawer` computed the base-unit amount as `amount * 10 ** decimals` and passed it to `BigInt()`. A fractional amount yields a non-integer float — e.g. `0.0045 * 10**18 = 4499999999999999.5` — which throws `cannot be converted to a BigInt because it is not an integer`. Observed in production (`x.cartridge.gg`, `/inventory/token/…`). Fix: parse the raw decimal input string into base units exactly with bigint math (`parseTokenAmount`), thread the input string through `amount.tsx`, and treat invalid/over-precision input as no-amount. Regression test added (`0.0045` @ 18 decimals).

## C2 — dev HMR error class: `react-refresh/only-export-components`
Provider modules exported `createContext()`/hooks/constants alongside the Provider, breaking Vite Fast Refresh and invalidating context identity on hot-reload — cause of the ~100 dev-only `useX must be used within XProvider` errors. Enabled `react-refresh/only-export-components` (warn) and split the offenders (starterpack, onchain-purchase, credit-purchase, upgrade, wallets) into context/provider/hook modules.

## Verification
`tsc -b`, lint (0 errors), `format:check`, keychain tests (**579 passing**) green. Triaged + implemented with Codex; the "credits" PostHog errors were an unmerged local WIP branch (not on main) — nothing to fix there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)