### PR TITLE
fix: harden 0.13.12+ keychain compatibility

### DIFF
--- a/packages/controller/src/__tests__/keychainCompatibility.test.ts
+++ b/packages/controller/src/__tests__/keychainCompatibility.test.ts
@@ -1,0 +1,224 @@
+const mockExternalDetectWallets = jest.fn();
+const mockExternalConnectWallet = jest.fn();
+const mockExternalSignMessage = jest.fn();
+const mockExternalSignTypedData = jest.fn();
+const mockExternalSendTransaction = jest.fn();
+const mockExternalGetBalance = jest.fn();
+const mockExternalSwitchChain = jest.fn();
+const mockExternalWaitForTransaction = jest.fn();
+
+// Capture the reverse (keychain -> SDK) method table where KeychainIFrame
+// hands it to the real IFrame/Penpal boundary. Wallet implementations are
+// deterministic spies; KeychainIFrame's URL and wrapper construction are real.
+const mockBridgeMethods = {
+  externalDetectWallets: (_origin: string) => mockExternalDetectWallets,
+  externalConnectWallet: (_origin: string) => mockExternalConnectWallet,
+  externalSignMessage: (_origin: string) => mockExternalSignMessage,
+  externalSignTypedData: (_origin: string) => mockExternalSignTypedData,
+  externalSendTransaction: (_origin: string) => mockExternalSendTransaction,
+  externalGetBalance: (_origin: string) => mockExternalGetBalance,
+  externalSwitchChain: (_origin: string) => mockExternalSwitchChain,
+  externalWaitForTransaction: (_origin: string) =>
+    mockExternalWaitForTransaction,
+};
+
+let mockIFrameOptions: {
+  url: URL;
+  methods: Record<string, (origin: string) => (...args: any[]) => unknown>;
+};
+
+jest.mock("../iframe/base", () => ({
+  IFrame: class {
+    constructor(options: typeof mockIFrameOptions) {
+      mockIFrameOptions = options;
+    }
+
+    close() {}
+  },
+}));
+
+jest.mock("../wallets/bridge", () => ({
+  WalletBridge: jest.fn().mockImplementation(() => ({
+    getIFrameMethods: () => mockBridgeMethods,
+  })),
+}));
+
+import { KeychainIFrame } from "../iframe/keychain";
+
+const createKeychain = (overrides: Record<string, unknown> = {}) =>
+  new KeychainIFrame({
+    url: "https://x.cartridge.gg",
+    onConnect: jest.fn(),
+    ...overrides,
+  });
+
+describe("hosted keychain compatibility contract", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("keeps the SDK version gate and sends both Torii generations additively", () => {
+    createKeychain({
+      version: "0.13.13",
+      slot: "legacy-game",
+      toriiUrl: "https://torii.example.com/custom/",
+    });
+
+    expect(
+      decodeURIComponent(mockIFrameOptions.url.searchParams.get("v")!),
+    ).toBe("0.13.13");
+    expect(
+      decodeURIComponent(mockIFrameOptions.url.searchParams.get("ps")!),
+    ).toBe("legacy-game");
+    expect(
+      decodeURIComponent(mockIFrameOptions.url.searchParams.get("torii")!),
+    ).toBe("https://torii.example.com/custom/");
+  });
+
+  it("leaves the 0.13.12 Slot-only query contract unchanged", () => {
+    createKeychain({ version: "0.13.12", slot: "legacy-game" });
+
+    expect(
+      decodeURIComponent(mockIFrameOptions.url.searchParams.get("v")!),
+    ).toBe("0.13.12");
+    expect(
+      decodeURIComponent(mockIFrameOptions.url.searchParams.get("ps")!),
+    ).toBe("legacy-game");
+    expect(mockIFrameOptions.url.searchParams.has("torii")).toBe(false);
+  });
+
+  it.each(["0.13.12", "0.13.13", "0.14.0-alpha.1"])(
+    "keeps the same hosted bridge surface for Controller %s",
+    (version) => {
+      createKeychain({ version });
+
+      expect(
+        decodeURIComponent(mockIFrameOptions.url.searchParams.get("v")!),
+      ).toBe(version);
+      expect(Object.keys(mockIFrameOptions.methods)).toEqual(
+        expect.arrayContaining([
+          ...Object.keys(mockBridgeMethods),
+          "onSessionCreated",
+          "onStarterpackPlay",
+        ]),
+      );
+    },
+  );
+
+  it("exposes the established external-wallet bridge names and positions", async () => {
+    createKeychain();
+
+    const externalMethods = Object.keys(mockIFrameOptions.methods)
+      .filter((name) => name.startsWith("external"))
+      .sort();
+    expect(externalMethods).toEqual(
+      expect.arrayContaining([
+        "externalConnectWallet",
+        "externalDetectWallets",
+        "externalGetBalance",
+        "externalSendTransaction",
+        "externalSignMessage",
+        "externalSignTypedData",
+        "externalSwitchChain",
+        "externalWaitForTransaction",
+      ]),
+    );
+
+    mockExternalDetectWallets.mockResolvedValue([
+      { type: "metamask", available: true },
+    ]);
+    mockExternalConnectWallet.mockResolvedValue({
+      success: true,
+      wallet: "metamask",
+      account: "0xabc",
+    });
+    mockExternalSignMessage.mockResolvedValue({
+      success: true,
+      wallet: "metamask",
+      result: "0xsig",
+    });
+    mockExternalSignTypedData.mockResolvedValue({
+      success: true,
+      wallet: "metamask",
+      result: "0xtyped",
+    });
+    mockExternalSendTransaction.mockResolvedValue({
+      success: true,
+      wallet: "metamask",
+      result: "0xtx",
+    });
+    mockExternalGetBalance.mockResolvedValue({
+      success: true,
+      wallet: "metamask",
+      result: "0x10",
+    });
+    mockExternalSwitchChain.mockResolvedValue(true);
+    mockExternalWaitForTransaction.mockResolvedValue({
+      success: true,
+      wallet: "metamask",
+      result: { status: "confirmed" },
+    });
+
+    const methods = mockIFrameOptions.methods;
+    const results = [
+      await methods.externalDetectWallets("https://game.example")(),
+      await methods.externalConnectWallet("https://game.example")("metamask"),
+      await methods.externalSignMessage("https://game.example")(
+        "metamask",
+        "hello",
+      ),
+      await methods.externalSignTypedData("https://game.example")("metamask", {
+        domain: { name: "game" },
+      }),
+      await methods.externalSendTransaction("https://game.example")(
+        "metamask",
+        { to: "0x123" },
+      ),
+      await methods.externalGetBalance("https://game.example")(
+        "metamask",
+        "0xtoken",
+      ),
+      await methods.externalSwitchChain("https://game.example")(
+        "metamask",
+        "0x1",
+      ),
+      await methods.externalWaitForTransaction("https://game.example")(
+        "metamask",
+        "0xtx",
+        30_000,
+      ),
+    ];
+
+    expect(mockExternalDetectWallets).toHaveBeenCalledWith();
+    expect(mockExternalConnectWallet).toHaveBeenCalledWith("metamask");
+    expect(mockExternalSignMessage).toHaveBeenCalledWith("metamask", "hello");
+    expect(mockExternalSignTypedData).toHaveBeenCalledWith("metamask", {
+      domain: { name: "game" },
+    });
+    expect(mockExternalSendTransaction).toHaveBeenCalledWith("metamask", {
+      to: "0x123",
+    });
+    expect(mockExternalGetBalance).toHaveBeenCalledWith("metamask", "0xtoken");
+    expect(mockExternalSwitchChain).toHaveBeenCalledWith("metamask", "0x1");
+    expect(mockExternalWaitForTransaction).toHaveBeenCalledWith(
+      "metamask",
+      "0xtx",
+      30_000,
+    );
+    expect(results).toEqual([
+      [{ type: "metamask", available: true }],
+      { success: true, wallet: "metamask", account: "0xabc" },
+      { success: true, wallet: "metamask", result: "0xsig" },
+      { success: true, wallet: "metamask", result: "0xtyped" },
+      { success: true, wallet: "metamask", result: "0xtx" },
+      { success: true, wallet: "metamask", result: "0x10" },
+      true,
+      {
+        success: true,
+        wallet: "metamask",
+        result: { status: "confirmed" },
+      },
+    ]);
+    expect(JSON.parse(JSON.stringify(results))).toEqual(results);
+  });
+});

--- a/packages/keychain/src/components/ConnectRoute.test.tsx
+++ b/packages/keychain/src/components/ConnectRoute.test.tsx
@@ -3,6 +3,7 @@ import { screen, waitFor } from "@testing-library/react";
 import { ConnectRoute } from "./ConnectRoute";
 import { renderWithProviders } from "@/test/mocks/providers";
 import { ResponseCodes } from "@cartridge/controller";
+import { SemVer } from "semver";
 
 // Mock dependencies
 const mockSafeRedirect = vi.fn();
@@ -46,6 +47,7 @@ const defaultConnection = {
   ageGate: undefined,
   locationGateVerified: false,
   isNewControllerRef: { current: false },
+  controllerVersion: new SemVer("0.13.13"),
 };
 
 const mockUseConnection = vi.fn();
@@ -76,9 +78,14 @@ vi.mock("@/utils/connection/callbacks", () => ({
 }));
 
 const mockParseConnectParams = vi.fn();
-vi.mock("@/utils/connection/connect", () => ({
-  parseConnectParams: (...args: unknown[]) => mockParseConnectParams(...args),
-}));
+vi.mock("@/utils/connection/connect", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/utils/connection/connect")>();
+  return {
+    ...actual,
+    parseConnectParams: (...args: unknown[]) => mockParseConnectParams(...args),
+  };
+});
 
 // Snapshot functionality removed in commit 66db7db5
 // const mockSnapshotLocalStorageToCookie = vi.fn();
@@ -150,6 +157,45 @@ describe("ConnectRoute", () => {
           keepOpen: false,
         });
         expect(mockCleanupCallbacks).toHaveBeenCalledWith("test-id");
+      });
+    });
+
+    it("keeps onboarding visible on first mount for v0.13.13", async () => {
+      mockLocation.search = "?v=0.13.13";
+      mockUseConnection.mockReturnValue({
+        controller: mockController,
+        controllerVersion: new SemVer("0.13.13"),
+        policies: null,
+        isNewControllerRef: { current: true },
+      });
+
+      renderWithProviders(<ConnectRoute />);
+
+      await waitFor(() => {
+        expect(mockParams.resolve).toHaveBeenCalledWith({
+          code: ResponseCodes.SUCCESS,
+          address: "0x123456789abcdef",
+          keepOpen: true,
+        });
+      });
+    });
+
+    it("omits keepOpen for a preloaded v0.13.12 controller", async () => {
+      mockLocation.search = "?v=0.13.12";
+      mockUseConnection.mockReturnValue({
+        controller: mockController,
+        controllerVersion: new SemVer("0.13.12"),
+        policies: null,
+        isNewControllerRef: { current: true },
+      });
+
+      renderWithProviders(<ConnectRoute />);
+
+      await waitFor(() => {
+        expect(mockParams.resolve).toHaveBeenCalledWith({
+          code: ResponseCodes.SUCCESS,
+          address: "0x123456789abcdef",
+        });
       });
     });
 

--- a/packages/keychain/src/components/ConnectRoute.tsx
+++ b/packages/keychain/src/components/ConnectRoute.tsx
@@ -4,7 +4,11 @@ import { ResponseCodes } from "@cartridge/controller";
 import { useConnection } from "@/hooks/connection";
 import { hasApprovalPolicies } from "@/hooks/session";
 import { cleanupCallbacks } from "@/utils/connection/callbacks";
-import { parseConnectParams } from "@/utils/connection/connect";
+import {
+  createConnectReply,
+  parseConnectParams,
+  supportsConnectKeepOpen,
+} from "@/utils/connection/connect";
 import { hasConfiguredLocationGate } from "@/utils/location-gate";
 import { createLocationGateUrl } from "@/utils/connection/location-gate";
 import { CreateSession } from "./connect/CreateSession";
@@ -56,6 +60,7 @@ export function ConnectRoute() {
     locationGate,
     locationGateVerified,
     isNewControllerRef,
+    controllerVersion,
   } = useConnection();
   const navigate = useNavigate();
   const [hasAutoConnected, setHasAutoConnected] = useState(false);
@@ -87,6 +92,7 @@ export function ConnectRoute() {
 
   // Check if this is standalone mode (not in iframe)
   const isStandalone = useMemo(() => !isIframe(), []);
+  const canKeepOpen = supportsConnectKeepOpen(controllerVersion, isStandalone);
 
   // Get redirect_url from query params for standalone mode
   const redirectUrl = useMemo(() => {
@@ -163,11 +169,13 @@ export function ConnectRoute() {
       }
     }
 
-    params.resolve?.({
-      code: ResponseCodes.SUCCESS,
-      address: controller.address(),
-      keepOpen: isNewControllerRef.current,
-    });
+    params.resolve?.(
+      createConnectReply(
+        controller.address(),
+        isNewControllerRef.current === true,
+        canKeepOpen,
+      ),
+    );
     if (params.params.id) {
       cleanupCallbacks(params.params.id);
     }
@@ -212,6 +220,7 @@ export function ConnectRoute() {
     isStandalone,
     redirectUrl,
     isNewControllerRef,
+    canKeepOpen,
   ]);
 
   const handleSkip = useCallback(async () => {
@@ -227,11 +236,13 @@ export function ConnectRoute() {
       }
     }
 
-    params.resolve?.({
-      code: ResponseCodes.SUCCESS,
-      address: controller.address(),
-      keepOpen: isNewControllerRef.current,
-    });
+    params.resolve?.(
+      createConnectReply(
+        controller.address(),
+        isNewControllerRef.current === true,
+        canKeepOpen,
+      ),
+    );
     if (params.params.id) {
       cleanupCallbacks(params.params.id);
     }
@@ -276,6 +287,7 @@ export function ConnectRoute() {
     isStandalone,
     redirectUrl,
     isNewControllerRef,
+    canKeepOpen,
   ]);
 
   // Handle cases where we can connect immediately (embedded mode only)
@@ -304,11 +316,13 @@ export function ConnectRoute() {
       if (hasRequestedSession) {
         setHasAutoConnected(true);
         clearConnectParams();
-        params.resolve?.({
-          code: ResponseCodes.SUCCESS,
-          address: controller.address(),
-          keepOpen: isNewControllerRef.current,
-        });
+        params.resolve?.(
+          createConnectReply(
+            controller.address(),
+            isNewControllerRef.current === true,
+            canKeepOpen,
+          ),
+        );
 
         if (params.params.id) {
           cleanupCallbacks(params.params.id);
@@ -349,11 +363,13 @@ export function ConnectRoute() {
 
     // if no policies, we can connect immediately
     if (!policies) {
-      params.resolve?.({
-        code: ResponseCodes.SUCCESS,
-        address: controller.address(),
-        keepOpen: isNewControllerRef.current,
-      });
+      params.resolve?.(
+        createConnectReply(
+          controller.address(),
+          isNewControllerRef.current === true,
+          canKeepOpen,
+        ),
+      );
 
       if (params.params.id) {
         cleanupCallbacks(params.params.id);
@@ -377,11 +393,13 @@ export function ConnectRoute() {
               policies,
             });
           }
-          params.resolve?.({
-            code: ResponseCodes.SUCCESS,
-            address: controller.address(),
-            keepOpen: isNewControllerRef.current,
-          });
+          params.resolve?.(
+            createConnectReply(
+              controller.address(),
+              isNewControllerRef.current === true,
+              canKeepOpen,
+            ),
+          );
           if (params.params.id) {
             cleanupCallbacks(params.params.id);
           }
@@ -421,6 +439,7 @@ export function ConnectRoute() {
     locationGateVerified,
     navigate,
     isNewControllerRef,
+    canKeepOpen,
   ]);
 
   // Don't render anything if we don't have controller yet - CreateController handles loading
@@ -457,11 +476,13 @@ export function ConnectRoute() {
           } else {
             await createVerifiedSession({ controller, origin, policies });
           }
-          params?.resolve?.({
-            code: ResponseCodes.SUCCESS,
-            address: controller.address(),
-            keepOpen: isNewControllerRef.current,
-          });
+          params?.resolve?.(
+            createConnectReply(
+              controller.address(),
+              isNewControllerRef.current === true,
+              canKeepOpen,
+            ),
+          );
           if (params?.params.id) {
             cleanupCallbacks(params.params.id);
           }

--- a/packages/keychain/src/components/connect/create/useCreateController.ts
+++ b/packages/keychain/src/components/connect/create/useCreateController.ts
@@ -13,6 +13,7 @@ import {
   ResponseCodes,
   WalletAdapter,
 } from "@cartridge/controller";
+import { isIframe } from "@cartridge/controller-ui/utils";
 import { computeAccountAddress, Signer } from "@cartridge/controller-wasm";
 import {
   ControllerQuery,
@@ -38,7 +39,11 @@ import { useWalletConnectAuthentication } from "./wallet-connect";
 import { useWebauthnAuthentication } from "./webauthn";
 import { cleanupCallbacks } from "@/utils/connection/callbacks";
 import { useRouteCallbacks, useRouteCompletion } from "@/hooks/route";
-import { parseConnectParams } from "@/utils/connection/connect";
+import {
+  createConnectReply,
+  parseConnectParams,
+  supportsConnectKeepOpen,
+} from "@/utils/connection/connect";
 import { ParsedSessionPolicies } from "@/hooks/session";
 import { safeRedirect } from "@/utils/url-validator";
 import {
@@ -101,6 +106,7 @@ const resolveConnect = async ({
   searchParams,
   missingParamsMessage,
   isNewController,
+  canKeepOpen,
   emitUserToast,
 }: {
   controller: Controller;
@@ -110,6 +116,7 @@ const resolveConnect = async ({
   searchParams: URLSearchParams;
   missingParamsMessage: string;
   isNewController: boolean;
+  canKeepOpen: boolean;
   emitUserToast?: EmitUserToast;
 }) => {
   let currentParams = params;
@@ -133,11 +140,9 @@ const resolveConnect = async ({
   url.search = "";
   window.history.replaceState(null, "", url.toString());
 
-  currentParams.resolve?.({
-    code: ResponseCodes.SUCCESS,
-    address: controller.address(),
-    keepOpen: isNewController,
-  });
+  currentParams.resolve?.(
+    createConnectReply(controller.address(), isNewController, canKeepOpen),
+  );
   if (currentParams.params.id) {
     cleanupCallbacks(currentParams.params.id);
   }
@@ -154,6 +159,7 @@ const createSession = async ({
   closeModal,
   searchParams,
   isNewController,
+  canKeepOpen,
   emitUserToast,
 }: {
   controller: Controller;
@@ -164,6 +170,7 @@ const createSession = async ({
   closeModal?: () => void;
   searchParams: URLSearchParams;
   isNewController: boolean;
+  canKeepOpen: boolean;
   emitUserToast?: EmitUserToast;
 }) => {
   // Handle no policies case - try to resolve connection, fallback to just closing modal
@@ -177,6 +184,7 @@ const createSession = async ({
       missingParamsMessage:
         "No params available for no-policies case, falling back to closeModal",
       isNewController,
+      canKeepOpen,
       emitUserToast,
     });
     return;
@@ -208,11 +216,9 @@ const createSession = async ({
       origin,
       policies,
     });
-    currentParams.resolve?.({
-      code: ResponseCodes.SUCCESS,
-      address: controller.address(),
-      keepOpen: isNewController,
-    });
+    currentParams.resolve?.(
+      createConnectReply(controller.address(), isNewController, canKeepOpen),
+    );
     if (currentParams.params.id) {
       cleanupCallbacks(currentParams.params.id);
     }
@@ -233,6 +239,7 @@ const completePopupConnect = async ({
   closeModal,
   searchParams,
   isNewController,
+  canKeepOpen,
   emitUserToast,
 }: {
   controller: Controller;
@@ -241,6 +248,7 @@ const completePopupConnect = async ({
   closeModal?: () => void;
   searchParams: URLSearchParams;
   isNewController: boolean;
+  canKeepOpen: boolean;
   emitUserToast?: EmitUserToast;
 }) => {
   await resolveConnect({
@@ -252,6 +260,7 @@ const completePopupConnect = async ({
     missingParamsMessage:
       "Params not available after popup auth, falling back to closeModal",
     isNewController,
+    canKeepOpen,
     emitUserToast,
   });
 };
@@ -341,7 +350,9 @@ export function useCreateController({
     locationGateVerified,
     setIsNewController,
     webauthnPopup,
+    controllerVersion,
   } = useConnection();
+  const canKeepOpen = supportsConnectKeepOpen(controllerVersion, !isIframe());
 
   // When location gate is configured and not yet verified, skip auto-session
   // creation and connect resolution. The natural re-render will show LocationGate
@@ -558,6 +569,7 @@ export function useCreateController({
             handleCompletion,
             searchParams,
             isNewController: true,
+            canKeepOpen,
             emitUserToast,
           });
         }
@@ -576,6 +588,7 @@ export function useCreateController({
       params,
       searchParams,
       shouldAutoCreateSession,
+      canKeepOpen,
       emitUserToast,
     ],
   );
@@ -604,6 +617,7 @@ export function useCreateController({
                 handleCompletion,
                 searchParams,
                 isNewController: true,
+                canKeepOpen,
                 emitUserToast,
               });
             }
@@ -740,6 +754,7 @@ export function useCreateController({
       handleCompletion,
       searchParams,
       changeWallet,
+      canKeepOpen,
       emitUserToast,
     ],
   );
@@ -870,6 +885,7 @@ export function useCreateController({
           handleCompletion,
           searchParams,
           isNewController: false,
+          canKeepOpen,
           emitUserToast,
         });
       }
@@ -887,6 +903,7 @@ export function useCreateController({
       params,
       searchParams,
       shouldAutoCreateSession,
+      canKeepOpen,
       emitUserToast,
     ],
   );
@@ -917,6 +934,7 @@ export function useCreateController({
             handleCompletion,
             searchParams,
             isNewController: false,
+            canKeepOpen,
             emitUserToast,
           });
         }
@@ -965,6 +983,7 @@ export function useCreateController({
                 handleCompletion,
                 searchParams,
                 isNewController: false,
+                canKeepOpen,
                 emitUserToast,
               });
             }
@@ -980,6 +999,7 @@ export function useCreateController({
               handleCompletion,
               searchParams,
               isNewController: false,
+              canKeepOpen,
               emitUserToast,
             });
           }
@@ -1110,6 +1130,7 @@ export function useCreateController({
       smsState,
       setWaitingForConfirmation,
       changeWallet,
+      canKeepOpen,
       emitUserToast,
     ],
   );

--- a/packages/keychain/src/helpers/torii-url.test.ts
+++ b/packages/keychain/src/helpers/torii-url.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { getToriiUrl } from "./torii-url";
+
+describe("getToriiUrl compatibility", () => {
+  it("uses an explicit Torii URL ahead of the legacy Slot project", () => {
+    expect(
+      getToriiUrl(
+        "legacy-game",
+        "https://torii.example.com/custom/indexer////",
+      ),
+    ).toBe("https://torii.example.com/custom/indexer");
+  });
+
+  it("normalizes an explicit Torii URL without changing its path", () => {
+    expect(getToriiUrl(null, "https://torii.example.com/a/b///")).toBe(
+      "https://torii.example.com/a/b",
+    );
+  });
+
+  it("keeps the Slot-derived fallback used by Controller 0.13.12", () => {
+    expect(getToriiUrl("legacy-game", null)).toBe(
+      "https://api.cartridge.gg/x/legacy-game/torii",
+    );
+  });
+
+  it("returns null when neither protocol generation configures Torii", () => {
+    expect(getToriiUrl(null, null)).toBeNull();
+  });
+});

--- a/packages/keychain/src/hooks/connection.test.ts
+++ b/packages/keychain/src/hooks/connection.test.ts
@@ -4,6 +4,7 @@ import {
   isNestedIframe,
   isOriginVerified,
   isSameRpcUrl,
+  parseControllerVersion,
   resolvePolicies,
   verifyStandaloneOrigin,
 } from "./connection";
@@ -15,6 +16,20 @@ vi.mock("@cartridge/controller", async () => {
     ...actual,
     getPresetSessionPolicies: vi.fn(() => undefined),
   };
+});
+
+describe("parseControllerVersion", () => {
+  it("validates the initial v query synchronously", () => {
+    expect(parseControllerVersion("0.13.13")?.version).toBe("0.13.13");
+    expect(parseControllerVersion("0.14.0-alpha.1")?.version).toBe(
+      "0.14.0-alpha.1",
+    );
+  });
+
+  it("rejects missing or invalid versions", () => {
+    expect(parseControllerVersion(null)).toBeUndefined();
+    expect(parseControllerVersion("not-semver")).toBeUndefined();
+  });
 });
 
 describe("isOriginVerified", () => {

--- a/packages/keychain/src/hooks/connection.ts
+++ b/packages/keychain/src/hooks/connection.ts
@@ -93,6 +93,17 @@ type ResolvedUrlParams = {
 export const URL_PARAMS_STORAGE_KEY = "keychain.urlParams";
 export const PRESERVE_URL_PARAMS_FLAG = "keychain.preserveOnReload";
 
+export function parseControllerVersion(
+  value?: string | null,
+): SemVer | undefined {
+  if (!value) return undefined;
+  try {
+    return new SemVer(decodeURIComponent(value));
+  } catch {
+    return undefined;
+  }
+}
+
 // Stable fallback so consumers keyed on `configuredChains` identity don't re-run.
 const NO_CONFIGURED_CHAINS: Chain[] = [];
 
@@ -426,7 +437,17 @@ export function useConnectionValue() {
   });
   const [controller, setController] = useState(window.controller);
   const [chainId, setChainId] = useState<string>();
-  const [controllerVersion, setControllerVersion] = useState<SemVer>();
+  // Read `v` synchronously so descendant auto-connect effects cannot resolve a
+  // stored controller using legacy behavior before the provider effect runs.
+  const [controllerVersion, setControllerVersion] = useState<
+    SemVer | undefined
+  >(() =>
+    parseControllerVersion(
+      typeof window === "undefined"
+        ? null
+        : new URLSearchParams(window.location.search).get("v"),
+    ),
+  );
   const connectionStateRef = useRef<HeadlessConnectionState>({
     origin,
     chainId,
@@ -902,13 +923,7 @@ export function useConnectionValue() {
   }, [urlParams, verified, configData, isConfigLoading, theme.name]);
 
   useEffect(() => {
-    if (urlParams.version) {
-      const validatedControllerVersion = new SemVer(
-        urlParams.version ?? "0.0.0",
-      );
-
-      setControllerVersion(validatedControllerVersion);
-    }
+    setControllerVersion(parseControllerVersion(urlParams.version));
   }, [urlParams.version]);
 
   // Handle policies configuration

--- a/packages/keychain/src/hooks/route.ts
+++ b/packages/keychain/src/hooks/route.ts
@@ -3,6 +3,11 @@ import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { cleanupCallbacks } from "@/utils/connection/callbacks";
 import { useConnection } from "@/hooks/connection";
 import { useNavigation } from "@/context";
+import { isIframe } from "@cartridge/controller-ui/utils";
+import {
+  shouldContinueConnectOnboarding,
+  supportsConnectKeepOpen,
+} from "@/utils/connection/connect";
 
 /**
  * Common hook for parsing route params from URL and managing callbacks
@@ -54,18 +59,34 @@ export function useRouteParams<
  * Hook for handling route completion (returnTo navigation or modal close)
  */
 export function useRouteCompletion() {
-  const { closeModal, isNewControllerRef, setIsNewController } =
-    useConnection();
+  const {
+    closeModal,
+    isNewControllerRef,
+    setIsNewController,
+    controllerVersion,
+  } = useConnection();
   const navigate = useNavigate();
   const { navigate: navigateWithStack } = useNavigation();
   const location = useLocation();
   const [searchParams] = useSearchParams();
   const returnTo = searchParams.get("returnTo");
+  const canKeepOpen = supportsConnectKeepOpen(controllerVersion, !isIframe());
 
   const handleCompletion = useCallback(() => {
-    if (isNewControllerRef.current && location.pathname !== "/session") {
-      // ignore on SessionProvider
+    const isNewController = isNewControllerRef.current === true;
+    if (isNewController) {
       setIsNewController(false);
+    }
+
+    if (
+      shouldContinueConnectOnboarding(
+        isNewController,
+        canKeepOpen,
+        location.pathname,
+      )
+    ) {
+      // The supporting SDK keeps the iframe visible while onboarding runs.
+      // Ignore on SessionProvider, which owns its own completion flow.
       navigateWithStack(`/welcome?${searchParams.toString()}`, { reset: true });
     } else if (returnTo) {
       navigate(returnTo, { replace: true });
@@ -82,6 +103,7 @@ export function useRouteCompletion() {
     isNewControllerRef,
     setIsNewController,
     location.pathname,
+    canKeepOpen,
   ]);
 
   return handleCompletion;

--- a/packages/keychain/src/utils/connection/connect.test.ts
+++ b/packages/keychain/src/utils/connection/connect.test.ts
@@ -13,7 +13,15 @@ import type {
   ConnectReply,
 } from "@cartridge/controller";
 import { ResponseCodes } from "@cartridge/controller";
-import { createConnectUrl, parseConnectParams, connect } from "./connect";
+import { SemVer } from "semver";
+import {
+  createConnectReply,
+  createConnectUrl,
+  parseConnectParams,
+  shouldContinueConnectOnboarding,
+  connect,
+  supportsConnectKeepOpen,
+} from "./connect";
 import { getCallbacks, storeCallbacks } from "./callbacks";
 
 describe("connect utils", () => {
@@ -39,6 +47,42 @@ describe("connect utils", () => {
       const searchParams = new URLSearchParams(url.split("?")[1]);
       expect(searchParams.get("id")).toBe("test-id");
       expect(searchParams.get("signers")).toBe(JSON.stringify(signers));
+    });
+  });
+
+  describe("keepOpen version gate", () => {
+    it("keeps onboarding out of the published 0.13.12 iframe", () => {
+      expect(supportsConnectKeepOpen(new SemVer("0.13.12"), false)).toBe(false);
+      expect(createConnectReply("0xabc", false, false)).toEqual({
+        code: ResponseCodes.SUCCESS,
+        address: "0xabc",
+      });
+      expect(shouldContinueConnectOnboarding(true, false, "/connect")).toBe(
+        false,
+      );
+    });
+
+    it("enables additive keepOpen behavior from 0.13.13 onward", () => {
+      expect(supportsConnectKeepOpen(new SemVer("0.13.13"), false)).toBe(true);
+      expect(supportsConnectKeepOpen(new SemVer("0.14.0-alpha.1"), false)).toBe(
+        true,
+      );
+      expect(createConnectReply("0xabc", true, true)).toEqual({
+        code: ResponseCodes.SUCCESS,
+        address: "0xabc",
+        keepOpen: true,
+      });
+      expect(shouldContinueConnectOnboarding(true, true, "/connect")).toBe(
+        true,
+      );
+      expect(shouldContinueConnectOnboarding(true, true, "/session")).toBe(
+        false,
+      );
+    });
+
+    it("uses current onboarding behavior in standalone mode", () => {
+      expect(supportsConnectKeepOpen(undefined, true)).toBe(true);
+      expect(supportsConnectKeepOpen(undefined, false)).toBe(false);
     });
   });
 
@@ -134,6 +178,39 @@ describe("connect utils", () => {
         code: ResponseCodes.SUCCESS,
         address: "0xabc",
       });
+    });
+
+    it("keeps the Controller 0.13.12 positional connect signature", () => {
+      const navigate = vi.fn();
+      const setRpcUrl = vi.fn();
+      const connectFn = connect({ navigate, setRpcUrl })();
+      const policies = {
+        contracts: {
+          "0x123": {
+            methods: [{ entrypoint: "transfer" }],
+          },
+        },
+      };
+
+      void connectFn(policies, "https://rpc.example.com", ["webauthn"]);
+
+      expect(setRpcUrl).toHaveBeenCalledWith("https://rpc.example.com");
+      const url = vi.mocked(navigate).mock.calls[0][0] as string;
+      const searchParams = new URLSearchParams(url.split("?")[1]);
+      expect(searchParams.get("signers")).toBe(JSON.stringify(["webauthn"]));
+    });
+
+    it("keeps the current ConnectOptions object signature", () => {
+      const navigate = vi.fn();
+      const setRpcUrl = vi.fn();
+      const connectFn = connect({ navigate, setRpcUrl })();
+
+      void connectFn({ signupOptions: ["password"] });
+
+      expect(setRpcUrl).not.toHaveBeenCalled();
+      const url = vi.mocked(navigate).mock.calls[0][0] as string;
+      const searchParams = new URLSearchParams(url.split("?")[1]);
+      expect(searchParams.get("signers")).toBe(JSON.stringify(["password"]));
     });
   });
 });

--- a/packages/keychain/src/utils/connection/connect.ts
+++ b/packages/keychain/src/utils/connection/connect.ts
@@ -4,10 +4,51 @@ import {
   ConnectOptions,
   ConnectReply,
   LocationGateOptions,
+  ResponseCodes,
 } from "@cartridge/controller";
 import { SessionPolicies } from "@cartridge/presets";
 import { generateCallbackId, storeCallbacks, getCallbacks } from "./callbacks";
 import { createLocationGateUrl } from "./location-gate";
+import type { SemVer } from "semver";
+import gte from "semver/functions/gte";
+
+export const CONNECT_KEEP_OPEN_MIN_VERSION = "0.13.13";
+
+/**
+ * `keepOpen` was added after the published 0.13.12 SDK. Standalone keychain
+ * flows have no parent SDK and always use the current behavior.
+ */
+export function supportsConnectKeepOpen(
+  controllerVersion: SemVer | undefined,
+  isStandalone: boolean,
+): boolean {
+  return (
+    isStandalone ||
+    (!!controllerVersion &&
+      gte(controllerVersion, CONNECT_KEEP_OPEN_MIN_VERSION))
+  );
+}
+
+/** Only add the response field for SDKs that know how to keep the iframe open. */
+export function createConnectReply(
+  address: string,
+  keepOpen: boolean,
+  includeKeepOpen: boolean,
+): ConnectReply {
+  return {
+    code: ResponseCodes.SUCCESS,
+    address,
+    ...(includeKeepOpen ? { keepOpen } : {}),
+  };
+}
+
+export function shouldContinueConnectOnboarding(
+  isNewController: boolean,
+  canKeepOpen: boolean,
+  pathname: string,
+): boolean {
+  return isNewController && canKeepOpen && pathname !== "/session";
+}
 
 export interface ConnectParams {
   id: string;

--- a/packages/keychain/src/utils/connection/execute.test.ts
+++ b/packages/keychain/src/utils/connection/execute.test.ts
@@ -3,9 +3,10 @@ import {
   createExecuteUrl,
   parseControllerError,
   execute,
+  normalizeExecuteCompatibility,
   normalizeCalls,
 } from "./execute";
-import { ResponseCodes } from "@cartridge/controller";
+import { FeeSource, ResponseCodes } from "@cartridge/controller";
 import { ErrorCode } from "@cartridge/controller-wasm";
 import { storeCallbacks, cleanupCallbacks } from "./callbacks";
 import { Call } from "starknet";
@@ -39,6 +40,21 @@ const mockController = {
 };
 
 describe("execute utils", () => {
+  it("accepts the published 0.13.12 manual error in position five", () => {
+    const legacyError = {
+      code: ErrorCode.ManualExecutionRequired,
+      message: "manual approval",
+    };
+
+    expect(normalizeExecuteCompatibility(legacyError)).toEqual({
+      error: legacyError,
+    });
+    expect(normalizeExecuteCompatibility(FeeSource.PAYMASTER)).toEqual({
+      feeSource: FeeSource.PAYMASTER,
+      error: undefined,
+    });
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     // @ts-expect-error - Mocking global

--- a/packages/keychain/src/utils/connection/execute.ts
+++ b/packages/keychain/src/utils/connection/execute.ts
@@ -29,6 +29,20 @@ export type ControllerError = {
 
 export const ESTIMATE_FEE_PERCENTAGE = 10;
 
+export function normalizeExecuteCompatibility(
+  feeSourceOrLegacyError?: FeeSource | ControllerError,
+  error?: ControllerError,
+): { feeSource?: FeeSource; error?: ControllerError } {
+  if (
+    feeSourceOrLegacyError &&
+    typeof feeSourceOrLegacyError === "object" &&
+    "message" in feeSourceOrLegacyError
+  ) {
+    return { error: error ?? feeSourceOrLegacyError };
+  }
+  return { feeSource: feeSourceOrLegacyError, error };
+}
+
 export interface ExecuteParams {
   id: string;
   transactions: Call[];
@@ -127,15 +141,19 @@ export function execute({
       __?: Abi[],
       ___?: InvocationsDetails,
       sync?: boolean,
-      feeSource?: FeeSource,
+      feeSourceOrLegacyError?: FeeSource | ControllerError,
       error?: ControllerError,
     ): Promise<InvokeFunctionResponse | ConnectError> => {
       const calls = normalizeCalls(transactions);
+      const normalized = normalizeExecuteCompatibility(
+        feeSourceOrLegacyError,
+        error,
+      );
 
       if (sync) {
         return await new Promise((resolve, reject) => {
           const url = createExecuteUrl(toArray(transactions), {
-            error,
+            error: normalized.error,
             resolve,
             reject,
           });
@@ -178,7 +196,7 @@ export function execute({
             const { transaction_hash } = await executeCore(
               origin,
               calls,
-              feeSource,
+              normalized.feeSource,
             );
             return resolve({
               code: ResponseCodes.SUCCESS,

--- a/packages/keychain/src/utils/connection/index.ts
+++ b/packages/keychain/src/utils/connection/index.ts
@@ -67,6 +67,17 @@ function merkleDropsPath(keys: string[], options?: MerkleDropsRouteOptions) {
   return `/purchase/merkle-drops/${encodedKeys}${query ? `?${query}` : ""}`;
 }
 
+/**
+ * Reload after Penpal has had a chance to serialize and post the RPC reply.
+ * Published Controller 0.13.12 awaits disconnect without catching an iframe
+ * unload rejection, so a synchronous reload prevents its remaining cleanup.
+ */
+export function scheduleKeychainReload(
+  reload: () => void = () => window.location.reload(),
+) {
+  setTimeout(reload, 0);
+}
+
 export function connectToController<
   ParentMethods extends HeadlessConnectParent,
 >({
@@ -165,7 +176,7 @@ export function connectToController<
         // Reload the iframe so the next bootstrap (main.tsx -> Controller.fromStore)
         // runs against cleared storage and lands on a fresh login, matching the
         // internal "Log out" flow (packages/keychain/src/hooks/connection.ts).
-        window.location.reload();
+        scheduleKeychainReload();
       },
       logout: () => async () => {
         // First clear the React state

--- a/packages/keychain/src/utils/connection/protocol-contract.test.ts
+++ b/packages/keychain/src/utils/connection/protocol-contract.test.ts
@@ -1,0 +1,368 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * jsdom protocol harness for the hosted keychain.
+ *
+ * This imports the production `connectToController` registration and captures
+ * the exact method table at the `connectToParent` (Penpal) boundary. Method
+ * implementations are replaced with deterministic spies so the contract can
+ * run in jsdom without an account, popup, or RPC. Behavioral parsing for the
+ * two connect generations is covered separately by connect.test.ts.
+ *
+ * Keep this test unchanged during the Starknet.js v10 migration: the same
+ * hosted keychain must continue to accept the 0.13.12+ wire protocol.
+ */
+type ProtocolMethod = (origin: string) => (...args: unknown[]) => unknown;
+
+const contract = vi.hoisted(() => ({
+  methods: {} as Record<string, ProtocolMethod>,
+  connect: vi.fn(),
+  deploy: vi.fn(),
+  execute: vi.fn(),
+  estimateInvokeFee: vi.fn(),
+  probe: vi.fn(),
+  signMessage: vi.fn(),
+  openSettings: vi.fn(),
+  navigate: vi.fn(),
+  credits: vi.fn(),
+  openLocationPrompt: vi.fn(),
+  switchChain: vi.fn(),
+  updateSession: vi.fn(),
+  createConnectHandler: vi.fn(),
+  connectToParent: vi.fn(),
+}));
+
+vi.mock("@cartridge/penpal", () => ({
+  connectToParent: contract.connectToParent.mockImplementation(
+    ({ methods }: { methods: Record<string, ProtocolMethod> }) => {
+      contract.methods = methods;
+      return {
+        promise: Promise.resolve({ origin: "https://game.example" }),
+        destroy: vi.fn(),
+      };
+    },
+  ),
+}));
+
+vi.mock("@cartridge/controller-ui/utils", () => ({
+  normalize: (method: ProtocolMethod) => method,
+}));
+
+vi.mock("@/hooks/connection", () => ({
+  PRESERVE_URL_PARAMS_FLAG: "keychain.preserveOnReload",
+}));
+
+vi.mock("@/utils/controller", () => ({ default: class Controller {} }));
+
+vi.mock("./connect", () => ({
+  connect: () => () => vi.fn(),
+}));
+
+vi.mock("./credits", () => ({
+  creditsFactory: () => contract.credits,
+}));
+
+vi.mock("./deploy", () => ({
+  deployFactory: () => contract.deploy,
+}));
+
+vi.mock("./estimate", () => ({
+  estimateInvokeFee: contract.estimateInvokeFee,
+}));
+
+vi.mock("./execute", () => ({
+  execute:
+    () =>
+    (origin: string) =>
+    (...args: unknown[]) =>
+      contract.execute(origin, ...args),
+}));
+
+vi.mock("./headless", () => ({
+  headlessConnect: () => vi.fn(),
+}));
+
+vi.mock("./probe", () => ({
+  probe:
+    () =>
+    (origin: string) =>
+    (...args: unknown[]) =>
+      contract.probe(origin, ...args),
+}));
+
+vi.mock("./settings", () => ({
+  openSettingsFactory: () => contract.openSettings,
+}));
+
+vi.mock("./sign", () => ({
+  signMessageFactory:
+    () =>
+    (origin: string) =>
+    (...args: unknown[]) =>
+      contract.signMessage(origin, ...args),
+}));
+
+vi.mock("./switchChain", () => ({
+  switchChain: () => contract.switchChain,
+}));
+
+vi.mock("./navigate", () => ({
+  navigateFactory: () => contract.navigate,
+}));
+
+vi.mock("./update-session", () => ({
+  updateSession:
+    () =>
+    () =>
+    (...args: unknown[]) =>
+      contract.updateSession(...args),
+}));
+
+vi.mock("./headless-requests", () => ({
+  waitForHeadlessApprovalRequest: vi.fn(),
+}));
+
+vi.mock("./connect-routing", () => ({
+  createConnectHandler: contract.createConnectHandler.mockImplementation(
+    () =>
+      (...args: unknown[]) =>
+        contract.connect(...args),
+  ),
+}));
+
+vi.mock("./location", () => ({
+  locationPromptFactory: () => contract.openLocationPrompt,
+}));
+
+import { connectToController, scheduleKeychainReload } from "./index";
+
+const PUBLISHED_0_13_12_METHODS = [
+  "connect",
+  "delegateAccount",
+  "deploy",
+  "disconnect",
+  "estimateInvokeFee",
+  "execute",
+  "logout",
+  "navigate",
+  "openBundle",
+  "openLocationPrompt",
+  "openPurchaseCredits",
+  "openSettings",
+  "openStarterPack",
+  "probe",
+  "reset",
+  "signMessage",
+  "switchChain",
+  "updateSession",
+  "username",
+] as const;
+
+const setupProtocol = () => {
+  const setController = vi.fn();
+  const setRpcUrl = vi.fn();
+  const navigate = vi.fn();
+
+  connectToController({
+    setController,
+    setRpcUrl,
+    navigate,
+    getParent: () => undefined,
+    getConnectionState: () => ({
+      origin: "https://game.example",
+      rpcUrl: "https://rpc.example",
+      policies: undefined,
+      chainId: "0x1",
+      isPoliciesResolved: true,
+      isConfigLoading: false,
+    }),
+  });
+
+  return { setController, setRpcUrl, navigate };
+};
+
+const assertPlainPayload = (payload: unknown) => {
+  expect(JSON.parse(JSON.stringify(payload))).toEqual(payload);
+};
+
+describe("Controller 0.13.12+ hosted-keychain protocol contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    contract.methods = {};
+  });
+
+  it("keeps the published Penpal method names", () => {
+    setupProtocol();
+
+    expect(Object.keys(contract.methods)).toEqual(
+      expect.arrayContaining([...PUBLISHED_0_13_12_METHODS]),
+    );
+    // Later SDK methods are additive; older consumers simply never call them.
+    expect(contract.methods).toHaveProperty("credits");
+    expect(contract.methods).toHaveProperty("openMerkleDrops");
+  });
+
+  it("keeps probe, execute, sign, chain-switch, and session positions", async () => {
+    contract.probe.mockResolvedValue({
+      code: "SUCCESS",
+      address: "0xabc",
+      rpcUrl: "https://rpc.example",
+    });
+    contract.execute.mockResolvedValue({
+      code: "SUCCESS",
+      transaction_hash: "0xtx",
+    });
+    contract.signMessage.mockResolvedValue(["0x1", "0x2"]);
+    contract.switchChain.mockResolvedValue(undefined);
+    contract.updateSession.mockResolvedValue({
+      code: "SUCCESS",
+      address: "0xabc",
+    });
+    setupProtocol();
+
+    const origin = "https://game.example";
+    const calls = [
+      { contractAddress: "0x123", entrypoint: "transfer", calldata: ["0x1"] },
+    ];
+    const typedData = { domain: { name: "game" }, types: {}, message: {} };
+    const policies = {
+      contracts: {
+        "0x123": { methods: [{ entrypoint: "transfer" }] },
+      },
+    };
+
+    const probeResult = await contract.methods.probe(origin)(
+      "https://rpc.example",
+    );
+    const executeResult = await contract.methods.execute(origin)(
+      calls,
+      undefined,
+      undefined,
+      true,
+      "PAYMASTER",
+      { code: 1, message: "retry" },
+    );
+    const legacyManualError = { code: 2, message: "manual approval" };
+    const legacyExecuteResult = await contract.methods.execute(origin)(
+      calls,
+      undefined,
+      undefined,
+      true,
+      legacyManualError,
+    );
+    const signResult = await contract.methods.signMessage(origin)(
+      typedData,
+      "0xabc",
+      true,
+    );
+    await contract.methods.switchChain(origin)("https://rpc-2.example");
+    const updateResult = await contract.methods.updateSession(origin)(
+      policies,
+      "game-preset",
+    );
+
+    expect(contract.probe).toHaveBeenCalledWith(origin, "https://rpc.example");
+    expect(contract.execute).toHaveBeenCalledWith(
+      origin,
+      calls,
+      undefined,
+      undefined,
+      true,
+      "PAYMASTER",
+      { code: 1, message: "retry" },
+    );
+    expect(contract.execute).toHaveBeenNthCalledWith(
+      2,
+      origin,
+      calls,
+      undefined,
+      undefined,
+      true,
+      legacyManualError,
+    );
+    expect(contract.signMessage).toHaveBeenCalledWith(
+      origin,
+      typedData,
+      "0xabc",
+      true,
+    );
+    expect(contract.switchChain).toHaveBeenCalledWith("https://rpc-2.example");
+    expect(contract.updateSession).toHaveBeenCalledWith(
+      policies,
+      "game-preset",
+    );
+    [
+      probeResult,
+      executeResult,
+      legacyExecuteResult,
+      signResult,
+      updateResult,
+    ].forEach(assertPlainPayload);
+  });
+
+  it("accepts both legacy positional connect and current ConnectOptions", async () => {
+    contract.connect.mockResolvedValue({ code: "SUCCESS", address: "0xabc" });
+    setupProtocol();
+
+    const origin = "https://game.example";
+    const legacyPolicies = {
+      contracts: {
+        "0x123": { methods: [{ entrypoint: "transfer" }] },
+      },
+    };
+    const legacyResult = await contract.methods.connect(origin)(
+      legacyPolicies,
+      "https://rpc.example",
+      ["webauthn"],
+    );
+    const optionsResult = await contract.methods.connect(origin)({
+      signupOptions: ["password"],
+    });
+
+    expect(contract.connect).toHaveBeenNthCalledWith(
+      1,
+      legacyPolicies,
+      "https://rpc.example",
+      ["webauthn"],
+    );
+    expect(contract.connect).toHaveBeenNthCalledWith(
+      2,
+      { signupOptions: ["password"] },
+      undefined,
+      undefined,
+    );
+    assertPlainPayload(legacyResult);
+    assertPlainPayload(optionsResult);
+  });
+
+  it("keeps disconnect cleanup observable before the iframe reload", async () => {
+    vi.useFakeTimers();
+    const disconnect = vi.fn().mockResolvedValue(undefined);
+    window.controller = { disconnect } as typeof window.controller;
+    const { setController } = setupProtocol();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    await contract.methods.disconnect("https://game.example")();
+
+    expect(setController).toHaveBeenCalledWith(undefined);
+    expect(disconnect).toHaveBeenCalledOnce();
+    expect(sessionStorage.getItem("keychain.preserveOnReload")).toBe("1");
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    consoleError.mockRestore();
+  });
+
+  it("defers reload to the task after the Penpal handler resolves", () => {
+    vi.useFakeTimers();
+    const reload = vi.fn();
+
+    scheduleKeychainReload(reload);
+    expect(reload).not.toHaveBeenCalled();
+
+    vi.runAllTimers();
+    expect(reload).toHaveBeenCalledOnce();
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
Harden hosted-keychain compatibility for published Controller 0.13.12 and upcoming 0.13.13 by deferring disconnect reload, gating `keepOpen`/onboarding, and preserving legacy connect and execute positions.
Add frozen Penpal method/bridge contracts plus Torii precedence, normalization, and Slot-fallback coverage.

## Validation
Frozen install, lint, 738 package tests, full monorepo/example build, and the compatibility audit pass; the baseline Storybook suite still has unrelated missing-provider failures.
Starknet.js remains on v8, and the real three-version Playwright/structured-clone matrix remains a hard gate for the later v10 PR.