### PR TITLE
fix(ui): suppress PostHog capture on localhost (re-enable dev guard)

### DIFF
--- a/packages/ui/src/utils/context/posthog.tsx
+++ b/packages/ui/src/utils/context/posthog.tsx
@@ -6,7 +6,6 @@ type Properties = Record<string, any>;
 
 export class PostHogWrapper extends PostHog {
   isLocal =
-    false &&
     typeof window !== "undefined" &&
     window.location.hostname.includes("localhost");
 


### PR DESCRIPTION
## Why
From the controller error triage: **~99% of recent PostHog `$exception` volume was localhost dev noise**, burying the real production signal (and inflating ingest).

`PostHogWrapper` already has an `isLocal` guard meant to suppress capture on localhost — but it was dead-coded:
```ts
isLocal =
  false &&   // ← short-circuits to always false
  typeof window !== "undefined" &&
  window.location.hostname.includes("localhost");
```
So `capture`/`identify`/`group`/`reset` and `captureException` (which routes through `capture`) all sent events from local dev to the **production** PostHog project. The `false &&` was introduced incidentally in #2552 (a dependency refactor), not as a deliberate choice.

## Change
Remove the `false &&` so the guard evaluates as intended — on localhost, events are logged to the console instead of sent. **Production behavior is unchanged.**

Complements the centaur-side query filter (which now also excludes dev hosts), but fixing it at the source is cleaner: every PostHog consumer (dashboards, error tracking) gets clean prod-only data and ingest drops.

Verified: `biome lint` clean, `tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)