### PR TITLE
feat: ControllerOptions.toriiUrl, katana upgrade fix

### DIFF
--- a/examples/next/next.config.js
+++ b/examples/next/next.config.js
@@ -8,6 +8,15 @@ const nextConfig = {
     externalDir: true,
   },
   webpack: (config, { isServer, dev }) => {
+    // Disable the persistent filesystem cache in dev. Workspace deps
+    // (@cartridge/controller, @cartridge/connector) are consumed as prebuilt
+    // dist/ files; controller's `vite build --watch` re-empties its dist on
+    // rebuild, so Next can momentarily compile an empty module and cache the
+    // broken result (default === undefined → "is not a constructor"). The cache
+    // otherwise survives dev restarts, forcing a full clean. Disabling it means
+    // a plain restart always recovers.
+    if (dev) config.cache = false;
+
     config.output.environment = {
       ...config.output.environment,
       asyncFunction: true,

--- a/examples/next/src/components/providers/StarknetProvider.tsx
+++ b/examples/next/src/components/providers/StarknetProvider.tsx
@@ -314,6 +314,10 @@ export const controllerConnector = new ControllerConnector({
     erc20: ["lords", "strk"],
   },
   ...(controllerPreset ? presets[controllerPreset] : {}),
+  /// slot instance for tokens
+  // slot: "pg-mainnet-10", // build torii url
+  toriiUrl: "https://api.cartridge.gg/x/pg-mainnet-10/torii",
+  // toriiUrl: "http://localhost:8080",
 });
 
 const session = new SessionConnector({

--- a/packages/controller/src/iframe/keychain.ts
+++ b/packages/controller/src/iframe/keychain.ts
@@ -28,6 +28,7 @@ export class KeychainIFrame extends IFrame<Keychain> {
     policies,
     version,
     slot,
+    toriiUrl,
     namespace,
     tokens,
     preset,
@@ -64,6 +65,10 @@ export class KeychainIFrame extends IFrame<Keychain> {
 
     if (slot) {
       _url.searchParams.set("ps", encodeURIComponent(slot));
+    }
+
+    if (toriiUrl) {
+      _url.searchParams.set("torii", encodeURIComponent(toriiUrl));
     }
 
     if (namespace) {

--- a/packages/controller/src/types.ts
+++ b/packages/controller/src/types.ts
@@ -292,6 +292,8 @@ export type KeychainOptions = IFrameOptions & {
   shouldOverridePresetPolicies?: boolean;
   /** The project name of Slot instance. */
   slot?: string;
+  /** The Torii indexer URL used to fetch tokens/collections. Takes precedence over `slot`. */
+  toriiUrl?: string;
   /** The namespace to use to fetch trophies data from indexer. Will be mandatory once profile page is in production */
   namespace?: string;
   /** The tokens to be listed on Inventory modal */

--- a/packages/keychain/src/components/DeployController.tsx
+++ b/packages/keychain/src/components/DeployController.tsx
@@ -75,7 +75,7 @@ export function DeployControllerView({
   onComplete: (hash: string) => void;
   ctrlError?: ControllerError;
 }) {
-  const { controller } = useConnection();
+  const { controller, isMainnet } = useConnection();
   const { deploySelf, isDeploying } = useDeploy();
   const { token: feeToken, isLoading } = useFeeToken();
   const [deployHash, setDeployHash] = useState<string>();
@@ -89,10 +89,7 @@ export function DeployControllerView({
   const feeEstimate: FeeEstimate | undefined = ctrlError?.data?.fee_estimate;
 
   useEffect(() => {
-    if (
-      !controller ||
-      controller.chainId() === constants.StarknetChainId.SN_MAIN
-    ) {
+    if (!controller || isMainnet) {
       return;
     }
 
@@ -101,7 +98,7 @@ export function DeployControllerView({
     // not-deployed state can arrive without `fee_estimate`. Move straight to the
     // deploy step regardless; selfDeploy estimates internally when no fee is given.
     setAccountState("deploy");
-  }, [controller, feeEstimate]);
+  }, [controller, feeEstimate, isMainnet]);
 
   useEffect(() => {
     if (deployHash && controller) {

--- a/packages/keychain/src/components/ExecutionContainer.test.tsx
+++ b/packages/keychain/src/components/ExecutionContainer.test.tsx
@@ -237,6 +237,29 @@ describe("ExecutionContainer", () => {
     expect(screen.getByText("ADD FUNDS")).toBeInTheDocument();
   });
 
+  it("attempts the action (no upfront Add Funds) on an appchain when balance is insufficient", async () => {
+    await act(async () => {
+      renderWithConnection(
+        <ExecutionContainer
+          {...defaultProps}
+          executionError={{
+            code: 113, // ErrorCode.InsufficientBalance,
+            message: "Insufficient balance",
+          }}
+        />,
+        {
+          // Appchain: the chain may not charge fees / may use a different fee token,
+          // so the user should be able to attempt the action before being asked to
+          // add funds.
+          isAppchain: true,
+        },
+      );
+    });
+
+    expect(screen.getByText("SUBMIT")).toBeInTheDocument();
+    expect(screen.queryByText("ADD FUNDS")).not.toBeInTheDocument();
+  });
+
   it("shows continue button for already registered session", async () => {
     await act(async () => {
       renderWithConnection(

--- a/packages/keychain/src/components/ExecutionContainer.test.tsx
+++ b/packages/keychain/src/components/ExecutionContainer.test.tsx
@@ -197,6 +197,29 @@ describe("ExecutionContainer", () => {
     expect(screen.getByText("DEPLOY ACCOUNT")).toBeInTheDocument();
   });
 
+  it("submits without a deploy screen when not deployed on an appchain", async () => {
+    await act(async () => {
+      renderWithConnection(
+        <ExecutionContainer
+          {...defaultProps}
+          executionError={{
+            code: 112, // ErrorCode.CartridgeControllerNotDeployed,
+            message: "Controller not deployed",
+          }}
+        />,
+        {
+          // On an appchain the controller deploys itself on first execute, so the
+          // transaction submits directly rather than diverting to the
+          // (double-deploying) deploy screen.
+          isAppchain: true,
+        },
+      );
+    });
+
+    expect(screen.getByText("SUBMIT")).toBeInTheDocument();
+    expect(screen.queryByText("DEPLOY ACCOUNT")).not.toBeInTheDocument();
+  });
+
   it("shows funding view when balance is insufficient", async () => {
     await act(async () => {
       renderWithProviders(

--- a/packages/keychain/src/components/ExecutionContainer.tsx
+++ b/packages/keychain/src/components/ExecutionContainer.tsx
@@ -50,7 +50,7 @@ export function ExecutionContainer({
   children,
 }: ExecutionContainerProps &
   Pick<HeaderProps, "title" | "description" | "icon">) {
-  const { controller, policies } = useConnection();
+  const { controller, policies, isAppchain } = useConnection();
   const { navigate } = useNavigation();
   const [maxFee, setMaxFee] = useState<FeeEstimate | undefined>();
   const [ctrlError, setCtrlError] = useState<ControllerError | undefined>(
@@ -245,6 +245,26 @@ export function ExecutionContainer({
         {(() => {
           switch (ctrlError?.code) {
             case ErrorCode.CartridgeControllerNotDeployed:
+              // On appchains the controller deploys itself on first execute, so
+              // there's no separate deploy step: submitting the transaction deploys
+              // and executes in one shot (the wasm estimates the fee internally when
+              // none is provided up front). Surfacing the deploy screen here instead
+              // double-deploys and fails with "contract already deployed". Only
+              // mainnet keeps the explicit deploy/fund flow.
+              if (isAppchain) {
+                // No fee estimate is shown: the account isn't deployed yet, so the
+                // fee can't be estimated up front. The wasm estimates internally and
+                // deploys + executes when the transaction is submitted.
+                return (
+                  <Button
+                    onClick={handleSubmit}
+                    isLoading={isLoading}
+                    disabled={isEstimating || !transactions}
+                  >
+                    {buttonText}
+                  </Button>
+                );
+              }
               return (
                 <>
                   <ControllerErrorAlert error={ctrlError} />

--- a/packages/keychain/src/components/ExecutionContainer.tsx
+++ b/packages/keychain/src/components/ExecutionContainer.tsx
@@ -59,6 +59,11 @@ export function ExecutionContainer({
   const [isLoading, setIsLoading] = useState(false);
   const [isEstimating, setIsEstimating] = useState(true);
   const [ctaState, setCTAState] = useState<"deploy" | "execute">("execute");
+  // Tracks whether the user has already attempted to submit. On appchains we
+  // attempt the action optimistically and only fall back to the "Add Funds" flow
+  // if that attempt itself fails on funds (the chain may not charge fees, may
+  // settle in a different fee token, or a paymaster may sponsor).
+  const [submitAttempted, setSubmitAttempted] = useState(false);
 
   // Prevent unnecessary estimate fee calls. Track the controller too: on a chain
   // switch a *new* Controller instance is created (bound to the new RPC), and the
@@ -171,6 +176,7 @@ export function ExecutionContainer({
 
   const handleSubmit = async () => {
     setIsLoading(true);
+    setSubmitAttempted(true);
     try {
       await onSubmit(maxFee);
     } catch (e) {
@@ -274,6 +280,22 @@ export function ExecutionContainer({
                 </>
               );
             case ErrorCode.InsufficientBalance:
+              // On appchains, don't gate on a client-side balance check up front:
+              // the chain may not actually charge fees, may settle in a different
+              // fee token, or a paymaster may sponsor. Let the user attempt the
+              // action first; only surface "Add Funds" once the submission itself
+              // has failed on funds.
+              if (isAppchain && !submitAttempted) {
+                return (
+                  <Button
+                    onClick={handleSubmit}
+                    isLoading={isLoading}
+                    disabled={isLoading || !transactions}
+                  >
+                    {buttonText}
+                  </Button>
+                );
+              }
               return (
                 <>
                   <Fees

--- a/packages/keychain/src/components/inventory/collection/collectible-purchase.tsx
+++ b/packages/keychain/src/components/inventory/collection/collectible-purchase.tsx
@@ -43,7 +43,7 @@ import { formatUsdValue } from "@/utils/format-value";
 
 export function CollectiblePurchase() {
   const { address: contractAddress, tokenId } = useParams();
-  const { project, controller, closeModal } = useConnection();
+  const { project, toriiUrl, controller, closeModal } = useConnection();
   const { goBack, canGoBack } = useNavigation();
   const { tokens } = useTokens();
   const [royalties, setRoyalties] = useState<{ [orderId: number]: bigint }>({});
@@ -88,11 +88,13 @@ export function CollectiblePurchase() {
   const { collections, status: collectionStatus } = useToriiCollections();
 
   const collection = useMemo(() => {
-    if (!project || !collections || !contractAddress) return;
-    const projectCollections = collections[project];
+    // Must match the key `useToriiCollections` stores collections under.
+    const projectKey = project ?? toriiUrl;
+    if (!projectKey || !collections || !contractAddress) return;
+    const projectCollections = collections[projectKey];
     if (!projectCollections) return;
     return projectCollections[getChecksumAddress(contractAddress)];
-  }, [collections, contractAddress, project]);
+  }, [collections, contractAddress, project, toriiUrl]);
 
   const { tokens: assets, status: assetsStatus } = useToriiCollection({
     contractAddress: contractAddress || "",
@@ -182,11 +184,16 @@ export function CollectiblePurchase() {
         } catch {
           tokenName = asset.name;
         }
-        const newImage = `https://api.cartridge.gg/x/${project}/torii/static/${addAddressPadding(contractAddress)}/${asset.token_id}/image`;
-        const oldImage = `https://api.cartridge.gg/x/${project}/torii/static/0x${BigInt(contractAddress).toString(16)}/${asset.token_id}/image`;
+        const newImage = toriiUrl
+          ? `${toriiUrl}/static/${addAddressPadding(contractAddress)}/${asset.token_id}/image`
+          : undefined;
+        const oldImage = toriiUrl
+          ? `${toriiUrl}/static/0x${BigInt(contractAddress).toString(16)}/${asset.token_id}/image`
+          : undefined;
+        const images = [newImage, oldImage].filter(Boolean) as string[];
         return {
           orderId: order.id,
-          images: [newImage, oldImage],
+          images,
           name: tokenName,
           collection: collection.name,
           collectionAddress: contractAddress,
@@ -201,7 +208,7 @@ export function CollectiblePurchase() {
     collection,
     tokenOrders,
     contractAddress,
-    project,
+    toriiUrl,
     token?.metadata.decimals,
   ]);
 

--- a/packages/keychain/src/components/inventory/collection/collection-purchase.tsx
+++ b/packages/keychain/src/components/inventory/collection/collection-purchase.tsx
@@ -43,7 +43,7 @@ import { formatUsdValue } from "@/utils/format-value";
 
 export function CollectionPurchase() {
   const { address: contractAddress, tokenId } = useParams();
-  const { project, controller, closeModal } = useConnection();
+  const { toriiUrl, controller, closeModal } = useConnection();
   const { goBack, canGoBack } = useNavigation();
   const { tokens } = useTokens();
   const [royalties, setRoyalties] = useState<{ [orderId: number]: bigint }>({});
@@ -131,8 +131,8 @@ export function CollectionPurchase() {
         } catch {
           tokenName = asset.name;
         }
-        const newImage = `https://api.cartridge.gg/x/${project}/torii/static/${addAddressPadding(contractAddress)}/${asset.token_id}/image`;
-        const oldImage = `https://api.cartridge.gg/x/${project}/torii/static/0x${BigInt(contractAddress).toString(16)}/${asset.token_id}/image`;
+        const newImage = `${toriiUrl}/static/${addAddressPadding(contractAddress)}/${asset.token_id}/image`;
+        const oldImage = `${toriiUrl}/static/0x${BigInt(contractAddress).toString(16)}/${asset.token_id}/image`;
         return {
           orderId: order.id,
           images: [newImage, oldImage],
@@ -150,7 +150,7 @@ export function CollectionPurchase() {
     tokenContract,
     tokenOrders,
     contractAddress,
-    project,
+    toriiUrl,
     token?.metadata.decimals,
   ]);
 

--- a/packages/keychain/src/components/provider/connection.tsx
+++ b/packages/keychain/src/components/provider/connection.tsx
@@ -41,6 +41,7 @@ export type ConnectionContextValue = {
   isPoliciesResolved: boolean;
   isPoliciesError: boolean;
   isMainnet: boolean;
+  isAppchain: boolean; // not public chains (mainnet/sepolia)
   verified: boolean;
   chainId?: string;
   setController: (controller?: Controller) => void;

--- a/packages/keychain/src/components/provider/connection.tsx
+++ b/packages/keychain/src/components/provider/connection.tsx
@@ -23,6 +23,7 @@ export type ConnectionContextValue = {
   origin: string;
   rpcUrl: string;
   project: string | null;
+  toriiUrl: string | null;
   namespace: string | null;
   propagateError: boolean;
   webauthnPopup: {

--- a/packages/keychain/src/components/provider/data.tsx
+++ b/packages/keychain/src/components/provider/data.tsx
@@ -7,6 +7,7 @@ import {
 } from "@cartridge/controller-ui/utils/api/cartridge";
 import { useAccount, useUsernames } from "@/hooks/account";
 import { useConnection, useControllerTheme } from "@/hooks/connection";
+import { getToriiUrl } from "@/helpers/torii-url";
 import { addAddressPadding, getChecksumAddress } from "starknet";
 import { erc20Metadata } from "@cartridge/presets";
 import { getDate } from "@cartridge/controller-ui/utils";
@@ -65,7 +66,7 @@ export function DataProvider({ children }: { children: ReactNode }) {
     () => (account ? addAddressPadding(account.address) : ""),
     [account],
   );
-  const { project } = useConnection();
+  const { project, toriiUrl } = useConnection();
   const shouldFetchHistory = useMemo(
     () => shouldFetchProfileHistory(location.pathname),
     [location.pathname],
@@ -225,7 +226,7 @@ export function DataProvider({ children }: { children: ReactNode }) {
               metadata.attributes?.find(
                 (attribute) => attribute.trait?.toLowerCase() === "name",
               )?.value || metadata.name;
-            const image = `https://api.cartridge.gg/x/${item.meta.project}/torii/static/${addAddressPadding(transfer.contractAddress)}/${transfer.tokenId}/image`;
+            const image = `${toriiUrl ?? getToriiUrl(item.meta.project)}/static/${addAddressPadding(transfer.contractAddress)}/${transfer.tokenId}/image`;
             const userAddress =
               BigInt(transfer.fromAddress) === BigInt(address)
                 ? transfer.toAddress
@@ -259,7 +260,7 @@ export function DataProvider({ children }: { children: ReactNode }) {
           });
       }) || []
     );
-  }, [transfers, address, getUsername, theme]);
+  }, [transfers, address, getUsername, theme, toriiUrl]);
 
   const actions: CardProps[] = useMemo(() => {
     return (

--- a/packages/keychain/src/components/session.test.tsx
+++ b/packages/keychain/src/components/session.test.tsx
@@ -63,6 +63,7 @@ describe("Session", () => {
       origin: "https://test.app",
       rpcUrl: "https://rpc.test.app",
       project: null,
+      toriiUrl: null,
       namespace: null,
       propagateError: false,
       webauthnPopup: {

--- a/packages/keychain/src/components/session.test.tsx
+++ b/packages/keychain/src/components/session.test.tsx
@@ -89,6 +89,7 @@ describe("Session", () => {
       isPoliciesResolved: true,
       isPoliciesError: false,
       isMainnet: false,
+      isAppchain: false,
       verified: true,
       chainId: "SN_MAIN",
       setController: vi.fn(),

--- a/packages/keychain/src/components/slot/crypto-fund.tsx
+++ b/packages/keychain/src/components/slot/crypto-fund.tsx
@@ -89,7 +89,7 @@ function SlotCryptoFundInner({
   onBack,
   onComplete,
 }: SlotCryptoFundProps) {
-  const { controller } = useConnection();
+  const { controller, isMainnet } = useConnection();
   const { setOnBackCallback } = useNavigation();
   const { connectAsync, connectors, isPending: isConnecting } = useConnect();
   const { account: extAccount } = useAccount();
@@ -263,7 +263,7 @@ function SlotCryptoFundInner({
         tokenAddress: selectedToken.address,
         tokenAmount: amount,
         teamId: team.id,
-        isMainnet: controller.chainId() === constants.StarknetChainId.SN_MAIN,
+        isMainnet,
       });
 
       setPhase("transferring");
@@ -289,7 +289,15 @@ function SlotCryptoFundInner({
     } finally {
       setPhase("idle");
     }
-  }, [amount, controller, extAccount, onComplete, selectedToken, team.id]);
+  }, [
+    amount,
+    controller,
+    extAccount,
+    onComplete,
+    selectedToken,
+    team.id,
+    isMainnet,
+  ]);
 
   const phaseLabel = getPhaseLabel(phase);
   const walletConnectors = connectors.filter((c) =>

--- a/packages/keychain/src/components/transaction/ConfirmTransaction.test.tsx
+++ b/packages/keychain/src/components/transaction/ConfirmTransaction.test.tsx
@@ -42,6 +42,18 @@ vi.mock("@/context/toast", () => ({
   })),
 }));
 
+// Stub the balance-change simulation. These tests assert on the confirm/execute
+// flow, not on simulation output. The real hook kicks off an async tx simulation
+// (and a 10s repeat loop) that outlives the test and, on its error path, rejects
+// late into a torn-down environment — surfacing as a flaky unhandled rejection.
+vi.mock("@/components/simulation/use-simulate", () => ({
+  useSimulateBalanceChanges: () => ({
+    isSimulating: false,
+    simulationError: null,
+    simulationBalances: [],
+  }),
+}));
+
 describe("ConfirmTransaction", () => {
   const mockTransactions = [
     {

--- a/packages/keychain/src/components/transaction/ConfirmTransaction.tsx
+++ b/packages/keychain/src/components/transaction/ConfirmTransaction.tsx
@@ -26,7 +26,7 @@ export function ConfirmTransaction({
   transactions,
   executionError,
 }: ConfirmTransactionProps) {
-  const { controller, origin, policies } = useConnection();
+  const { controller, origin, policies, isAppchain } = useConnection();
   const account = controller;
   const { toast } = useToast();
 
@@ -60,7 +60,11 @@ export function ConfirmTransaction({
   }, [error, executionError]);
 
   const onSubmit = async (maxFee?: FeeEstimate) => {
-    if (maxFee === undefined || !account) {
+    // On appchains the controller deploys on first execute, so the fee can't be
+    // estimated up front and `maxFee` is undefined — `account.execute` estimates
+    // internally and deploys + executes in one shot. On public chains a fee
+    // estimate is required before submitting.
+    if (!account || (maxFee === undefined && !isAppchain)) {
       return;
     }
 

--- a/packages/keychain/src/context/quest.tsx
+++ b/packages/keychain/src/context/quest.tsx
@@ -98,7 +98,7 @@ export function QuestProvider({ children }: { children: React.ReactNode }) {
   const [client, setClient] = useState<torii.ToriiClient>();
   const entitySubscriptionRef = useRef<torii.Subscription | null>(null);
   const eventSubscriptionRef = useRef<torii.Subscription | null>(null);
-  const { namespace, project } = useConnection();
+  const { namespace, toriiUrl } = useConnection();
   const [definitions, setDefinitions] = useState<QuestDefinition[]>([]);
   const [completions, setCompletions] = useState<QuestCompletion[]>([]);
   const [advancements, setAdvancements] = useState<QuestAdvancement[]>([]);
@@ -109,16 +109,16 @@ export function QuestProvider({ children }: { children: React.ReactNode }) {
 
   // Initialize Torii client
   useEffect(() => {
-    if (!namespace || !project) return;
+    if (!namespace || !toriiUrl) return;
     const getClient = async () => {
       const client = await new torii.ToriiClient({
-        toriiUrl: `https://api.cartridge.gg/x/${project}/torii`,
+        toriiUrl,
         worldAddress: "0x0",
       });
       setClient(client);
     };
     getClient();
-  }, [project, namespace]);
+  }, [toriiUrl, namespace]);
 
   // Handler for entity updates (definitions, completions, advancements, creations)
   const onEntityUpdate = useCallback(
@@ -218,7 +218,7 @@ export function QuestProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     if (
       !namespace ||
-      !project ||
+      !toriiUrl ||
       entitySubscriptionRef.current ||
       eventSubscriptionRef.current
     )
@@ -241,7 +241,7 @@ export function QuestProvider({ children }: { children: React.ReactNode }) {
         eventSubscriptionRef.current.cancel();
       }
     };
-  }, [refresh, namespace, project]);
+  }, [refresh, namespace, toriiUrl]);
 
   // Compute quests from the raw data
   const quests: QuestProps[] = useMemo(() => {

--- a/packages/keychain/src/helpers/torii-url.ts
+++ b/packages/keychain/src/helpers/torii-url.ts
@@ -1,0 +1,20 @@
+/**
+ * Resolve the Torii base URL — the single source of truth for how a Torii URL
+ * is built across the keychain.
+ *
+ * A caller-provided `toriiUrl` (SDK `toriiUrl` option) takes precedence over the
+ * default Slot URL derived from `project` (SDK `slot` option). Trailing slashes
+ * are stripped so callers can safely append paths like `/static/...`.
+ *
+ * @param project - The Slot project name (from the `ps` URL param).
+ * @param toriiUrl - An explicit Torii URL override (from the `torii` URL param).
+ * @returns The resolved Torii base URL, or `null` when neither is available.
+ */
+export function getToriiUrl(
+  project?: string | null,
+  toriiUrl?: string | null,
+): string | null {
+  if (toriiUrl) return toriiUrl.replace(/\/+$/, "");
+  if (project) return `https://api.cartridge.gg/x/${project}/torii`;
+  return null;
+}

--- a/packages/keychain/src/helpers/torii.ts
+++ b/packages/keychain/src/helpers/torii.ts
@@ -9,14 +9,13 @@ const BATCH_SIZE = 1000;
  */
 export default {
   /**
-   * Get a ToriiClient instance for a given project
-   * @param project - The project name
+   * Get a ToriiClient instance for a resolved Torii URL
+   * @param toriiUrl - The resolved Torii base URL (see `getToriiUrl`)
    * @returns A ToriiClient instance
    */
-  async getClient(project: string): Promise<torii.ToriiClient> {
-    const url = `https://api.cartridge.gg/x/${project}/torii`;
+  async getClient(toriiUrl: string): Promise<torii.ToriiClient> {
     const client = new torii.ToriiClient({
-      toriiUrl: url,
+      toriiUrl,
       worldAddress: "0x0",
     });
     return client;

--- a/packages/keychain/src/hooks/collection.ts
+++ b/packages/keychain/src/hooks/collection.ts
@@ -45,7 +45,7 @@ export function useCollection({
   tokenIds?: string[];
 }): UseCollectionResponse {
   const { address } = useAccountProfile({ overridable: true });
-  const { project } = useConnection();
+  const { toriiUrl } = useConnection();
 
   const [assets, setAssets] = useState<{ [key: string]: Asset }>({});
   const [collection, setCollection] = useState<Collection | undefined>(
@@ -57,9 +57,9 @@ export function useCollection({
   );
 
   useEffect(() => {
-    if (!project) return;
-    Torii.getClient(project).then((client) => setClient(client));
-  }, [project]);
+    if (!toriiUrl) return;
+    Torii.getClient(toriiUrl).then((client) => setClient(client));
+  }, [toriiUrl]);
 
   useEffect(() => {
     if (!client || !address || !trigger || !contractAddress) return;
@@ -97,9 +97,9 @@ export function useCollection({
         console.error(error);
       }
       if (!metadata.name || !metadata.image) return;
-      const contractImage = `https://api.cartridge.gg/x/${project}/torii/static/${addAddressPadding(contractAddress)}/image`;
-      const oldImage = `https://api.cartridge.gg/x/${project}/torii/static/0x${BigInt(contractAddress).toString(16)}/${asset.token_id}/image`;
-      const newImage = `https://api.cartridge.gg/x/${project}/torii/static/${addAddressPadding(contractAddress)}/${asset.token_id}/image`;
+      const contractImage = `${toriiUrl}/static/${addAddressPadding(contractAddress)}/image`;
+      const oldImage = `${toriiUrl}/static/0x${BigInt(contractAddress).toString(16)}/${asset.token_id}/image`;
+      const newImage = `${toriiUrl}/static/${addAddressPadding(contractAddress)}/${asset.token_id}/image`;
       const newCollection: Collection = {
         address: contractAddress,
         name: asset.name || metadata.name,
@@ -130,8 +130,8 @@ export function useCollection({
               BigInt(b.balance) !== 0n,
           )?.account_address;
           if (!owner) return; // Skip assets without owners
-          const oldImage = `https://api.cartridge.gg/x/${project}/torii/static/0x${BigInt(contractAddress).toString(16)}/${asset.token_id}/image`;
-          const newImage = `https://api.cartridge.gg/x/${project}/torii/static/${addAddressPadding(contractAddress)}/${asset.token_id}/image`;
+          const oldImage = `${toriiUrl}/static/0x${BigInt(contractAddress).toString(16)}/${asset.token_id}/image`;
+          const newImage = `${toriiUrl}/static/${addAddressPadding(contractAddress)}/${asset.token_id}/image`;
           const balance =
             balances.find(
               (b) =>
@@ -153,7 +153,7 @@ export function useCollection({
       setAssets(newAssets);
     };
     getCollections();
-  }, [client, address, trigger, project, contractAddress, tokenIds]);
+  }, [client, address, trigger, toriiUrl, contractAddress, tokenIds]);
 
   const refetch = useCallback(() => {
     setTrigger(true);
@@ -195,7 +195,7 @@ export type CollectionType = {
 
 export function useCollections(): UseCollectionsResponse {
   const { address } = useAccountProfile({ overridable: true });
-  const { project } = useConnection();
+  const { toriiUrl } = useConnection();
   const [collections, setCollections] = useState<{ [key: string]: Collection }>(
     {},
   );
@@ -205,9 +205,9 @@ export function useCollections(): UseCollectionsResponse {
   const [trigger, setTrigger] = useState(true);
 
   useEffect(() => {
-    if (!project) return;
-    Torii.getClient(project).then((client) => setClient(client));
-  }, [project]);
+    if (!toriiUrl) return;
+    Torii.getClient(toriiUrl).then((client) => setClient(client));
+  }, [toriiUrl]);
 
   useEffect(() => {
     if (!client || !address || !trigger) return;
@@ -249,8 +249,8 @@ export function useCollections(): UseCollectionsResponse {
           } catch (error) {
             console.error(error);
           }
-          const oldImage = `https://api.cartridge.gg/x/${project}/torii/static/0x${BigInt(contractAddress).toString(16)}/${asset.token_id}/image`;
-          const newImage = `https://api.cartridge.gg/x/${project}/torii/static/${addAddressPadding(contractAddress)}/${asset.token_id}/image`;
+          const oldImage = `${toriiUrl}/static/0x${BigInt(contractAddress).toString(16)}/${asset.token_id}/image`;
+          const newImage = `${toriiUrl}/static/${addAddressPadding(contractAddress)}/${asset.token_id}/image`;
           const type = contracts.find(
             (c) => c.contract_address === contractAddress,
           )?.contract_type;
@@ -266,7 +266,7 @@ export function useCollections(): UseCollectionsResponse {
       setCollections(collections);
     };
     getCollections();
-  }, [client, address, project, trigger]);
+  }, [client, address, toriiUrl, trigger]);
 
   const refetch = useCallback(() => {
     setTrigger(true);
@@ -289,17 +289,20 @@ export type UseToriiCollectionsResponse = {
 
 export function useToriiCollections(): UseToriiCollectionsResponse {
   const { provider } = useMarketplace();
-  const { project } = useConnection();
+  const { project, toriiUrl } = useConnection();
   const [client, setClient] = useState<ToriiClient | undefined>(undefined);
   const [status, setStatus] = useState<
     "success" | "error" | "idle" | "loading"
   >("idle");
   const [collections, setCollections] = useState<Collections>({});
 
+  // Identifier under which the marketplace keys this project's collections.
+  const projectKey = project ?? toriiUrl;
+
   const refetch = useCallback(() => {
-    if (!client || !project) return;
+    if (!client || !projectKey) return;
     setStatus("loading");
-    Marketplace.fetchCollections({ [project]: client }, LIMIT)
+    Marketplace.fetchCollections({ [projectKey]: client }, LIMIT)
       .then((collections) => {
         setCollections(collections);
         setStatus("success");
@@ -308,17 +311,16 @@ export function useToriiCollections(): UseToriiCollectionsResponse {
         setStatus("error");
         console.error(error);
       });
-  }, [project, client, setStatus, setCollections]);
+  }, [projectKey, client, setStatus, setCollections]);
 
   useEffect(() => {
-    if (!project) return;
+    if (!toriiUrl) return;
     const getClients = async () => {
-      const url = `https://api.cartridge.gg/x/${project}/torii`;
-      const client = await provider.getToriiClient(url);
+      const client = await provider.getToriiClient(toriiUrl);
       setClient(client);
     };
     getClients();
-  }, [provider, project]);
+  }, [provider, toriiUrl]);
 
   useEffect(() => {
     refetch();
@@ -345,7 +347,7 @@ export function useToriiCollection({
   tokenIds: string[];
 }): UseToriiCollectionResponse {
   const { provider } = useMarketplace();
-  const { project } = useConnection();
+  const { toriiUrl } = useConnection();
   const [client, setClient] = useState<ToriiClient | undefined>(undefined);
   const [status, setStatus] = useState<
     "success" | "error" | "idle" | "loading"
@@ -353,14 +355,13 @@ export function useToriiCollection({
   const [tokens, setTokens] = useState<Token[]>([]);
 
   useEffect(() => {
-    if (!project) return;
+    if (!toriiUrl) return;
     const getClient = async () => {
-      const url = `https://api.cartridge.gg/x/${project}/torii`;
-      const client = await provider.getToriiClient(url);
+      const client = await provider.getToriiClient(toriiUrl);
       setClient(client);
     };
     getClient();
-  }, [provider, project]);
+  }, [provider, toriiUrl]);
 
   const refetch = useCallback(() => {
     if (!client || !contractAddress || !tokenIds.length) return;

--- a/packages/keychain/src/hooks/connection.ts
+++ b/packages/keychain/src/hooks/connection.ts
@@ -5,6 +5,7 @@ import {
   VerifiableControllerTheme,
 } from "@/components/provider/connection";
 import { useNavigation } from "@/context/navigation";
+import { getToriiUrl } from "@/helpers/torii-url";
 import { connectToController } from "@/utils/connection";
 import type { HeadlessConnectionState } from "@/utils/connection/headless";
 import { requestPopupAuthOrigin } from "@/utils/connection/popup";
@@ -76,6 +77,7 @@ type ResolvedUrlParams = {
   shouldOverridePresetPolicies: boolean;
   version: string | null;
   project: string | null;
+  toriiUrl: string | null;
   namespace: string | null;
   tokens: string[];
   ref: string | null;
@@ -541,6 +543,8 @@ export function useConnectionValue() {
       urlParams.get("should_override_preset_policies") === "true";
     const version = urlParams.get("v");
     const project = urlParams.get("ps");
+    const toriiUrlParam = urlParams.get("torii");
+    const toriiUrl = toriiUrlParam ? decodeURIComponent(toriiUrlParam) : null;
     const namespace = urlParams.get("ns");
     const ref = urlParams.get("ref");
     const refGroup = urlParams.get("ref_group");
@@ -598,6 +602,7 @@ export function useConnectionValue() {
         false,
       version: version || urlParamsRef.current?.version || null,
       project: project || urlParamsRef.current?.project || null,
+      toriiUrl: toriiUrl || urlParamsRef.current?.toriiUrl || null,
       namespace: namespace || urlParamsRef.current?.namespace || null,
       tokens: erc20Param ? tokens : urlParamsRef.current?.tokens || tokens,
       ref: ref || urlParamsRef.current?.ref || null,
@@ -1141,6 +1146,12 @@ export function useConnectionValue() {
     [parent],
   );
 
+  // Resolved Torii URL: the `toriiUrl` override wins, else the Slot URL from `project`.
+  const toriiUrl = useMemo(
+    () => getToriiUrl(urlParams.project, urlParams.toriiUrl),
+    [urlParams.project, urlParams.toriiUrl],
+  );
+
   return {
     parent,
     controller,
@@ -1151,6 +1162,7 @@ export function useConnectionValue() {
     setOnModalClose,
     theme,
     project: urlParams.project,
+    toriiUrl,
     namespace: urlParams.namespace,
     tokens: urlParams.tokens,
     propagateError: urlParams.propagateError,

--- a/packages/keychain/src/hooks/connection.ts
+++ b/packages/keychain/src/hooks/connection.ts
@@ -41,6 +41,7 @@ import {
   USDC_CONTRACT_ADDRESS,
   USDT_CONTRACT_ADDRESS,
   LORDS_CONTRACT_ADDRESS,
+  isPublicChain,
 } from "@cartridge/controller-ui/utils";
 import { Eip191Credentials } from "@cartridge/controller-ui/utils/api/cartridge";
 import { getAddress } from "ethers";
@@ -391,6 +392,7 @@ export function useConnectionValue() {
     () => !!initialPreset,
   );
   const [isMainnet, setIsMainnet] = useState<boolean>(false);
+  const [isAppchain, setIsAppchain] = useState<boolean>(false);
   const [configData, setConfigData] = useState<Record<string, unknown> | null>(
     null,
   );
@@ -746,6 +748,8 @@ export function useConnectionValue() {
 
   useEffect(() => {
     setIsMainnet(controller?.chainId() === constants.StarknetChainId.SN_MAIN);
+    const chainId = controller?.chainId();
+    setIsAppchain(!!chainId && !isPublicChain(chainId));
   }, [controller]);
 
   // Load config when preset is provided
@@ -1174,6 +1178,7 @@ export function useConnectionValue() {
     isPoliciesResolved,
     isPoliciesError,
     isMainnet,
+    isAppchain,
     verified,
     chainId,
     setController,

--- a/packages/keychain/src/hooks/contracts.ts
+++ b/packages/keychain/src/hooks/contracts.ts
@@ -14,7 +14,7 @@ export function useTokenContract({
 }: {
   contractAddress?: string;
 }): UseTokenContractResponse {
-  const { project } = useConnection();
+  const { toriiUrl } = useConnection();
   const [tokenContract, setTokenContract] = useState<
     torii.TokenContract | undefined
   >(undefined);
@@ -27,9 +27,9 @@ export function useTokenContract({
   );
 
   useEffect(() => {
-    if (!project) return;
-    Torii.getClient(project).then((client) => setClient(client));
-  }, [project]);
+    if (!toriiUrl) return;
+    Torii.getClient(toriiUrl).then((client) => setClient(client));
+  }, [toriiUrl]);
 
   // console.log("COLLECTION", contractAddress?.slice(0, 10), tokenIds, address)
 
@@ -48,7 +48,7 @@ export function useTokenContract({
       }
     };
     getTokenContract();
-  }, [client, trigger, project, contractAddress]);
+  }, [client, trigger, toriiUrl, contractAddress]);
 
   const refetch = useCallback(() => {
     setTrigger(true);

--- a/packages/keychain/src/hooks/token.ts
+++ b/packages/keychain/src/hooks/token.ts
@@ -20,10 +20,9 @@ import * as torii from "@dojoengine/torii-wasm";
 
 const CONTRACT_TYPES: torii.ContractType[] = ["ERC20"];
 
-async function getToriiClient(project: string): Promise<torii.ToriiClient> {
-  const url = `https://api.cartridge.gg/x/${project}/torii`;
+async function getToriiClient(toriiUrl: string): Promise<torii.ToriiClient> {
   const client = await new torii.ToriiClient({
-    toriiUrl: url,
+    toriiUrl,
     worldAddress: "0x0",
   });
   return client;
@@ -206,20 +205,20 @@ export function useTokens(accountAddress?: string): UseTokensResponse {
   const provider = controller?.provider;
   const account = useAccount();
   const address = account?.address || "";
-  const { project } = useConnection();
+  const { toriiUrl } = useConnection();
   const [contracts, setContracts] = useState<string[]>([]);
 
   useEffect(() => {
     async function getContracts() {
-      if (!project || !address) return;
-      const client = await getToriiClient(project);
+      if (!toriiUrl || !address) return;
+      const client = await getToriiClient(toriiUrl);
       const contracts = await fetchContracts(client);
       setContracts(
         contracts.map((c) => getChecksumAddress(c.contract_address)),
       );
     }
     getContracts();
-  }, [project, address]);
+  }, [toriiUrl, address]);
 
   // Fetch credits
   const { username } = useUsername({ address });

--- a/packages/keychain/src/hooks/transfers.ts
+++ b/packages/keychain/src/hooks/transfers.ts
@@ -7,18 +7,18 @@ import type { TokenTransfer } from "@dojoengine/torii-wasm";
 export type Transfer = TokenTransfer;
 
 export const useTransfers = (contractAddress: string, tokenId: string[]) => {
-  const { project } = useConnection();
+  const { toriiUrl } = useConnection();
   const [client, setClient] = useState<Awaited<
     ReturnType<typeof Torii.getClient>
   > | null>(null);
 
   useEffect(() => {
-    if (!project) return;
-    Torii.getClient(project).then(setClient);
-  }, [project]);
+    if (!toriiUrl) return;
+    Torii.getClient(toriiUrl).then(setClient);
+  }, [toriiUrl]);
 
   const query = useQuery(
-    ["transfers", contractAddress, tokenId, project],
+    ["transfers", contractAddress, tokenId, toriiUrl],
     async () => {
       if (!client) return [];
       const result = await Torii.fetchTransfers(

--- a/packages/keychain/src/test/mocks/connection.tsx
+++ b/packages/keychain/src/test/mocks/connection.tsx
@@ -36,6 +36,7 @@ export const defaultMockConnection: ConnectionContextValue = {
   isPoliciesResolved: true,
   isPoliciesError: false,
   isMainnet: false,
+  isAppchain: false,
   theme: {
     verified: true,
     name: "test",

--- a/packages/keychain/src/test/mocks/connection.tsx
+++ b/packages/keychain/src/test/mocks/connection.tsx
@@ -29,6 +29,7 @@ export const defaultMockConnection: ConnectionContextValue = {
   chainId: "SN_MAIN",
   parent: undefined,
   project: null,
+  toriiUrl: null,
   namespace: null,
   verified: false,
   isConfigLoading: false,

--- a/packages/keychain/src/test/mocks/connection.tsx
+++ b/packages/keychain/src/test/mocks/connection.tsx
@@ -18,6 +18,9 @@ const defaultMockController: any = {
   chainId: vi.fn().mockImplementation(() => constants.StarknetChainId.SN_MAIN),
   address: vi.fn().mockImplementation(async () => "0x123456789abcdef"),
   username: vi.fn().mockImplementation(async () => "testuser"),
+  provider: {
+    getClassHashAt: vi.fn().mockResolvedValue("0x0"),
+  },
 } as const;
 
 export const defaultMockConnection: ConnectionContextValue = {


### PR DESCRIPTION
* added `toriiUrl` to `ControllerOptions`, substitute for `slot` when fetching owned tokens
* fixed the upgrade screen asking to add funds on Katana