### PR TITLE
fix(keychain): surface the account upgrade at login for undeployed accounts on outdated creation classes

### DIFF
--- a/packages/keychain/src/components/provider/upgrade.test.tsx
+++ b/packages/keychain/src/components/provider/upgrade.test.tsx
@@ -167,11 +167,55 @@ describe("UpgradeProvider", () => {
     expect(result.current.isBeta).toBe(false);
   });
 
-  it("should not offer an upgrade for an account that isn't deployed on the chain", async () => {
-    // A counterfactual account's address is bound to its creation class, so it can
-    // only deploy as that class and upgrade in place — it can't be upgraded before it
-    // exists on-chain. So a "Contract not found" must NOT be reported as outdated,
-    // even though the mock's creation class (CONTROLLER_VERSIONS[3]) is behind latest.
+  it("offers an upgrade for an UNDEPLOYED account whose creation class is outdated", async () => {
+    // A counterfactual account deploys AT ITS CREATION CLASS on first use (the
+    // address is bound to that class). The mock's creation class is
+    // CONTROLLER_VERSIONS[3] — behind stable — so "Contract not found" must be
+    // treated as that outdated class, surfacing the upgrade right after login
+    // (the paymaster deploys the account when the upgrade's outside execution
+    // lands) instead of letting the first action deploy a stale class and fail.
+    mockController.provider.getClassHashAt.mockRejectedValueOnce(
+      new Error("Contract not found"),
+    );
+
+    const { result } = renderHook(() => useUpgrade(), { wrapper });
+
+    // Wait for the component to update
+    await act(async () => {
+      // Wait for all promises to resolve
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // Wait for the component to update
+    await act(async () => {
+      // Manually trigger the state updates that would happen after API calls
+      await vi.waitFor(
+        () => {
+          return result.current.isSynced === true;
+        },
+        { timeout: 5000 },
+      );
+    });
+
+    expect(result.current.available).toBe(true);
+    // The ACTIVE chain has no deployed class — `current` reports what's on-chain.
+    expect(result.current.current).toBeUndefined();
+    expect(result.current.latest).toBe(STABLE_CONTROLLER);
+
+    // The upgrade executes at the CREATION class's outside-execution version
+    // (VERSIONS[3] is V3) — the paymaster auto-deploys the account beneath it.
+    await act(async () => {
+      await result.current.onUpgrade();
+    });
+    expect(mockController.executeFromOutsideV3).toHaveBeenCalled();
+    expect(mockController.executeFromOutsideV2).not.toHaveBeenCalled();
+  });
+
+  it("should not offer an upgrade for an undeployed account created on the stable class", async () => {
+    // Fresh accounts must stay unprompted (the original point of the undeployed
+    // guard): their creation class IS the stable class, so there is nothing to
+    // upgrade — on this chain or any other.
+    mockController.classHash.mockReturnValue(STABLE_CONTROLLER.hash);
     mockController.provider.getClassHashAt.mockRejectedValueOnce(
       new Error("Contract not found"),
     );
@@ -198,6 +242,9 @@ describe("UpgradeProvider", () => {
     expect(result.current.available).toBe(false);
     expect(result.current.current).toBeUndefined();
     expect(result.current.latest).toBe(STABLE_CONTROLLER);
+
+    // Restore the module-scope mock for subsequent tests.
+    mockController.classHash.mockReturnValue(CONTROLLER_VERSIONS[3].hash);
   });
 
   it("should handle other errors", async () => {

--- a/packages/keychain/src/components/provider/upgrade.tsx
+++ b/packages/keychain/src/components/provider/upgrade.tsx
@@ -79,13 +79,10 @@ const findVersion = (classHash: string): ControllerVersionInfo | undefined =>
 /** The controller version actually deployed at `address` on a chain, or `undefined`
  *  when the account isn't deployed there yet.
  *
- *  A counterfactual account's address is bound to its creation class, so it can only
- *  ever deploy *as* that class and then upgrade in place — there's no way to upgrade it
- *  before it exists on-chain (the upgrade runs via `execute_from_outside`, which needs a
- *  deployed contract). So we deliberately do NOT report the creation class here: a not-
- *  yet-deployed account must not be flagged as "outdated", or we'd offer a premature
- *  upgrade that can't execute. It deploys at its creation class on first use, and the
- *  upgrade is offered then — once `getClassHashAt` returns a real, deployed class. */
+ *  A counterfactual account's address is bound to its creation class, so on a chain
+ *  where it isn't deployed yet it can only ever deploy *as* that class (and upgrade in
+ *  place afterwards). `undefined` therefore means "will be the creation class on first
+ *  use" — the caller substitutes it accordingly. */
 async function deployedVersion(
   provider: Pick<RpcProvider, "getClassHashAt">,
   address: string,
@@ -202,7 +199,7 @@ export const UpgradeProvider: React.FC<UpgradeProviderProps> = ({
     (async () => {
       try {
         const address = controller.address();
-        // const creationClassHash = controller.classHash();
+        const creation = findVersion(controller.classHash());
         const activeRpcUrl = controller.rpcUrl();
 
         const active = await deployedVersion(controller.provider, address);
@@ -219,8 +216,9 @@ export const UpgradeProvider: React.FC<UpgradeProviderProps> = ({
                   version: await deployedVersion(provider, address),
                 };
               } catch {
-                // A single unreachable chain must not block the upgrade gate.
-                return { rpcUrl, version: undefined };
+                // A single unreachable chain must not block the upgrade gate —
+                // and must not be mistaken for "not deployed" either; skip it.
+                return null;
               }
             }),
         );
@@ -229,11 +227,23 @@ export const UpgradeProvider: React.FC<UpgradeProviderProps> = ({
 
         const outdated = [
           { rpcUrl: activeRpcUrl, version: active },
-          ...others,
-        ].filter(
-          (c): c is OutdatedChain =>
-            !!c.version && determineUpgradePath(c.version, isBeta).available,
-        );
+          ...others.filter((c): c is Exclude<typeof c, null> => c !== null),
+        ]
+          // A chain with no deployment yet will get the account AT ITS CREATION
+          // CLASS on first use (the address is bound to that class), so when the
+          // creation class is behind, that chain needs the same upgrade — and it
+          // can run immediately: the paymaster deploys the account when the
+          // upgrade's outside execution lands. Substituting the creation class
+          // here surfaces the upgrade right after login, instead of letting the
+          // first game action deploy a stale class and fail (e.g.
+          // ENTRYPOINT_NOT_FOUND on execute_from_outside_v3 for ≤ v1.0.5).
+          // Fresh accounts are unaffected: their creation class IS the stable
+          // class, so determineUpgradePath reports no upgrade.
+          .map((c) => (c.version ? c : { ...c, version: creation }))
+          .filter(
+            (c): c is OutdatedChain =>
+              !!c.version && determineUpgradePath(c.version, isBeta).available,
+          );
 
         setCurrent(active);
         setOutdated(outdated);


### PR DESCRIPTION
## Problem

#2616 made the upgrade gate check every configured chain at connect — but #2622 (correctly, at the time) skips chains where the account **isn't deployed yet**. Those two interact badly for accounts created on old classes joining a **fresh chain**:

1. At login, the account doesn't exist on the new chain → the gate stays silent (by design).
2. The player's **first action** auto-deploys the account at its **creation class** (the address is bound to it — deploying any other class is impossible).
3. The paymaster then calls the account at the latest OE version and reverts mid-game.

Hit in production on the dungeon-demo mainnet+sepolia rollup pair: an account created on **v1.0.4** (already upgraded to v1.0.9 on the mainnet appchain) auto-deployed at v1.0.4 on the fresh sepolia appchain, and the first move failed with:

```
Error in contract (… class hash: 0x024a9edbfa7082…c412c9ab, selector: 0x03dbc508…3587e3):
0x454e545259504f494e545f4e4f545f464f554e44 ('ENTRYPOINT_NOT_FOUND')
```

(selector = `execute_from_outside_v3`; class = v1.0.4, which only has V2.)

## Fix

Treat "not deployed on this chain" as "**will be the creation class** on first use" — substitute the creation class for undeployed chains in the gate. The Upgrade screen then shows **right after login**, and `onUpgrade` works unchanged: it already dispatches at the flagged version's OE version (V2 for ≤1.0.5), and the paymaster deploys the account beneath the upgrade's outside execution.

- **Fresh accounts keep #2622's behavior**: their creation class *is* the stable class, so `determineUpgradePath` reports nothing — no premature prompt during onboarding.
- **Unreachable chains** are now skipped outright instead of being conflated with "not deployed" (previously both produced `version: undefined`).

## Tests

- `offers an upgrade for an UNDEPLOYED account whose creation class is outdated` — gate flags it, and `onUpgrade` executes at the creation class's OE version.
- `should not offer an upgrade for an undeployed account created on the stable class` — preserves #2622 for fresh accounts.
- All 16 provider tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)