### PR TITLE
feat: credits() balance read on controller SDK

### DIFF
--- a/packages/connector/src/controller.ts
+++ b/packages/connector/src/controller.ts
@@ -38,6 +38,10 @@ export default class ControllerConnector extends InjectedConnector {
     return this.controller.username();
   }
 
+  credits() {
+    return this.controller.credits();
+  }
+
   lookupUsername(username: string) {
     return this.controller.lookupUsername(username);
   }

--- a/packages/controller/src/__tests__/credits.test.ts
+++ b/packages/controller/src/__tests__/credits.test.ts
@@ -1,0 +1,37 @@
+import ControllerProvider from "../controller";
+
+describe("ControllerProvider.credits", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("returns the credits balance from the keychain", async () => {
+    const controller = new ControllerProvider({});
+    const keychainCredits = jest.fn().mockResolvedValue(1234);
+    (controller as any).keychain = {
+      credits: keychainCredits,
+    };
+
+    await expect(controller.credits()).resolves.toBe(1234);
+    expect(keychainCredits).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns undefined and logs when keychain is not ready", () => {
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const controller = new ControllerProvider({});
+
+    expect(controller.credits()).toBeUndefined();
+    expect(consoleError).toHaveBeenCalled();
+  });
+
+  test("propagates keychain errors", async () => {
+    const controller = new ControllerProvider({});
+    (controller as any).keychain = {
+      credits: jest.fn().mockRejectedValue(new Error("NOT_CONNECTED")),
+    };
+
+    await expect(controller.credits()).rejects.toThrow("NOT_CONNECTED");
+  });
+});

--- a/packages/controller/src/controller.ts
+++ b/packages/controller/src/controller.ts
@@ -608,6 +608,25 @@ export default class ControllerProvider extends BaseProvider {
     return this.keychain.username();
   }
 
+  /**
+   * Get the Cartridge Credits balance of the currently connected account.
+   *
+   * The balance is returned as a raw credits amount, where 1 credit = $0.01
+   * USD. Games typically format it as dollars for display, e.g.
+   * `(credits / 100).toFixed(2)`.
+   *
+   * This is a display-only read; the Cartridge backend remains authoritative
+   * for all credits accounting.
+   */
+  credits() {
+    if (!this.keychain) {
+      console.error(new NotReadyToConnect().message);
+      return;
+    }
+
+    return this.keychain.credits();
+  }
+
   async openLocationPrompt(options?: LocationPromptOptions) {
     if (!this.iframes) {
       return;

--- a/packages/controller/src/types.ts
+++ b/packages/controller/src/types.ts
@@ -198,6 +198,7 @@ export interface Keychain {
   }>;
   delegateAccount(): string;
   username(): string;
+  credits(): Promise<number>;
   openPurchaseCredits(): void;
   openExecute(calls: Call[]): Promise<void>;
   openLocationPrompt(

--- a/packages/keychain/src/utils/connection/credits.test.ts
+++ b/packages/keychain/src/utils/connection/credits.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { creditsFactory } from "./credits";
+import { ResponseCodes } from "@cartridge/controller";
+import { fetchData } from "@/utils/graphql";
+import { CreditDocument } from "@/utils/api";
+
+vi.mock("@/utils/graphql", () => ({
+  fetchData: vi.fn(),
+}));
+
+describe("creditsFactory", () => {
+  const mockController = {
+    username: vi.fn(() => "alice"),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.controller = mockController as unknown as Window["controller"];
+  });
+
+  afterEach(() => {
+    window.controller = undefined;
+  });
+
+  it("rejects when no controller is connected", async () => {
+    window.controller = undefined;
+
+    const credits = creditsFactory();
+
+    await expect(credits()).rejects.toEqual({
+      code: ResponseCodes.NOT_CONNECTED,
+    });
+    expect(fetchData).not.toHaveBeenCalled();
+  });
+
+  it("queries the current account's credits and returns the balance", async () => {
+    vi.mocked(fetchData).mockResolvedValue({
+      account: {
+        credits: { amount: "1234000000", decimals: 6 },
+      },
+    });
+
+    const credits = creditsFactory();
+
+    await expect(credits()).resolves.toBe(1234);
+    expect(mockController.username).toHaveBeenCalled();
+    expect(fetchData).toHaveBeenCalledWith(CreditDocument, {
+      username: "alice",
+    });
+  });
+
+  it("handles zero-decimal balances", async () => {
+    vi.mocked(fetchData).mockResolvedValue({
+      account: {
+        credits: { amount: "250", decimals: 0 },
+      },
+    });
+
+    const credits = creditsFactory();
+
+    await expect(credits()).resolves.toBe(250);
+  });
+
+  it("returns 0 when the account has no credits", async () => {
+    vi.mocked(fetchData).mockResolvedValue({ account: null });
+
+    const credits = creditsFactory();
+
+    await expect(credits()).resolves.toBe(0);
+  });
+
+  it("propagates API errors", async () => {
+    vi.mocked(fetchData).mockRejectedValue(new Error("network error"));
+
+    const credits = creditsFactory();
+
+    await expect(credits()).rejects.toThrow("network error");
+  });
+});

--- a/packages/keychain/src/utils/connection/credits.ts
+++ b/packages/keychain/src/utils/connection/credits.ts
@@ -1,0 +1,34 @@
+import { ResponseCodes } from "@cartridge/controller";
+import { CreditDocument, CreditQuery, CreditQueryVariables } from "@/utils/api";
+import { fetchData } from "@/utils/graphql";
+
+/**
+ * Returns the Cartridge Credits balance of the currently authenticated
+ * account, denominated in credits (1 credit = $0.01 USD).
+ *
+ * Requires an authenticated session: the handler only ever queries the
+ * balance of the controller currently connected in the keychain, never an
+ * arbitrary username supplied by the caller.
+ */
+export function creditsFactory() {
+  return async (): Promise<number> => {
+    if (!window.controller) {
+      return Promise.reject({
+        code: ResponseCodes.NOT_CONNECTED,
+      });
+    }
+
+    const username = window.controller.username();
+    const data = await fetchData<CreditQuery, CreditQueryVariables>(
+      CreditDocument,
+      { username },
+    );
+
+    const credits = data.account?.credits;
+    if (!credits) {
+      return 0;
+    }
+
+    return Number(credits.amount) / Math.pow(10, credits.decimals);
+  };
+}

--- a/packages/keychain/src/utils/connection/index.ts
+++ b/packages/keychain/src/utils/connection/index.ts
@@ -2,6 +2,7 @@ import Controller from "@/utils/controller";
 import { connectToParent } from "@cartridge/penpal";
 import { normalize } from "@cartridge/controller-ui/utils";
 import { connect } from "./connect";
+import { creditsFactory } from "./credits";
 import { deployFactory } from "./deploy";
 import { estimateInvokeFee } from "./estimate";
 import { execute } from "./execute";
@@ -173,6 +174,7 @@ export function connectToController<
         await window.controller?.disconnect();
       },
       username: () => () => window.controller?.username(),
+      credits: () => creditsFactory(),
       delegateAccount: () => () => window.controller?.delegateAccount(),
       openPurchaseCredits: () => () => {
         navigate("/funding", { replace: true });


### PR DESCRIPTION
## Motivation

Games need to render the user's Cartridge Credits balance in their own UI — e.g. a header balance tile or a "Play · $1" affordance. First consumer is PuttFall, which now stakes Cartridge credits on ranked matches and needs a display-only read of the balance. The platform backend stays authoritative on every debit; this PR adds no spend or auth-token surface.

## API

```ts
const controller = new Controller();

// Raw credits balance of the connected account. 1 credit = $0.01 USD.
// Games typically format it as dollars: `(credits / 100).toFixed(2)`.
const credits = await controller.credits(); // Promise<number>
```

Also mirrored on `ControllerConnector` (`connector.credits()`), same as `username()`.

## Plumbing

Mirrors the existing `username()` seam end to end:

- `packages/controller/src/types.ts` — `credits(): Promise<number>` added to the `Keychain` interface.
- `packages/controller/src/controller.ts` — `credits()` on `ControllerProvider`, delegating to the keychain iframe RPC (same not-ready guard as `username()`).
- `packages/connector/src/controller.ts` — `credits()` passthrough on the starknet-react connector.
- `packages/keychain/src/utils/connection/credits.ts` — keychain-side handler. Rejects with `NOT_CONNECTED` when no controller session is active, then resolves the **current** account's balance via the existing `Credit` GraphQL query (`packages/keychain/src/utils/api/account.graphql`) through the imperative `fetchData` client (`@/utils/graphql`, cookie/bearer auth included). The username is always taken from `window.controller` — never from the caller.
- No new GraphQL documents or codegen changes needed; `CreditDocument` already existed in the generated API.

"Add funds" needs no new surface: `openPurchaseCredits()` already deep-links to the funding flow.

## Tests

- `packages/controller/src/__tests__/credits.test.ts` (jest): resolves balance from the keychain RPC, returns `undefined` + logs when keychain not ready, propagates rejections.
- `packages/keychain/src/utils/connection/credits.test.ts` (vitest): rejects when unauthenticated, queries `CreditDocument` with the connected username, converts `amount`/`decimals` to whole credits, returns 0 for missing accounts, propagates API errors.

Evidence: `pnpm lint:check` clean; controller suite 55/55; keychain suite 40 files / 586 passed (with `--no-experimental-webstorage` on Node 25 — pre-existing env issue in `features.test.tsx`, unrelated); connector 1/1; `turbo build:deps build` green for controller/connector/keychain.

## Follow-ups

- Credits-change events (push/subscription) so games don't have to poll after a match settles.
- Backend Authorization surface: games' own backends (e.g. PuttFall's match-settlement service) need a way to call the platform API on behalf of the user for authoritative debits — intentionally excluded here as it's a separate security discussion.
- The live API schema has drifted from the checked-in generated GraphQL types (new Coinflow credits-intent types); left untouched to keep this diff focused.
