### PR TITLE
feat: multichain sessions opt-in (one approval flow, one session per chain)

### DIFF
--- a/packages/controller/src/__tests__/multichainSessions.test.ts
+++ b/packages/controller/src/__tests__/multichainSessions.test.ts
@@ -1,0 +1,135 @@
+import { constants, shortString } from "starknet";
+import ControllerProvider from "../controller";
+import { KeychainIFrame } from "../iframe/keychain";
+import { getPresetSessionPoliciesForChains } from "../utils";
+
+// Mock the KeychainIFrame to capture constructor options
+jest.mock("../iframe/keychain", () => ({
+  KeychainIFrame: jest.fn().mockImplementation(() => ({
+    open: jest.fn(),
+    close: jest.fn(),
+  })),
+}));
+
+const APPCHAIN_RPC = "https://api.cartridge.gg/x/gbomb/katana";
+const APPCHAIN_CHAIN_ID = shortString.encodeShortString("WP_GBOMB");
+
+const policies = {
+  contracts: {
+    "0x1": { methods: [{ entrypoint: "play" }] },
+  },
+};
+
+describe("ControllerProvider multichainSessions option", () => {
+  let originalConsoleError: unknown;
+  let originalConsoleWarn: unknown;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    originalConsoleError = console.error;
+    originalConsoleWarn = console.warn;
+    console.error = jest.fn();
+    console.warn = jest.fn();
+  });
+
+  afterEach(() => {
+    console.error = originalConsoleError as typeof console.error;
+    console.warn = originalConsoleWarn as typeof console.warn;
+  });
+
+  test("passes resolved session chains to the keychain iframe", () => {
+    new ControllerProvider({
+      defaultChainId: constants.StarknetChainId.SN_SEPOLIA,
+      chains: [{ rpcUrl: APPCHAIN_RPC }],
+      policies,
+      multichainSessions: [
+        constants.StarknetChainId.SN_SEPOLIA,
+        APPCHAIN_CHAIN_ID,
+      ],
+    });
+
+    const options = (KeychainIFrame as unknown as jest.Mock).mock.calls[0][0];
+    expect(options.sessionChains).toEqual([
+      {
+        chainId: constants.StarknetChainId.SN_SEPOLIA,
+        rpcUrl: "https://api.cartridge.gg/x/starknet/sepolia/rpc/v0_9",
+      },
+      {
+        chainId: APPCHAIN_CHAIN_ID,
+        rpcUrl: APPCHAIN_RPC,
+      },
+    ]);
+  });
+
+  test("omits sessionChains when the option is absent", () => {
+    new ControllerProvider({
+      defaultChainId: constants.StarknetChainId.SN_SEPOLIA,
+      policies,
+    });
+
+    const options = (KeychainIFrame as unknown as jest.Mock).mock.calls[0][0];
+    expect(options.sessionChains).toBeUndefined();
+  });
+
+  test("throws when a session chain is not configured", () => {
+    expect(
+      () =>
+        new ControllerProvider({
+          defaultChainId: constants.StarknetChainId.SN_SEPOLIA,
+          policies,
+          multichainSessions: [APPCHAIN_CHAIN_ID],
+        }),
+    ).toThrow(/not a configured chain/);
+  });
+
+  test("throws when neither policies nor preset is provided", () => {
+    expect(
+      () =>
+        new ControllerProvider({
+          defaultChainId: constants.StarknetChainId.SN_SEPOLIA,
+          multichainSessions: [constants.StarknetChainId.SN_SEPOLIA],
+        }),
+    ).toThrow(/requires `policies` or `preset`/);
+  });
+
+  test("accepts a preset instead of policies", () => {
+    expect(
+      () =>
+        new ControllerProvider({
+          defaultChainId: constants.StarknetChainId.SN_SEPOLIA,
+          preset: "glitch-bomb",
+          multichainSessions: [constants.StarknetChainId.SN_SEPOLIA],
+        }),
+    ).not.toThrow();
+  });
+});
+
+describe("getPresetSessionPoliciesForChains", () => {
+  const config = {
+    chains: {
+      SN_SEPOLIA: { policies },
+      WP_GBOMB: { policies },
+    },
+  };
+
+  test("resolves policies for every requested chain", () => {
+    const result = getPresetSessionPoliciesForChains(config, [
+      constants.StarknetChainId.SN_SEPOLIA,
+      APPCHAIN_CHAIN_ID,
+    ]);
+
+    expect(result.size).toBe(2);
+    expect(
+      result.get(constants.StarknetChainId.SN_SEPOLIA)?.contracts,
+    ).toBeDefined();
+    expect(result.get(APPCHAIN_CHAIN_ID)?.contracts).toBeDefined();
+  });
+
+  test("throws when a chain is missing from the preset", () => {
+    expect(() =>
+      getPresetSessionPoliciesForChains(config, [
+        constants.StarknetChainId.SN_MAIN,
+      ]),
+    ).toThrow(/No policies found for chain SN_MAIN/);
+  });
+});

--- a/packages/controller/src/controller.ts
+++ b/packages/controller/src/controller.ts
@@ -38,6 +38,7 @@ import {
   MerkleDropsOptions,
   UpdateSessionOptions,
   BundleOptions,
+  SessionChain,
 } from "./types";
 import { validateRedirectUrl } from "./url-validator";
 import { parseChainId } from "./utils";
@@ -157,6 +158,7 @@ export default class ControllerProvider extends BaseProvider {
     }
 
     this.initializeChains(chains);
+    this.validateMultichainSessions();
 
     this.iframes = {
       keychain: options.lazyload ? undefined : this.createKeychainIframe(),
@@ -913,6 +915,45 @@ export default class ControllerProvider extends BaseProvider {
     }
   }
 
+  // Multichain sessions are an explicit opt-in with a security contract: every
+  // requested chain must be one the dapp configured, and session policies must
+  // be resolvable — fail fast at construction instead of silently degrading.
+  private validateMultichainSessions() {
+    const sessionChainIds = this.options.multichainSessions;
+    if (!sessionChainIds || sessionChainIds.length === 0) {
+      return;
+    }
+
+    if (!this.options.policies && !this.options.preset) {
+      throw new Error(
+        "`multichainSessions` requires `policies` or `preset` to be provided.",
+      );
+    }
+
+    for (const chainId of sessionChainIds) {
+      if (!this.chains.has(chainId)) {
+        throw new Error(
+          `\`multichainSessions\` chain ${chainId} is not a configured chain. ` +
+            `Available chains: ${Array.from(this.chains.keys()).join(", ")}`,
+        );
+      }
+    }
+  }
+
+  // Resolve the opted-in session chains to their rpcUrl so the keychain never
+  // has to re-derive chain ids from URLs.
+  private sessionChains(): SessionChain[] | undefined {
+    const sessionChainIds = this.options.multichainSessions;
+    if (!sessionChainIds || sessionChainIds.length === 0) {
+      return undefined;
+    }
+
+    return sessionChainIds.map((chainId) => ({
+      chainId,
+      rpcUrl: this.chains.get(chainId)!.rpcUrl,
+    }));
+  }
+
   private createKeychainIframe(): KeychainIFrame {
     // Check if we're returning from standalone auth flow
     const isReturningFromRedirect =
@@ -944,6 +985,7 @@ export default class ControllerProvider extends BaseProvider {
       ...this.options,
       rpcUrl: this.rpcUrl(),
       userChains: this.userChains,
+      sessionChains: this.sessionChains(),
       onClose: () => {
         this.keychain?.reset?.();
       },

--- a/packages/controller/src/iframe/keychain.ts
+++ b/packages/controller/src/iframe/keychain.ts
@@ -1,5 +1,5 @@
 import { KEYCHAIN_URL } from "../constants";
-import { Chain, Keychain, KeychainOptions } from "../types";
+import { Chain, Keychain, KeychainOptions, SessionChain } from "../types";
 import { WalletBridge } from "../wallets/bridge";
 import { IFrame, IFrameOptions } from "./base";
 
@@ -15,6 +15,11 @@ type KeychainIframeOptions = IFrameOptions<Keychain> &
     encryptedBlob?: string;
     /** Chains the dapp explicitly configured (see Controller.userChains). */
     userChains?: Chain[];
+    /**
+     * Chains covered by a single multichain session approval, resolved to
+     * their rpcUrl SDK-side so the keychain doesn't re-derive chain ids.
+     */
+    sessionChains?: SessionChain[];
   };
 
 const STARTERPACK_PLAY_CALLBACK_DELAY_MS = 200;
@@ -47,6 +52,7 @@ export class KeychainIFrame extends IFrame<Keychain> {
     coinflowSandbox,
     webauthnPopup,
     userChains,
+    sessionChains,
     ...iframeOptions
   }: KeychainIframeOptions) {
     let onStarterpackPlayHandler: (() => Promise<void>) | undefined;
@@ -103,6 +109,16 @@ export class KeychainIFrame extends IFrame<Keychain> {
       _url.searchParams.set(
         "chains",
         encodeURIComponent(JSON.stringify(userChains)),
+      );
+    }
+
+    // Chains covered by a single multichain session approval (explicit opt-in
+    // via ControllerOptions.multichainSessions). The keychain creates one
+    // session per entry within one approval flow.
+    if (sessionChains && sessionChains.length > 0) {
+      _url.searchParams.set(
+        "session_chains",
+        encodeURIComponent(JSON.stringify(sessionChains)),
       );
     }
 

--- a/packages/controller/src/session/provider.ts
+++ b/packages/controller/src/session/provider.ts
@@ -26,9 +26,20 @@ interface SessionRegistration {
   allowedPoliciesRoot?: string;
 }
 
+export type SessionChainOption = {
+  rpc: string;
+  chainId: string;
+};
+
 export type SessionOptions = {
   rpc: string;
   chainId: string;
+  /**
+   * Explicit opt-in to multichain sessions: every chain (beyond `rpc`/
+   * `chainId`, which stays the active one) that a single registration flow
+   * must cover. Each chain needs resolvable policies (preset or manual).
+   */
+  chains?: SessionChainOption[];
   policies?: SessionPolicies;
   preset?: string;
   shouldOverridePresetPolicies?: boolean;
@@ -49,6 +60,11 @@ export default class SessionProvider extends BaseProvider {
   protected _redirectUrl: string;
   protected _disconnectRedirectUrl?: string;
   protected _policies: ParsedSessionPolicies;
+  // Multichain opt-in: every covered chain (active one included), with its
+  // resolved policies. Empty when single-chain.
+  protected _sessionChains: SessionChainOption[] = [];
+  protected _chainPolicies: Map<string, ParsedSessionPolicies> = new Map();
+  protected _accounts: Map<string, SessionAccount> = new Map();
   protected _preset?: string;
   protected _keychainUrl: string;
   protected _apiUrl: string;
@@ -61,6 +77,7 @@ export default class SessionProvider extends BaseProvider {
   constructor({
     rpc,
     chainId,
+    chains,
     policies,
     preset,
     shouldOverridePresetPolicies,
@@ -92,6 +109,19 @@ export default class SessionProvider extends BaseProvider {
         );
       }
       this._policies = { verified: false };
+    }
+
+    // Multichain opt-in: normalize to the full covered set, active chain
+    // first, deduplicated by chain id.
+    if (chains && chains.length > 0) {
+      const seen = new Set<bigint>([BigInt(chainId)]);
+      this._sessionChains = [{ rpc, chainId }];
+      for (const chain of chains) {
+        const id = BigInt(chain.chainId);
+        if (seen.has(id)) continue;
+        seen.add(id);
+        this._sessionChains.push(chain);
+      }
     }
 
     this._rpcUrl = rpc;
@@ -138,7 +168,13 @@ export default class SessionProvider extends BaseProvider {
   // Resolve preset policies asynchronously.
   // Public methods await this before proceeding.
   private async _resolvePreset(): Promise<void> {
-    if (!this._preset) return;
+    if (!this._preset) {
+      // Manual policies apply to every opted-in chain.
+      for (const chain of this._sessionChains) {
+        this._chainPolicies.set(chain.chainId, this._policies);
+      }
+      return;
+    }
 
     const config = await loadConfig(this._preset);
     if (!config) {
@@ -153,6 +189,19 @@ export default class SessionProvider extends BaseProvider {
     }
 
     this._policies = parsePolicies(sessionPolicies);
+
+    // Multichain opt-in: every covered chain must resolve, a missing chain is
+    // an error (the registration flow would silently cover fewer chains than
+    // the dapp asked for).
+    for (const chain of this._sessionChains) {
+      const chainPolicies = getPresetSessionPolicies(config, chain.chainId);
+      if (!chainPolicies) {
+        throw new Error(
+          `No policies found for chain ${chain.chainId} in preset ${this._preset}`,
+        );
+      }
+      this._chainPolicies.set(chain.chainId, parsePolicies(chainPolicies));
+    }
   }
 
   private validatePoliciesSubset(
@@ -272,7 +321,10 @@ export default class SessionProvider extends BaseProvider {
       return this.account;
     }
 
-    localStorage.setItem("sessionPolicies", JSON.stringify(this._policies));
+    localStorage.setItem(
+      "sessionPolicies",
+      JSON.stringify(this._storablePolicies()),
+    );
     localStorage.setItem("lastUsedConnector", this.id);
 
     try {
@@ -296,6 +348,16 @@ export default class SessionProvider extends BaseProvider {
           `&redirect_uri=${this._redirectUrl}` +
           `&redirect_query_name=startapp` +
           `&rpc_url=${this._rpcUrl}`;
+
+        // Multichain opt-in: the keychain registers the session on every
+        // covered chain within the same flow.
+        if (this._sessionChains.length > 0) {
+          const sessionChains = this._sessionChains.map((chain) => ({
+            chainId: chain.chainId,
+            rpcUrl: chain.rpc,
+          }));
+          url += `&session_chains=${encodeURIComponent(JSON.stringify(sessionChains))}`;
+        }
 
         if (this._preset) {
           url += `&preset=${encodeURIComponent(this._preset)}`;
@@ -337,8 +399,104 @@ export default class SessionProvider extends BaseProvider {
     }
   }
 
-  switchStarknetChain(_chainId: string): Promise<boolean> {
-    throw new Error("switchStarknetChain not implemented");
+  // Stored shape of the approved policies: a per-chain map when multichain,
+  // the plain active-chain policies otherwise (legacy shape).
+  private _storablePolicies():
+    | ParsedSessionPolicies
+    | { multichain: true; chains: Record<string, ParsedSessionPolicies> } {
+    if (this._sessionChains.length === 0) {
+      return this._policies;
+    }
+    const chains: Record<string, ParsedSessionPolicies> = {};
+    for (const [chainId, policies] of this._chainPolicies) {
+      chains[chainId] = policies;
+    }
+    return { multichain: true, chains };
+  }
+
+  /**
+   * Switches the active chain of a multichain session.
+   *
+   * The stored registration is chain-agnostic (registered sessions are
+   * validated on-chain), so switching only rebinds the account to the target
+   * chain's rpc and policies — no new approval. Returns false when the chain
+   * was not part of the multichain opt-in or no session is available.
+   */
+  async switchStarknetChain(chainId: string): Promise<boolean> {
+    await this._readyPromise;
+
+    if (BigInt(chainId) === BigInt(this._chainId)) {
+      return true;
+    }
+
+    const chain = this._sessionChains.find(
+      (c) => BigInt(c.chainId) === BigInt(chainId),
+    );
+    const policies = this._chainPolicies.get(chain?.chainId ?? "");
+    if (!chain || !policies) {
+      console.error(
+        `switchStarknetChain: chain ${chainId} is not part of the session's chains`,
+      );
+      return false;
+    }
+
+    // Make sure a session exists before rebinding.
+    if (!this.account) {
+      this.tryRetrieveSessionAccount();
+      if (!this.account) {
+        return false;
+      }
+    }
+
+    const cached = this._accounts.get(chain.chainId);
+    if (cached) {
+      this.account = cached;
+    } else {
+      const account = this._buildSessionAccount(chain, policies);
+      if (!account) {
+        return false;
+      }
+      this._accounts.set(chain.chainId, account);
+      this.account = account;
+    }
+
+    this._chainId = chain.chainId;
+    this._rpcUrl = chain.rpc;
+    this.emitNetworkChanged(chain.chainId);
+
+    return true;
+  }
+
+  private _buildSessionAccount(
+    chain: SessionChainOption,
+    policies: ParsedSessionPolicies,
+  ): SessionAccount | undefined {
+    const sessionString = localStorage.getItem("session");
+    const signerString = localStorage.getItem("sessionSigner");
+    if (!sessionString || !signerString) {
+      return undefined;
+    }
+
+    const sessionRegistration = this.normalizeSession(
+      JSON.parse(sessionString) as Partial<SessionRegistration>,
+    );
+    if (!sessionRegistration) {
+      return undefined;
+    }
+    const signer = JSON.parse(signerString);
+
+    return new SessionAccount(this, {
+      rpcUrl: chain.rpc,
+      privateKey: signer.privKey,
+      address: sessionRegistration.address,
+      ownerGuid: sessionRegistration.ownerGuid,
+      chainId: chain.chainId,
+      expiresAt: parseInt(sessionRegistration.expiresAt),
+      policies: toWasmPolicies(policies),
+      guardianKeyGuid: sessionRegistration.guardianKeyGuid,
+      metadataHash: sessionRegistration.metadataHash,
+      sessionKeyGuid: sessionRegistration.sessionKeyGuid,
+    });
   }
 
   addStarknetChain(_chain: AddStarknetChainParameters): Promise<boolean> {
@@ -352,6 +510,7 @@ export default class SessionProvider extends BaseProvider {
     localStorage.removeItem("lastUsedConnector");
     this.account = undefined;
     this._username = undefined;
+    this._accounts.clear();
 
     // calling this InjectedConnector callback hangs forever, and we do not disconnect properly
     // looking at InjectedConnector, it will disconnect is we pass [], so it must be safe to bypass
@@ -441,21 +600,58 @@ export default class SessionProvider extends BaseProvider {
       return;
     }
 
-    // Check stored policies
+    // Check stored policies. The stored value is either the legacy
+    // single-chain shape or a per-chain map for multichain sessions.
     const storedPoliciesStr = localStorage.getItem("sessionPolicies");
     if (storedPoliciesStr) {
-      const storedPolicies = JSON.parse(
-        storedPoliciesStr,
-      ) as ParsedSessionPolicies;
+      const stored = JSON.parse(storedPoliciesStr) as
+        | ParsedSessionPolicies
+        | { multichain: true; chains: Record<string, ParsedSessionPolicies> };
 
-      const isValid = this.validatePoliciesSubset(
-        this._policies,
-        storedPolicies,
-      );
-
-      if (!isValid) {
-        this.clearStoredSession();
-        return;
+      if ("multichain" in stored && stored.multichain) {
+        if (this._sessionChains.length === 0) {
+          // Multichain grant, single-chain request: the active chain's stored
+          // policies must cover the request.
+          const active = this._findStoredChainPolicies(
+            stored.chains,
+            this._chainId,
+          );
+          if (!active || !this.validatePoliciesSubset(this._policies, active)) {
+            this.clearStoredSession();
+            return;
+          }
+        } else {
+          // Every requested chain must be covered by the stored grant.
+          for (const chain of this._sessionChains) {
+            const requested = this._chainPolicies.get(chain.chainId);
+            const storedChain = this._findStoredChainPolicies(
+              stored.chains,
+              chain.chainId,
+            );
+            if (
+              !requested ||
+              !storedChain ||
+              !this.validatePoliciesSubset(requested, storedChain)
+            ) {
+              this.clearStoredSession();
+              return;
+            }
+          }
+        }
+      } else {
+        if (this._sessionChains.length > 0) {
+          // Single-chain grant cannot satisfy a multichain request.
+          this.clearStoredSession();
+          return;
+        }
+        const isValid = this.validatePoliciesSubset(
+          this._policies,
+          stored as ParsedSessionPolicies,
+        );
+        if (!isValid) {
+          this.clearStoredSession();
+          return;
+        }
       }
     }
 
@@ -472,8 +668,29 @@ export default class SessionProvider extends BaseProvider {
       metadataHash: sessionRegistration.metadataHash,
       sessionKeyGuid: sessionRegistration.sessionKeyGuid,
     });
+    if (this._sessionChains.length > 0) {
+      this._accounts.set(this._chainId, this.account as SessionAccount);
+    }
 
     return this.account;
+  }
+
+  // Stored chain keys may differ in casing/padding from the requested ones;
+  // compare as field elements.
+  private _findStoredChainPolicies(
+    chains: Record<string, ParsedSessionPolicies>,
+    chainId: string,
+  ): ParsedSessionPolicies | undefined {
+    for (const [storedChainId, policies] of Object.entries(chains)) {
+      try {
+        if (BigInt(storedChainId) === BigInt(chainId)) {
+          return policies;
+        }
+      } catch {
+        // Ignore malformed keys.
+      }
+    }
+    return undefined;
   }
 
   private clearStoredSession(): void {
@@ -481,5 +698,6 @@ export default class SessionProvider extends BaseProvider {
     localStorage.removeItem("session");
     localStorage.removeItem("sessionPolicies");
     localStorage.removeItem("lastUsedConnector");
+    this._accounts.clear();
   }
 }

--- a/packages/controller/src/types.ts
+++ b/packages/controller/src/types.ts
@@ -264,6 +264,15 @@ export type IFrameOptions = {
   preset?: string;
 };
 
+/**
+ * A chain covered by a multichain session approval, resolved to its rpcUrl
+ * SDK-side so the keychain never re-derives chain ids from URLs.
+ */
+export type SessionChain = {
+  chainId: string;
+  rpcUrl: string;
+};
+
 export type Chain = {
   /** RPC url */
   rpcUrl: string;
@@ -304,6 +313,14 @@ export type KeychainOptions = IFrameOptions & {
   coinflowSandbox?: boolean;
   /** When true, manually provided policies will override preset policies. Default is false. */
   shouldOverridePresetPolicies?: boolean;
+  /**
+   * Explicit opt-in to multichain sessions: chain IDs covered by a single
+   * session approval flow. Each entry must correspond to a chain configured
+   * via `chains` (or a default Cartridge chain), and `policies` or `preset`
+   * must be provided. When absent, sessions are created for the active chain
+   * only (current behavior).
+   */
+  multichainSessions?: ChainId[];
   /** The project name of Slot instance. */
   slot?: string;
   /** The Torii indexer URL used to fetch tokens/collections. Takes precedence over `slot`. */

--- a/packages/controller/src/utils.ts
+++ b/packages/controller/src/utils.ts
@@ -61,6 +61,30 @@ export function getPresetSessionPolicies(
   return toSessionPolicies(chainConfig.policies as Policies);
 }
 
+/**
+ * Resolves preset session policies for every requested chain.
+ *
+ * Unlike `getPresetSessionPolicies`, a missing chain is an error: multichain
+ * sessions are an explicit opt-in and silently skipping a chain would create
+ * fewer sessions than the dapp asked the user to approve.
+ */
+export function getPresetSessionPoliciesForChains(
+  config: Record<string, unknown>,
+  chainIds: string[],
+): Map<string, SessionPolicies> {
+  const result = new Map<string, SessionPolicies>();
+  for (const chainId of chainIds) {
+    const policies = getPresetSessionPolicies(config, chainId);
+    if (!policies) {
+      throw new Error(
+        `No policies found for chain ${shortString.decodeShortString(chainId)} (${chainId}) in preset config.`,
+      );
+    }
+    result.set(chainId, policies);
+  }
+  return result;
+}
+
 export function toSessionPolicies(policies: Policies): SessionPolicies {
   return Array.isArray(policies)
     ? policies.reduce<SessionPolicies>(

--- a/packages/keychain/src/components/ConnectRoute.tsx
+++ b/packages/keychain/src/components/ConnectRoute.tsx
@@ -34,7 +34,9 @@ import {
   HeaderInner,
   LayoutContent,
   LayoutFooter,
+  SpinnerIcon,
 } from "@cartridge/controller-ui";
+import { getChainName } from "@cartridge/controller-ui/utils";
 import { ControllerErrorAlert } from "@/components/ErrorAlert";
 import { useGeoLocation } from "@/hooks/geo";
 
@@ -65,12 +67,19 @@ export function ConnectRoute() {
     isNewControllerRef,
     controllerVersion,
     closeModal,
+    isPoliciesResolved,
   } = useConnection();
   const [hasAutoConnected, setHasAutoConnected] = useState(false);
   const [isSessionCreating, setIsSessionCreating] = useState(false);
   const [sessionError, setSessionError] = useState<Error>();
   const [showContinueButton, setShowContinueButton] = useState(false);
   const [locationGateVerified, setLocationGateVerified] = useState(false);
+  // Which chain is being signed during (multichain) auto session creation.
+  const [signingProgress, setSigningProgress] = useState<{
+    chainId: string;
+    index: number;
+    total: number;
+  }>();
   const [hasRequestedSession, setHasRequestedSession] = useState<
     boolean | undefined
   >(undefined);
@@ -301,6 +310,14 @@ export function ConnectRoute() {
       return;
     }
 
+    // Wait for policy resolution (e.g. preset config still loading) before
+    // deciding between auto-create and the approval UI — otherwise a stored
+    // controller races the config fetch and we act on the empty fallback
+    // policies.
+    if (!isPoliciesResolved) {
+      return;
+    }
+
     const hasLocationGate = hasConfiguredLocationGate(locationGate);
 
     // Location gating is a US-only feature. Wait for the shared IP-country
@@ -392,6 +409,7 @@ export function ConnectRoute() {
     if (!requiresSessionApproval(policies, chainPolicies)) {
       const createSessionForVerifiedPolicies = async () => {
         try {
+          setIsSessionCreating(true);
           if (requiresWebauthnPopup) {
             // When session auth relies on WebAuthn, delegate it to a popup window.
             // The popup export blob carries a single session, so multichain
@@ -408,6 +426,8 @@ export function ConnectRoute() {
               origin,
               policies,
               chainPolicies,
+              onProgress: (chainId, index, total) =>
+                setSigningProgress({ chainId, index, total }),
             });
           }
           params.resolve?.(
@@ -432,6 +452,9 @@ export function ConnectRoute() {
             // Fall back to rejecting on other browsers
             params.reject?.(e);
           }
+        } finally {
+          setIsSessionCreating(false);
+          setSigningProgress(undefined);
         }
       };
 
@@ -442,6 +465,7 @@ export function ConnectRoute() {
     controller,
     policies,
     chainPolicies,
+    isPoliciesResolved,
     handleCompletion,
     isStandalone,
     redirectUrl,
@@ -502,6 +526,12 @@ export function ConnectRoute() {
         persistVerification={false}
       />
     );
+  }
+
+  // Policies still resolving (e.g. preset config loading): rendering now
+  // would show an approval screen built from the empty fallback policies.
+  if (!isPoliciesResolved) {
+    return null;
   }
 
   // Embedded mode: No policies and verified policies are handled in useCreateController
@@ -577,6 +607,28 @@ export function ConnectRoute() {
               continue
             </Button>
           </LayoutFooter>
+        </>
+      );
+    }
+
+    // Auto-creation in progress: show what is being signed instead of a
+    // blank modal — external-wallet owners (e.g. Rabby) see one signature
+    // request per chain and need context for each prompt.
+    if (isSessionCreating) {
+      return (
+        <>
+          <HeaderInner
+            className="pb-0"
+            title={theme ? `Play ${theme.name}` : "Creating Session"}
+            description={
+              signingProgress && signingProgress.total > 1
+                ? `Signing session ${signingProgress.index + 1}/${signingProgress.total} — ${getChainName(signingProgress.chainId)}`
+                : "Creating your session…"
+            }
+          />
+          <LayoutContent className="flex items-center justify-center">
+            <SpinnerIcon className="animate-spin" />
+          </LayoutContent>
         </>
       );
     }

--- a/packages/keychain/src/components/ConnectRoute.tsx
+++ b/packages/keychain/src/components/ConnectRoute.tsx
@@ -53,6 +53,7 @@ export function ConnectRoute() {
   const {
     controller,
     policies,
+    chainPolicies,
     origin,
     theme,
     webauthnPopup,
@@ -388,17 +389,25 @@ export function ConnectRoute() {
 
     // Bypass session approval screen for verified sessions in embedded mode
     // Note: This is a fallback - main logic is handled in useCreateController
-    if (!requiresSessionApproval(policies)) {
+    if (!requiresSessionApproval(policies, chainPolicies)) {
       const createSessionForVerifiedPolicies = async () => {
         try {
           if (requiresWebauthnPopup) {
             // When session auth relies on WebAuthn, delegate it to a popup window.
+            // The popup export blob carries a single session, so multichain
+            // approvals degrade to the active chain here.
+            if (chainPolicies?.length) {
+              console.warn(
+                "[ConnectRoute] Multichain sessions are not supported via the WebAuthn popup flow; creating a session for the active chain only.",
+              );
+            }
             await createSessionViaPopup(controller, setController, popupParams);
           } else {
             await createVerifiedSession({
               controller,
               origin,
               policies,
+              chainPolicies,
             });
           }
           params.resolve?.(
@@ -432,6 +441,7 @@ export function ConnectRoute() {
     params,
     controller,
     policies,
+    chainPolicies,
     handleCompletion,
     isStandalone,
     redirectUrl,
@@ -509,7 +519,7 @@ export function ConnectRoute() {
     return null;
   }
 
-  if (policies.verified && !hasTokenApprovals) {
+  if (!requiresSessionApproval(policies, chainPolicies)) {
     // Auto session creation failed on Chrome iOS — show a "Continue" button
     // so the user tap provides the gesture required by WebAuthn.
     if (showContinueButton) {
@@ -521,7 +531,12 @@ export function ConnectRoute() {
           if (requiresWebauthnPopup) {
             await createSessionViaPopup(controller, setController, popupParams);
           } else {
-            await createVerifiedSession({ controller, origin, policies });
+            await createVerifiedSession({
+              controller,
+              origin,
+              policies,
+              chainPolicies,
+            });
           }
           params?.resolve?.(
             createConnectReply(
@@ -587,6 +602,7 @@ export function ConnectRoute() {
   return (
     <CreateSession
       policies={policies}
+      chainPolicies={chainPolicies}
       onConnect={handleConnect}
       onSkip={handleSkip}
     />

--- a/packages/keychain/src/components/UpdateSessionRoute.tsx
+++ b/packages/keychain/src/components/UpdateSessionRoute.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { ResponseCodes, getPresetSessionPolicies } from "@cartridge/controller";
 import { loadConfig } from "@cartridge/presets";
-import { useConnection } from "@/hooks/connection";
+import { useConnection, type SessionChainPolicies } from "@/hooks/connection";
 import {
   parseSessionPolicies,
   type ParsedSessionPolicies,
@@ -33,9 +33,12 @@ const CANCEL_RESPONSE = {
 };
 
 export function UpdateSessionRoute() {
-  const { controller, origin, theme, chainId, verified } = useConnection();
+  const { controller, origin, theme, chainId, verified, sessionChains } =
+    useConnection();
   const [resolvedPolicies, setResolvedPolicies] =
     useState<ParsedSessionPolicies>();
+  const [resolvedChainPolicies, setResolvedChainPolicies] =
+    useState<SessionChainPolicies>();
   const [isLoading, setIsLoading] = useState(false);
   const [isSessionCreating, setIsSessionCreating] = useState(false);
   const [sessionError, setSessionError] = useState<Error>();
@@ -61,6 +64,12 @@ export function UpdateSessionRoute() {
         verified,
       });
       setResolvedPolicies(parsed);
+      // Multichain opt-in: direct policies apply to every opted-in chain.
+      if (sessionChains?.length) {
+        setResolvedChainPolicies(
+          sessionChains.map((chain) => ({ ...chain, policies: parsed })),
+        );
+      }
       return;
     }
 
@@ -90,6 +99,33 @@ export function UpdateSessionRoute() {
             verified,
           });
           setResolvedPolicies(parsed);
+
+          // Multichain opt-in: resolve every opted-in chain from the preset.
+          // A missing chain is an error — updating fewer chains than the dapp
+          // opted into would silently break the multichain contract.
+          if (sessionChains?.length) {
+            const chainPolicies: SessionChainPolicies = [];
+            for (const chain of sessionChains) {
+              const chainSessionPolicies = getPresetSessionPolicies(
+                config as Record<string, unknown>,
+                chain.chainId,
+              );
+              if (!chainSessionPolicies) {
+                console.error(
+                  `No policies found for chain ${chain.chainId} in preset ${preset}`,
+                );
+                return;
+              }
+              chainPolicies.push({
+                ...chain,
+                policies: parseSessionPolicies({
+                  policies: chainSessionPolicies,
+                  verified,
+                }),
+              });
+            }
+            setResolvedChainPolicies(chainPolicies);
+          }
         })
         .catch((error) => {
           console.error("Failed to resolve preset policies:", error);
@@ -98,7 +134,7 @@ export function UpdateSessionRoute() {
           setIsLoading(false);
         });
     }
-  }, [params, chainId, verified]);
+  }, [params, chainId, verified, sessionChains]);
 
   const handleConnect = useCallback(async () => {
     if (!params || !controller) {
@@ -118,8 +154,10 @@ export function UpdateSessionRoute() {
   // Auto-create session for verified policies that don't require approval
   useEffect(() => {
     if (!resolvedPolicies || !controller || !params) return;
+    // Multichain opt-in: wait for the per-chain resolution before creating.
+    if (sessionChains?.length && !resolvedChainPolicies) return;
 
-    if (!requiresSessionApproval(resolvedPolicies)) {
+    if (!requiresSessionApproval(resolvedPolicies, resolvedChainPolicies)) {
       const autoCreate = async () => {
         try {
           setIsSessionCreating(true);
@@ -127,6 +165,7 @@ export function UpdateSessionRoute() {
             controller,
             origin,
             policies: resolvedPolicies,
+            chainPolicies: resolvedChainPolicies,
           });
           params.resolve?.({
             code: ResponseCodes.SUCCESS,
@@ -146,7 +185,15 @@ export function UpdateSessionRoute() {
 
       void autoCreate();
     }
-  }, [resolvedPolicies, controller, params, origin, handleCompletion]);
+  }, [
+    resolvedPolicies,
+    resolvedChainPolicies,
+    sessionChains,
+    controller,
+    params,
+    origin,
+    handleCompletion,
+  ]);
 
   // Loading state
   if (!controller || isLoading) {
@@ -168,7 +215,10 @@ export function UpdateSessionRoute() {
   }
 
   // Verified policies auto-creating
-  if (resolvedPolicies.verified && !requiresSessionApproval(resolvedPolicies)) {
+  if (
+    resolvedPolicies.verified &&
+    !requiresSessionApproval(resolvedPolicies, resolvedChainPolicies)
+  ) {
     if (sessionError) {
       return (
         <>
@@ -192,6 +242,7 @@ export function UpdateSessionRoute() {
                     controller,
                     origin,
                     policies: resolvedPolicies,
+                    chainPolicies: resolvedChainPolicies,
                   });
                   params?.resolve?.({
                     code: ResponseCodes.SUCCESS,
@@ -223,6 +274,7 @@ export function UpdateSessionRoute() {
   return (
     <CreateSession
       policies={resolvedPolicies}
+      chainPolicies={resolvedChainPolicies}
       onConnect={handleConnect}
       isUpdate
     />

--- a/packages/keychain/src/components/connect/CreateSession.multichain.test.tsx
+++ b/packages/keychain/src/components/connect/CreateSession.multichain.test.tsx
@@ -1,0 +1,176 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { CreateSession } from "./CreateSession";
+import { renderWithProviders } from "@/test/mocks/providers";
+import type { ParsedSessionPolicies } from "@/hooks/session";
+import type { SessionChainPolicies } from "@/hooks/connection";
+import type Controller from "@/utils/controller";
+
+const SEPOLIA = "0x534e5f5345504f4c4941";
+const APPCHAIN = "0x4341525452494447455f544553544e4554";
+
+const makePolicies = (
+  verified: boolean,
+  contract: string,
+): ParsedSessionPolicies => ({
+  verified,
+  contracts: {
+    [contract]: {
+      methods: [
+        { name: "Pull", entrypoint: "pull", authorized: true, id: "pull" },
+      ],
+    },
+  },
+});
+
+const makeChainPolicies = (verified: boolean): SessionChainPolicies => [
+  {
+    chainId: SEPOLIA,
+    rpcUrl: "https://sepolia.example/rpc",
+    policies: makePolicies(verified, "0xaaa"),
+  },
+  {
+    chainId: APPCHAIN,
+    rpcUrl: "https://appchain.example/rpc",
+    policies: makePolicies(verified, "0xbbb"),
+  },
+];
+
+describe("CreateSession multichain", () => {
+  const makeController = (
+    results: Array<{ chainId: string; error?: Error }>,
+  ) => {
+    const createMultichainSession = vi.fn().mockResolvedValue(results);
+    const controller = {
+      createSession: vi.fn().mockResolvedValue({}),
+      createMultichainSession,
+    } as unknown as Controller;
+    return { controller, createMultichainSession };
+  };
+
+  const renderMultichain = (
+    controller: Controller,
+    chainPolicies: SessionChainPolicies,
+  ) =>
+    renderWithProviders(
+      <CreateSession
+        policies={chainPolicies[0].policies}
+        chainPolicies={chainPolicies}
+        onConnect={onConnect}
+      />,
+      {
+        connection: {
+          controller,
+          origin: "https://game.example",
+        },
+      },
+    );
+
+  let onConnect: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    onConnect = vi.fn();
+  });
+
+  it("renders one policy section per chain", () => {
+    const { controller } = makeController([]);
+    renderMultichain(controller, makeChainPolicies(false));
+
+    // Chain headers resolved via getChainName: Sepolia + decoded appchain name.
+    expect(screen.getByText("Sepolia")).toBeInTheDocument();
+    expect(screen.getByText("CARTRIDGE_TESTNET")).toBeInTheDocument();
+  });
+
+  it("requires consent for unverified chains before signing", async () => {
+    const { controller, createMultichainSession } = makeController([
+      { chainId: SEPOLIA },
+      { chainId: APPCHAIN },
+    ]);
+    renderMultichain(controller, makeChainPolicies(false));
+
+    const continueButton = screen.getByRole("button", { name: /continue/i });
+    // The continue button stays disabled until the consent box is checked.
+    expect(continueButton).toBeDisabled();
+    fireEvent.click(screen.getByText(/are not verified/i));
+    expect(createMultichainSession).not.toHaveBeenCalled();
+
+    fireEvent.click(continueButton);
+    await waitFor(() =>
+      expect(createMultichainSession).toHaveBeenCalledTimes(1),
+    );
+
+    const [origin, , inputs] = createMultichainSession.mock.calls[0];
+    expect(origin).toBe("https://game.example");
+    expect(inputs).toHaveLength(2);
+    expect(inputs.map((i: { chainId: string }) => i.chainId)).toEqual([
+      SEPOLIA,
+      APPCHAIN,
+    ]);
+    // UI-only fields are stripped and policies forced authorized.
+    expect(inputs[0].policies.contracts["0xaaa"].methods[0].id).toBeUndefined();
+    expect(inputs[0].policies.contracts["0xaaa"].methods[0].authorized).toBe(
+      true,
+    );
+    await waitFor(() => expect(onConnect).toHaveBeenCalledTimes(1));
+  });
+
+  it("offers to retry only the chains that failed", async () => {
+    const { controller, createMultichainSession } = makeController([
+      { chainId: SEPOLIA },
+      { chainId: APPCHAIN, error: new Error("user cancelled") },
+    ]);
+    renderMultichain(controller, makeChainPolicies(false));
+
+    fireEvent.click(screen.getByText(/are not verified/i)); // consent
+    fireEvent.click(screen.getByRole("button", { name: /continue/i })); // sign
+
+    // Partial failure: connect is NOT resolved, retry button appears.
+    const retryButton = await screen.findByRole("button", {
+      name: /retry remaining chains/i,
+    });
+    expect(onConnect).not.toHaveBeenCalled();
+
+    // Retrying only re-signs the failed chain.
+    createMultichainSession.mockResolvedValueOnce([{ chainId: APPCHAIN }]);
+    fireEvent.click(retryButton);
+    await waitFor(() =>
+      expect(createMultichainSession).toHaveBeenCalledTimes(2),
+    );
+    const retryInputs = createMultichainSession.mock.calls[1][2];
+    expect(retryInputs).toHaveLength(1);
+    expect(retryInputs[0].chainId).toBe(APPCHAIN);
+    await waitFor(() => expect(onConnect).toHaveBeenCalledTimes(1));
+  });
+
+  it("signs directly without consent when every chain is verified", async () => {
+    const { controller, createMultichainSession } = makeController([
+      { chainId: SEPOLIA },
+      { chainId: APPCHAIN },
+    ]);
+    renderMultichain(controller, makeChainPolicies(true));
+
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+    await waitFor(() =>
+      expect(createMultichainSession).toHaveBeenCalledTimes(1),
+    );
+    await waitFor(() => expect(onConnect).toHaveBeenCalledTimes(1));
+  });
+
+  it("keeps the single-chain path when no chainPolicies are provided", async () => {
+    const { controller, createMultichainSession } = makeController([]);
+    renderWithProviders(
+      <CreateSession
+        policies={makePolicies(true, "0xaaa")}
+        onConnect={onConnect}
+      />,
+      { connection: { controller, origin: "https://game.example" } },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+    await waitFor(() =>
+      expect(controller.createSession).toHaveBeenCalledTimes(1),
+    );
+    expect(createMultichainSession).not.toHaveBeenCalled();
+  });
+});

--- a/packages/keychain/src/components/connect/CreateSession.stories.tsx
+++ b/packages/keychain/src/components/connect/CreateSession.stories.tsx
@@ -1,7 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { constants, shortString } from "starknet";
 import { CreateSession } from "./CreateSession";
 import { ETH_CONTRACT_ADDRESS } from "@cartridge/controller-ui/utils";
 import { parseSessionPolicies } from "@/hooks/session";
+import type { SessionChainPolicies } from "@/hooks/connection";
 
 const meta: Meta<typeof CreateSession> = {
   component: CreateSession,
@@ -174,6 +176,80 @@ export const Default: Story = {
       },
     }),
     onConnect: () => {},
+  },
+};
+
+// Multichain approval: a settlement chain + an appchain covered by a single
+// approval screen (SDK `multichainSessions` opt-in).
+const gameContractPolicies = (vrfAddress: string) => ({
+  contracts: {
+    "0x0726ff219937aeb721fe61449bfbe60be6abe4f9fd06e391ae0051ec20cc5da2": {
+      name: "Game Actions",
+      methods: [
+        { name: "Pull Orb", entrypoint: "pull", description: "Pull an orb" },
+        {
+          name: "Cash Out",
+          entrypoint: "cash_out",
+          description: "Cash out and end the game",
+        },
+      ],
+    },
+    [vrfAddress]: {
+      name: "VRF Provider",
+      methods: [{ name: "Request Random", entrypoint: "request_random" }],
+    },
+  },
+});
+
+export const MultichainVerified: Story = {
+  args: {
+    policies: parseSessionPolicies({
+      verified: true,
+      policies: gameContractPolicies(
+        "0x051Fea4450Da9D6aeE758BDEbA88B2f665bCbf549D2C61421AA724E9AC0Ced8F",
+      ),
+    }),
+    chainPolicies: [
+      {
+        chainId: constants.StarknetChainId.SN_SEPOLIA,
+        rpcUrl: "https://api.cartridge.gg/x/starknet/sepolia/rpc/v0_9",
+        policies: parseSessionPolicies({
+          verified: true,
+          policies: gameContractPolicies(
+            "0x051Fea4450Da9D6aeE758BDEbA88B2f665bCbf549D2C61421AA724E9AC0Ced8F",
+          ),
+        }),
+      },
+      {
+        chainId: shortString.encodeShortString("CARTRIDGE_TESTNET"),
+        rpcUrl: "https://api.cartridge.gg/x/gbomb/katana",
+        policies: parseSessionPolicies({
+          verified: true,
+          policies: gameContractPolicies(
+            "0x04da58da34ca055e21fdc1ea3e694b9ea88e1a0f0a5e0d9d3ca228cbf4de7490",
+          ),
+        }),
+      },
+    ],
+    onConnect: () => {},
+  },
+};
+
+export const MultichainUnverified: Story = {
+  args: {
+    ...MultichainVerified.args,
+    policies: parseSessionPolicies({
+      verified: false,
+      policies: gameContractPolicies(
+        "0x051Fea4450Da9D6aeE758BDEbA88B2f665bCbf549D2C61421AA724E9AC0Ced8F",
+      ),
+    }),
+    chainPolicies: (
+      MultichainVerified.args!.chainPolicies as SessionChainPolicies
+    ).map((chain) => ({
+      ...chain,
+      policies: { ...chain.policies, verified: false },
+    })),
   },
 };
 

--- a/packages/keychain/src/components/connect/CreateSession.tsx
+++ b/packages/keychain/src/components/connect/CreateSession.tsx
@@ -3,7 +3,9 @@ import { UnverifiedSessionSummary } from "@/components/session/UnverifiedSession
 import { VerifiedSessionSummary } from "@/components/session/VerifiedSessionSummary";
 import { now } from "@/constants";
 import { CreateSessionProvider } from "@/context/session";
-import { useConnection } from "@/hooks/connection";
+import { useConnection, type SessionChainPolicies } from "@/hooks/connection";
+import type { MultichainSessionInput } from "@/utils/controller";
+import { getChainName } from "@cartridge/controller-ui/utils";
 import {
   type ContractType,
   type ParsedSessionPolicies,
@@ -32,12 +34,15 @@ const requiredPolicies: Array<ContractType> = ["VRF"];
 
 export function CreateSession({
   policies,
+  chainPolicies,
   onConnect,
   onSkip,
   isUpdate,
   expiresAt: expiresAtOverride,
 }: {
   policies: ParsedSessionPolicies;
+  /** Multichain approval: one policy set per opted-in chain. */
+  chainPolicies?: SessionChainPolicies;
   onConnect: () => void;
   onSkip?: () => void;
   isUpdate?: boolean;
@@ -50,6 +55,7 @@ export function CreateSession({
     >
       <CreateSessionLayout
         isUpdate={isUpdate}
+        chainPolicies={chainPolicies}
         onConnect={onConnect}
         onSkip={onSkip}
         expiresAtOverride={expiresAtOverride}
@@ -60,11 +66,13 @@ export function CreateSession({
 
 const CreateSessionLayout = ({
   isUpdate,
+  chainPolicies,
   onConnect,
   onSkip,
   expiresAtOverride,
 }: {
   isUpdate?: boolean;
+  chainPolicies?: SessionChainPolicies;
   onConnect: () => void;
   onSkip?: () => void;
   expiresAtOverride?: bigint;
@@ -82,17 +90,40 @@ const CreateSessionLayout = ({
   const advancedView = useAdvancedView();
   const sessionStartTime = useRef(performance.now());
 
+  // Multichain sessions (explicit dapp opt-in): one approval screen covering
+  // every opted-in chain, then one chain-bound signature per chain.
+  const isMultichain = !!chainPolicies && chainPolicies.length > 0;
+  // Chains still awaiting a session — repopulated with the failed subset when
+  // a signature in the loop fails or is cancelled, so "retry" only re-signs
+  // what's missing.
+  const [pendingChains, setPendingChains] = useState<SessionChainPolicies>();
+  const [signingProgress, setSigningProgress] = useState<{
+    chainId: string;
+    index: number;
+    total: number;
+  }>();
+
+  const allChainsVerified = useMemo(
+    () =>
+      isMultichain
+        ? chainPolicies!.every((c) => c.policies.verified)
+        : !!policies?.verified,
+    [isMultichain, chainPolicies, policies?.verified],
+  );
+
   const hasTokenApprovals = useMemo(
     () => hasApprovalPolicies(policies),
     [policies],
   );
 
   const defaultStep = useMemo<"summary" | "spending-limit">(() => {
-    // Only show spending limit page for verified sessions with token approvals
-    return policies?.verified && hasTokenApprovals
+    // Only show spending limit page for verified sessions with token approvals.
+    // Multichain approvals skip it: per-chain spending limits are not
+    // supported yet, policies are signed as-is.
+    return policies?.verified && hasTokenApprovals && !isMultichain
       ? "spending-limit"
       : "summary";
-  }, [policies?.verified, hasTokenApprovals]);
+  }, [policies?.verified, hasTokenApprovals, isMultichain]);
 
   const [step, setStep] = useState<"summary" | "spending-limit">(defaultStep);
 
@@ -165,13 +196,80 @@ const CreateSessionLayout = ({
     [controller, policies, expiresAt, origin],
   );
 
+  const createMultichainSession = useCallback(
+    async ({ successCallback }: { successCallback?: () => void }) => {
+      if (!controller || !chainPolicies) return;
+      const chains = pendingChains ?? chainPolicies;
+      try {
+        setError(undefined);
+        setIsConnecting(true);
+
+        const inputs: MultichainSessionInput[] = chains.map((chain) => ({
+          chainId: chain.chainId,
+          rpcUrl: chain.rpcUrl,
+          policies: processPolicies(chain.policies, false),
+        }));
+
+        const results = await controller.createMultichainSession(
+          origin,
+          expiresAt,
+          inputs,
+          (chainId, index, total) =>
+            setSigningProgress({ chainId, index, total }),
+        );
+
+        const failed = results.filter((r) => r.error);
+        if (failed.length > 0) {
+          const failedIds = new Set(failed.map((r) => BigInt(r.chainId)));
+          setPendingChains(
+            chains.filter((c) => failedIds.has(BigInt(c.chainId))),
+          );
+          setError(failed[0].error);
+          captureAnalyticsEvent(posthog, "session_register_failed", {
+            error_code: sanitizeErrorCode(failed[0].error),
+          });
+          return;
+        }
+
+        setPendingChains(undefined);
+        captureAnalyticsEvent(posthog, "session_approved", {
+          policy_count: chainPolicies.reduce(
+            (count, c) =>
+              count +
+              (c.policies.contracts
+                ? Object.keys(c.policies.contracts).length
+                : 0),
+            0,
+          ),
+          chain_count: chainPolicies.length,
+          duration_ms: Math.round(performance.now() - sessionStartTime.current),
+        });
+        successCallback?.();
+      } catch (e) {
+        setError(e as unknown as Error);
+        captureAnalyticsEvent(posthog, "session_register_failed", {
+          error_code: sanitizeErrorCode(e),
+        });
+      } finally {
+        setIsConnecting(false);
+        setSigningProgress(undefined);
+      }
+    },
+    [controller, chainPolicies, pendingChains, expiresAt, origin],
+  );
+
   const handlePrimaryAction = useCallback(async () => {
     if (!policies || isConnecting) {
       return;
     }
 
-    if (!policies.verified && !isConsent) {
+    if (!allChainsVerified && !isConsent) {
       setIsConsent(true);
+      return;
+    }
+
+    if (isMultichain) {
+      await createMultichainSession({ successCallback: onConnect });
       return;
     }
 
@@ -189,9 +287,12 @@ const CreateSessionLayout = ({
     policies,
     isConnecting,
     isConsent,
+    allChainsVerified,
+    isMultichain,
     hasTokenApprovals,
     step,
     createSession,
+    createMultichainSession,
     onConnect,
   ]);
 
@@ -201,7 +302,7 @@ const CreateSessionLayout = ({
         e.preventDefault();
 
         // If unverified and on the summary step without consent, check the consent box
-        if (!policies?.verified && step === "summary" && !isConsent) {
+        if (!allChainsVerified && step === "summary" && !isConsent) {
           setIsConsent(true);
           return;
         }
@@ -209,7 +310,7 @@ const CreateSessionLayout = ({
         void handlePrimaryAction();
       }
     },
-    [policies?.verified, step, isConsent, handlePrimaryAction],
+    [allChainsVerified, step, isConsent, handlePrimaryAction],
   );
 
   // Add keyboard listener to the document
@@ -269,7 +370,8 @@ const CreateSessionLayout = ({
         }
         description={isUpdate ? "The policies were updated" : undefined}
         right={
-          !isEditable ? (
+          // Per-policy editing is not supported for multichain approvals yet.
+          !isEditable && !isMultichain ? (
             <Button
               variant="icon"
               className="bg-background-150 hover:bg-background-200 w-auto h-auto p-1.5 text-foreground-300 hover:text-foreground"
@@ -281,7 +383,40 @@ const CreateSessionLayout = ({
         }
       />
       <LayoutContent className="pb-0">
-        {policies.verified ? (
+        {isMultichain ? (
+          <div className="flex flex-col gap-4">
+            {chainPolicies!.map((chain) => (
+              <div key={chain.chainId} className="flex flex-col gap-2">
+                <div className="flex items-center gap-2">
+                  <h3 className="text-xs font-semibold uppercase text-foreground-300">
+                    {getChainName(chain.chainId)}
+                  </h3>
+                  {pendingChains &&
+                    !pendingChains.some(
+                      (c) => BigInt(c.chainId) === BigInt(chain.chainId),
+                    ) && (
+                      <span className="text-xs text-foreground-400">
+                        session created
+                      </span>
+                    )}
+                </div>
+                {chain.policies.verified ? (
+                  <VerifiedSessionSummary
+                    game={theme.name}
+                    contracts={chain.policies.contracts}
+                    messages={chain.policies.messages}
+                  />
+                ) : (
+                  <UnverifiedSessionSummary
+                    game={theme?.name}
+                    contracts={chain.policies.contracts}
+                    messages={chain.policies.messages}
+                  />
+                )}
+              </div>
+            ))}
+          </div>
+        ) : policies.verified ? (
           <VerifiedSessionSummary
             game={theme.name}
             contracts={policies.contracts}
@@ -296,7 +431,7 @@ const CreateSessionLayout = ({
         )}
       </LayoutContent>
       <LayoutFooter>
-        {!policies?.verified && (
+        {!allChainsVerified && (
           <div
             className={cn(
               "flex items-center p-2 mt-4 gap-2 border border-solid-primary rounded-md cursor-pointer text-destructive-100 bg-background-100",
@@ -331,17 +466,27 @@ const CreateSessionLayout = ({
 
         {error && <ControllerErrorAlert className="mb-3" error={error} />}
 
+        {isConnecting && signingProgress && signingProgress.total > 1 && (
+          <div className="mb-3 text-center text-xs text-foreground-300">
+            {`Signing session ${signingProgress.index + 1}/${signingProgress.total} — ${getChainName(signingProgress.chainId)}`}
+          </div>
+        )}
+
         <div className="flex flex-col gap-2">
           <Button
             ref={createButtonRef}
-            className={cn("flex-1", policies.verified && "w-full")}
-            disabled={isConnecting || (!policies.verified && !isConsent)}
+            className={cn("flex-1", allChainsVerified && "w-full")}
+            disabled={isConnecting || (!allChainsVerified && !isConsent)}
             isLoading={isConnecting}
             onClick={() => {
               void handlePrimaryAction();
             }}
           >
-            {isUpdate ? "update session" : "continue"}
+            {pendingChains
+              ? "retry remaining chains"
+              : isUpdate
+                ? "update session"
+                : "continue"}
           </Button>
           <Button
             variant="secondary"

--- a/packages/keychain/src/components/connect/RegisterSession.tsx
+++ b/packages/keychain/src/components/connect/RegisterSession.tsx
@@ -4,12 +4,13 @@ import { UnverifiedSessionSummary } from "@/components/session/UnverifiedSession
 import { VerifiedSessionSummary } from "@/components/session/VerifiedSessionSummary";
 import { now } from "@/constants";
 import { CreateSessionProvider } from "@/context/session";
-import { useConnection } from "@/hooks/connection";
+import { useConnection, type SessionChainPolicies } from "@/hooks/connection";
 import {
   type ContractType,
   type ParsedSessionPolicies,
   useCreateSession,
 } from "@/hooks/session";
+import { getChainName } from "@cartridge/controller-ui/utils";
 import { Button, LayoutContent, SliderIcon } from "@cartridge/controller-ui";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
@@ -23,11 +24,14 @@ const requiredPolicies: Array<ContractType> = ["VRF"];
 
 export function RegisterSession({
   policies,
+  chainPolicies,
   onConnect,
   publicKey,
   expiresAt: expiresAtOverride,
 }: {
   policies: ParsedSessionPolicies;
+  /** Multichain registration: one policy set per opted-in chain. */
+  chainPolicies?: SessionChainPolicies;
   onConnect: (transaction_hash: string, expiresAt: bigint) => void;
   publicKey?: string;
   expiresAt?: bigint;
@@ -38,6 +42,7 @@ export function RegisterSession({
       requiredPolicies={requiredPolicies}
     >
       <RegisterSessionLayout
+        chainPolicies={chainPolicies}
         onConnect={onConnect}
         publicKey={publicKey}
         expiresAtOverride={expiresAtOverride}
@@ -47,19 +52,22 @@ export function RegisterSession({
 }
 
 const RegisterSessionLayout = ({
+  chainPolicies,
   onConnect,
   publicKey,
   expiresAtOverride,
 }: {
+  chainPolicies?: SessionChainPolicies;
   onConnect: (transaction_hash: string, expiresAt: bigint) => void;
   publicKey?: string;
   expiresAtOverride?: bigint;
 }) => {
   const { policies } = useCreateSession();
-  const { controller, theme, origin, isAppchain } = useConnection();
+  const { controller, theme, origin, isAppchain, chainId } = useConnection();
   const [transactions, setTransactions] = useState<Call[] | undefined>(
     undefined,
   );
+  const [registeringChain, setRegisteringChain] = useState<string>();
 
   const { duration, isEditable, onToggleEditable } = useCreateSession();
 
@@ -110,9 +118,50 @@ const RegisterSessionLayout = ({
         ],
       });
 
+      // Multichain registration: after the active chain, register on every
+      // other opted-in chain. Already-registered chains count as success, so
+      // resubmitting after a partial failure only retries what's missing.
+      if (chainPolicies?.length) {
+        const otherChains = chainPolicies.filter(
+          (chain) => !chainId || BigInt(chain.chainId) !== BigInt(chainId),
+        );
+        if (otherChains.length > 0) {
+          try {
+            const results = await controller.registerSessionOnChains(
+              origin,
+              expiresAt,
+              otherChains.map((chain) => ({
+                chainId: chain.chainId,
+                rpcUrl: chain.rpcUrl,
+                policies: chain.policies,
+              })),
+              publicKey,
+              (registeringChainId) =>
+                setRegisteringChain(getChainName(registeringChainId)),
+            );
+            const failed = results.filter((r) => r.error);
+            if (failed.length > 0) {
+              throw failed[0].error;
+            }
+          } finally {
+            setRegisteringChain(undefined);
+          }
+        }
+      }
+
       onConnect(transaction_hash, expiresAt);
     },
-    [controller, expiresAt, policies, publicKey, onConnect, origin, isAppchain],
+    [
+      controller,
+      expiresAt,
+      policies,
+      chainPolicies,
+      chainId,
+      publicKey,
+      onConnect,
+      origin,
+      isAppchain,
+    ],
   );
 
   if (!transactions) {
@@ -124,7 +173,11 @@ const RegisterSessionLayout = ({
       title="Register Session"
       transactions={transactions}
       onSubmit={onRegisterSession}
-      buttonText="Register Session"
+      buttonText={
+        registeringChain
+          ? `Registering on ${registeringChain}…`
+          : "Register Session"
+      }
       right={
         !isEditable ? (
           <Button
@@ -142,7 +195,30 @@ const RegisterSessionLayout = ({
     >
       <LayoutContent>
         <SessionConsent isVerified={policies?.verified} />
-        {policies?.verified ? (
+        {chainPolicies?.length ? (
+          <div className="flex flex-col gap-4">
+            {chainPolicies.map((chain) => (
+              <div key={chain.chainId} className="flex flex-col gap-2">
+                <h3 className="text-xs font-semibold uppercase text-foreground-300">
+                  {getChainName(chain.chainId)}
+                </h3>
+                {chain.policies.verified ? (
+                  <VerifiedSessionSummary
+                    game={theme.name}
+                    contracts={chain.policies.contracts}
+                    messages={chain.policies.messages}
+                  />
+                ) : (
+                  <UnverifiedSessionSummary
+                    game={theme?.name}
+                    contracts={chain.policies.contracts}
+                    messages={chain.policies.messages}
+                  />
+                )}
+              </div>
+            ))}
+          </div>
+        ) : policies?.verified ? (
           <VerifiedSessionSummary
             game={theme.name}
             contracts={policies.contracts}

--- a/packages/keychain/src/components/connect/StandaloneSessionCreation.tsx
+++ b/packages/keychain/src/components/connect/StandaloneSessionCreation.tsx
@@ -41,8 +41,15 @@ export function StandaloneSessionCreation({ username }: { username?: string }) {
   const [searchParams] = useSearchParams();
 
   const { duration, isEditable, onToggleEditable } = useCreateSession();
-  const { setController, theme, parent, closeModal, origin, policies } =
-    useConnection();
+  const {
+    setController,
+    theme,
+    parent,
+    closeModal,
+    origin,
+    policies,
+    chainPolicies,
+  } = useConnection();
 
   const redirectUrl = searchParams.get("redirect_url");
 
@@ -106,8 +113,25 @@ export function StandaloneSessionCreation({ username }: { username?: string }) {
         setController(controller);
 
         // Create session (now we have storage access)
-        const processedPolicies = processPolicies(policies, toggleOff);
-        await controller.createSession(origin, expiresAt, processedPolicies);
+        if (chainPolicies?.length && !toggleOff) {
+          // Multichain opt-in: one session per chain within this approval.
+          const results = await controller.createMultichainSession(
+            origin,
+            expiresAt,
+            chainPolicies.map((chain) => ({
+              chainId: chain.chainId,
+              rpcUrl: chain.rpcUrl,
+              policies: processPolicies(chain.policies, false),
+            })),
+          );
+          const failed = results.find((r) => r.error);
+          if (failed) {
+            throw failed.error;
+          }
+        } else {
+          const processedPolicies = processPolicies(policies, toggleOff);
+          await controller.createSession(origin, expiresAt, processedPolicies);
+        }
         // Notify parent that session was created
         if (parent) {
           if (
@@ -145,6 +169,7 @@ export function StandaloneSessionCreation({ username }: { username?: string }) {
     [
       closeModal,
       policies,
+      chainPolicies,
       expiresAt,
       redirectUrl,
       parent,

--- a/packages/keychain/src/components/connect/create/useCreateController.ts
+++ b/packages/keychain/src/components/connect/create/useCreateController.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { STABLE_CONTROLLER } from "@/components/provider/upgrade";
 import { DEFAULT_SESSION_DURATION, now } from "@/constants";
-import { useConnection } from "@/hooks/connection";
+import { useConnection, type SessionChainPolicies } from "@/hooks/connection";
 import { useToast } from "@/context/toast";
 import { useWallets } from "@/hooks/wallets";
 import Controller from "@/utils/controller";
@@ -154,6 +154,7 @@ const createSession = async ({
   controller,
   origin,
   policies,
+  chainPolicies,
   params,
   handleCompletion,
   closeModal,
@@ -165,6 +166,7 @@ const createSession = async ({
   controller: Controller;
   origin: string;
   policies?: ParsedSessionPolicies;
+  chainPolicies?: SessionChainPolicies;
   params?: ReturnType<typeof parseConnectParams>;
   handleCompletion: () => void;
   closeModal?: () => void;
@@ -215,6 +217,7 @@ const createSession = async ({
       controller,
       origin,
       policies,
+      chainPolicies,
     });
     currentParams.resolve?.(
       createConnectReply(controller.address(), isNewController, canKeepOpen),
@@ -344,6 +347,7 @@ export function useCreateController({
     chainId,
     setController,
     policies,
+    chainPolicies,
     isConfigLoading,
     isPoliciesResolved,
     locationGate,
@@ -366,7 +370,7 @@ export function useCreateController({
   }, [searchParams]);
   const handleCompletion = useRouteCompletion();
   const hasPolicies = !!policies;
-  const shouldAutoCreateSession = canAutoCreateSession(policies);
+  const shouldAutoCreateSession = canAutoCreateSession(policies, chainPolicies);
 
   const {
     signup: signupWithWebauthn,
@@ -564,6 +568,7 @@ export function useCreateController({
             controller,
             origin: effectiveOrigin,
             policies,
+            chainPolicies,
             params,
             handleCompletion,
             searchParams,
@@ -579,6 +584,7 @@ export function useCreateController({
       }
     },
     [
+      chainPolicies,
       setController,
       origin,
       policies,
@@ -880,6 +886,7 @@ export function useCreateController({
           controller: loginRet.controller,
           origin: effectiveOrigin,
           policies,
+          chainPolicies,
           params,
           handleCompletion,
           searchParams,
@@ -894,6 +901,7 @@ export function useCreateController({
       }
     },
     [
+      chainPolicies,
       origin,
       setController,
       policies,
@@ -994,6 +1002,7 @@ export function useCreateController({
               controller: loginController.controller,
               origin,
               policies,
+              chainPolicies,
               params,
               handleCompletion,
               searchParams,
@@ -1107,6 +1116,7 @@ export function useCreateController({
       });
     },
     [
+      chainPolicies,
       isSlot,
       loginWithWebauthn,
       loginWithWebauthnPopup,

--- a/packages/keychain/src/components/provider/connection.tsx
+++ b/packages/keychain/src/components/provider/connection.tsx
@@ -1,9 +1,10 @@
-import { ParentMethods } from "@/hooks/connection";
+import { ParentMethods, SessionChainPolicies } from "@/hooks/connection";
 import { ParsedSessionPolicies } from "@/hooks/session";
 import Controller from "@/utils/controller";
 import {
   type Chain,
   type DefaultPaymentMethod,
+  type SessionChain,
   ExternalWallet,
   ExternalWalletResponse,
   ExternalWalletType,
@@ -35,10 +36,16 @@ export type ConnectionContextValue = {
   };
   /** Chains the dapp explicitly configured (SDK `chains` param). */
   configuredChains: Chain[];
+  /** Chains covered by a multichain session approval (SDK `multichainSessions`
+   *  opt-in), resolved to their rpcUrl. */
+  sessionChains?: SessionChain[];
   preset: string | null;
   policiesStr: string | null;
   tokens?: string[];
   policies?: ParsedSessionPolicies;
+  /** One policy set per chain of a multichain session approval (SDK
+   *  `multichainSessions` opt-in). Undefined in single-chain mode. */
+  chainPolicies?: SessionChainPolicies;
   theme: VerifiableControllerTheme;
   isConfigLoading: boolean;
   isPoliciesResolved: boolean;

--- a/packages/keychain/src/components/session.tsx
+++ b/packages/keychain/src/components/session.tsx
@@ -61,7 +61,8 @@ export function Session() {
     }
   }, [queries.expires_at]);
 
-  const { controller, setController, policies } = useConnection();
+  const { controller, setController, policies, chainPolicies } =
+    useConnection();
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [isSuccess, setIsSuccess] = useState<boolean>(false);
   const [isFailure, setIsFailure] = useState<boolean>(false);
@@ -172,6 +173,14 @@ export function Session() {
       return;
     }
 
+    // Multichain registration: the already-registered shortcut only checks
+    // the active chain, which cannot prove the other chains are covered —
+    // always go through the registration flow (it is idempotent per chain).
+    if (chainPolicies?.length) {
+      setIsLoading(false);
+      return;
+    }
+
     // If the requested policies has no mismatch with existing policies and public key already
     // registered then return the exising session
     controller
@@ -203,6 +212,7 @@ export function Session() {
   }, [
     controller,
     policies,
+    chainPolicies,
     queries.public_key,
     hasExternalTarget,
     markCompleted,
@@ -242,6 +252,7 @@ export function Session() {
       {queries.public_key ? (
         <RegisterSession
           policies={policies}
+          chainPolicies={chainPolicies}
           onConnect={onConnect}
           publicKey={queries.public_key}
           expiresAt={expiresAt}
@@ -249,6 +260,7 @@ export function Session() {
       ) : (
         <CreateSession
           policies={policies}
+          chainPolicies={chainPolicies}
           onConnect={onConnect}
           expiresAt={expiresAt}
         />

--- a/packages/keychain/src/hooks/connection.test.ts
+++ b/packages/keychain/src/hooks/connection.test.ts
@@ -6,11 +6,13 @@ import {
   isSameRpcUrl,
   parseControllerVersion,
   parseDefaultPaymentMethod,
+  resolveChainPolicies,
   resolveCoinflowSandbox,
   resolveDefaultPaymentMethod,
   resolvePolicies,
   verifyStandaloneOrigin,
 } from "./connection";
+import { getPresetSessionPolicies } from "@cartridge/controller";
 import { vi } from "vitest";
 
 vi.mock("@cartridge/controller", async () => {
@@ -669,6 +671,167 @@ describe("resolvePolicies", () => {
 
     expect(result.isPoliciesResolved).toBe(false);
     expect(result.policies).toBeUndefined();
+  });
+});
+
+describe("resolveChainPolicies", () => {
+  const SEPOLIA = "0x534e5f5345504f4c4941";
+  const APPCHAIN = "0x4341525452494447455f544553544e4554";
+  const sessionChains = [
+    { chainId: SEPOLIA, rpcUrl: "https://sepolia.example/rpc" },
+    { chainId: APPCHAIN, rpcUrl: "https://appchain.example/rpc" },
+  ];
+  const encodedPolicies = encodeURIComponent(
+    JSON.stringify({
+      contracts: {
+        "0x1": {
+          methods: [{ entrypoint: "transfer" }],
+        },
+      },
+    }),
+  );
+
+  afterEach(() => {
+    vi.mocked(getPresetSessionPolicies).mockReset();
+    vi.mocked(getPresetSessionPolicies).mockImplementation(() => undefined);
+  });
+
+  it("resolves to undefined without error when no session chains are requested", () => {
+    const result = resolveChainPolicies({
+      policiesStr: encodedPolicies,
+      preset: null,
+      shouldOverridePresetPolicies: false,
+      configData: null,
+      sessionChains: undefined,
+      verified: false,
+      isConfigLoading: false,
+    });
+
+    expect(result.isResolved).toBe(true);
+    expect(result.chainPolicies).toBeUndefined();
+    expect(result.error).toBeUndefined();
+  });
+
+  it("replicates manual policies on every requested chain", () => {
+    const result = resolveChainPolicies({
+      policiesStr: encodedPolicies,
+      preset: null,
+      shouldOverridePresetPolicies: false,
+      configData: null,
+      sessionChains,
+      verified: false,
+      isConfigLoading: false,
+    });
+
+    expect(result.isResolved).toBe(true);
+    expect(result.error).toBeUndefined();
+    expect(result.chainPolicies).toHaveLength(2);
+    expect(result.chainPolicies![0].chainId).toBe(SEPOLIA);
+    expect(result.chainPolicies![0].rpcUrl).toBe(sessionChains[0].rpcUrl);
+    expect(result.chainPolicies![1].chainId).toBe(APPCHAIN);
+    expect(result.chainPolicies![0].policies.contracts).toBeDefined();
+  });
+
+  it("resolves per-chain policies from the preset config", () => {
+    vi.mocked(getPresetSessionPolicies).mockImplementation(
+      (_config, chainId) => ({
+        contracts: {
+          [chainId === SEPOLIA ? "0xaaa" : "0xbbb"]: {
+            methods: [{ entrypoint: "play" }],
+          },
+        },
+      }),
+    );
+
+    const result = resolveChainPolicies({
+      policiesStr: null,
+      preset: "glitch-bomb",
+      shouldOverridePresetPolicies: false,
+      configData: { chains: {} },
+      sessionChains,
+      verified: true,
+      isConfigLoading: false,
+    });
+
+    expect(result.isResolved).toBe(true);
+    expect(result.error).toBeUndefined();
+    expect(result.chainPolicies).toHaveLength(2);
+    expect(
+      result.chainPolicies![0].policies.contracts?.["0xaaa"],
+    ).toBeDefined();
+    expect(
+      result.chainPolicies![1].policies.contracts?.["0xbbb"],
+    ).toBeDefined();
+    expect(result.chainPolicies![0].policies.verified).toBe(true);
+  });
+
+  it("errors when the preset lacks policies for a requested chain", () => {
+    vi.mocked(getPresetSessionPolicies).mockImplementation(
+      (_config, chainId) =>
+        chainId === SEPOLIA
+          ? { contracts: { "0xaaa": { methods: [{ entrypoint: "play" }] } } }
+          : undefined,
+    );
+
+    const result = resolveChainPolicies({
+      policiesStr: null,
+      preset: "glitch-bomb",
+      shouldOverridePresetPolicies: false,
+      configData: { chains: {} },
+      sessionChains,
+      verified: true,
+      isConfigLoading: false,
+    });
+
+    expect(result.isResolved).toBe(true);
+    expect(result.error).toBe(true);
+    expect(result.chainPolicies).toBeUndefined();
+  });
+
+  it("errors when neither preset nor manual policies are available", () => {
+    const result = resolveChainPolicies({
+      policiesStr: null,
+      preset: null,
+      shouldOverridePresetPolicies: false,
+      configData: null,
+      sessionChains,
+      verified: false,
+      isConfigLoading: false,
+    });
+
+    expect(result.isResolved).toBe(true);
+    expect(result.error).toBe(true);
+  });
+
+  it("waits for the preset config before resolving", () => {
+    const result = resolveChainPolicies({
+      policiesStr: null,
+      preset: "glitch-bomb",
+      shouldOverridePresetPolicies: false,
+      configData: null,
+      sessionChains,
+      verified: true,
+      isConfigLoading: true,
+    });
+
+    expect(result.isResolved).toBe(false);
+    expect(result.chainPolicies).toBeUndefined();
+    expect(result.error).toBeUndefined();
+  });
+
+  it("overrides preset policies on every chain when requested", () => {
+    const result = resolveChainPolicies({
+      policiesStr: encodedPolicies,
+      preset: "glitch-bomb",
+      shouldOverridePresetPolicies: true,
+      configData: null,
+      sessionChains,
+      verified: false,
+      isConfigLoading: true,
+    });
+
+    expect(result.isResolved).toBe(true);
+    expect(result.chainPolicies).toHaveLength(2);
   });
 });
 

--- a/packages/keychain/src/hooks/connection.ts
+++ b/packages/keychain/src/hooks/connection.ts
@@ -25,6 +25,7 @@ import {
   WalletBridge,
   type Chain,
   type DefaultPaymentMethod,
+  type SessionChain,
 } from "@cartridge/controller";
 import { AsyncMethodReturns } from "@cartridge/penpal";
 import {
@@ -93,6 +94,9 @@ type ResolvedUrlParams = {
   /** Chains the dapp explicitly configured (SDK `chains` param). Optional so
    *  url-param snapshots persisted before this field existed stay valid. */
   chains?: Chain[];
+  /** Chains covered by a single multichain session approval (SDK
+   *  `multichainSessions` opt-in), resolved to their rpcUrl SDK-side. */
+  sessionChains?: SessionChain[];
 };
 
 export const URL_PARAMS_STORAGE_KEY = "keychain.urlParams";
@@ -312,6 +316,89 @@ export function resolvePolicies({
   return { policies: urlPolicies, isPoliciesResolved: true };
 }
 
+/** One entry per chain of a multichain session approval, in signing order. */
+export type SessionChainPolicies = Array<
+  SessionChain & { policies: ParsedSessionPolicies }
+>;
+
+/**
+ * Resolves session policies for every chain of a multichain session approval.
+ *
+ * Unlike `resolvePolicies`, a chain with no resolvable policies is an ERROR,
+ * never a silent fallback: multichain sessions are an explicit opt-in and
+ * creating fewer sessions than the dapp asked the user to approve would break
+ * that contract.
+ */
+export function resolveChainPolicies({
+  policiesStr,
+  preset,
+  shouldOverridePresetPolicies,
+  configData,
+  sessionChains,
+  verified,
+  isConfigLoading,
+}: {
+  policiesStr: string | null;
+  preset: string | null;
+  shouldOverridePresetPolicies: boolean;
+  configData: Record<string, unknown> | null;
+  sessionChains: SessionChain[] | undefined;
+  verified: boolean;
+  isConfigLoading: boolean;
+}): {
+  chainPolicies: SessionChainPolicies | undefined;
+  isResolved: boolean;
+  error?: boolean;
+} {
+  if (!sessionChains || sessionChains.length === 0) {
+    return { chainPolicies: undefined, isResolved: true };
+  }
+
+  const urlPolicies = parseUrlPolicies(policiesStr);
+  if (urlPolicies instanceof Error) {
+    return { chainPolicies: undefined, isResolved: true, error: true };
+  }
+
+  // Manual policies (no preset, or explicit override) apply to every
+  // requested chain.
+  if ((shouldOverridePresetPolicies || !preset) && urlPolicies) {
+    return {
+      chainPolicies: sessionChains.map((chain) => ({
+        ...chain,
+        policies: urlPolicies,
+      })),
+      isResolved: true,
+    };
+  }
+
+  if (!preset) {
+    // No preset and no manual policies: nothing to authorize.
+    return { chainPolicies: undefined, isResolved: true, error: true };
+  }
+
+  if (isConfigLoading) {
+    return { chainPolicies: undefined, isResolved: false };
+  }
+
+  const chainPolicies: SessionChainPolicies = [];
+  for (const chain of sessionChains) {
+    const configPolicies = getConfigChainPolicies(
+      configData,
+      chain.chainId,
+      verified,
+    );
+    if (configPolicies instanceof Error || !configPolicies) {
+      console.error(
+        `No preset policies found for multichain session chain ${chain.chainId}`,
+      );
+      return { chainPolicies: undefined, isResolved: true, error: true };
+    }
+    chainPolicies.push({ ...chain, policies: configPolicies });
+  }
+
+  return { chainPolicies, isResolved: true };
+}
+
 function computeVerifiedState(
   configData: Record<string, unknown>,
   currentOrigin: string | undefined,
@@ -439,6 +526,7 @@ export function useConnectionValue() {
     import.meta.env.VITE_RPC_MAINNET,
   );
   const [policies, setPolicies] = useState<ParsedSessionPolicies>();
+  const [chainPolicies, setChainPolicies] = useState<SessionChainPolicies>();
   const [isPoliciesResolved, setIsPoliciesResolved] = useState<boolean>(false);
   const [isPoliciesError, setIsPoliciesError] = useState<boolean>(false);
   const [verified, setVerified] = useState<boolean>(false);
@@ -653,6 +741,27 @@ export function useConnectionValue() {
       }
     })();
 
+    // JSON array of {chainId, rpcUrl} for multichain sessions, encoded by the
+    // SDK the same way as `chains`.
+    const sessionChains = (() => {
+      const raw = urlParams.get("session_chains");
+      if (!raw) return null;
+      try {
+        const parsed = JSON.parse(decodeURIComponent(raw));
+        return Array.isArray(parsed)
+          ? parsed.filter(
+              (c): c is SessionChain =>
+                !!c &&
+                typeof c === "object" &&
+                typeof c.chainId === "string" &&
+                typeof c.rpcUrl === "string",
+            )
+          : null;
+      } catch {
+        return null;
+      }
+    })();
+
     const erc20Param = urlParams.get("erc20");
     const tokens = erc20Param
       ? decodeURIComponent(erc20Param)
@@ -694,6 +803,7 @@ export function useConnectionValue() {
       errorDisplayMode:
         errorDisplayMode || urlParamsRef.current?.errorDisplayMode || undefined,
       chains: chains ?? urlParamsRef.current?.chains ?? [],
+      sessionChains: sessionChains ?? urlParamsRef.current?.sessionChains,
     };
 
     // Store the new params for future reference
@@ -986,9 +1096,27 @@ export function useConnectionValue() {
       isConfigLoading,
     });
 
+    // Multichain sessions: resolve one policy set per opted-in chain. Both
+    // resolutions must land before policies are considered resolved, and an
+    // error on either side blocks the flow.
+    const {
+      chainPolicies: resolvedChainPolicies,
+      isResolved: chainResolved,
+      error: chainError,
+    } = resolveChainPolicies({
+      policiesStr: policyStr,
+      preset,
+      shouldOverridePresetPolicies,
+      configData,
+      sessionChains: urlParams.sessionChains,
+      verified,
+      isConfigLoading,
+    });
+
     setPolicies(resolvedPolicies || { verified: false });
-    setIsPoliciesResolved(resolved);
-    setIsPoliciesError(error ?? false);
+    setChainPolicies(resolvedChainPolicies);
+    setIsPoliciesResolved(resolved && chainResolved);
+    setIsPoliciesError((error ?? false) || (chainError ?? false));
   }, [urlParams, chainId, verified, configData, isConfigLoading]);
 
   useThemeEffect({ theme, assetUrl: "" });
@@ -1236,6 +1364,7 @@ export function useConnectionValue() {
     origin: origin || "",
     rpcUrl,
     policies,
+    chainPolicies,
     onModalClose,
     setOnModalClose,
     theme,
@@ -1248,6 +1377,7 @@ export function useConnectionValue() {
     coinflowSandbox: urlParams.coinflowSandbox ?? false,
     webauthnPopup,
     configuredChains: urlParams.chains ?? NO_CONFIGURED_CHAINS,
+    sessionChains: urlParams.sessionChains,
     preset: urlParams.preset,
     policiesStr: urlParams.policies,
     isConfigLoading,

--- a/packages/keychain/src/types/analytics.ts
+++ b/packages/keychain/src/types/analytics.ts
@@ -150,6 +150,8 @@ interface SessionRequestedProps {
 interface SessionApprovedProps {
   policy_count: number;
   duration_ms: number;
+  /** Number of chains covered by a multichain session approval. */
+  chain_count?: number;
 }
 interface SessionRejectedProps {
   duration_ms: number;

--- a/packages/keychain/src/utils/connection/session-creation.test.ts
+++ b/packages/keychain/src/utils/connection/session-creation.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import type Controller from "@/utils/controller";
 import type { ParsedSessionPolicies } from "@/hooks/session";
+import type { SessionChainPolicies } from "@/hooks/connection";
 import {
+  canAutoCreateSession,
   createVerifiedSession,
   requiresSessionApproval,
   DEFAULT_VERIFIED_SESSION_DURATION_S,
@@ -109,6 +111,142 @@ describe("session-creation helpers", () => {
       );
       expect(processedPolicies.messages[0].id).toBeUndefined();
       expect(processedPolicies.messages[0].authorized).toBe(true);
+    });
+  });
+
+  describe("multichain sessions", () => {
+    const verifiedPolicies = {
+      verified: true,
+      contracts: {
+        "0x1": { methods: [{ entrypoint: "transfer" }] },
+      },
+    } as unknown as ParsedSessionPolicies;
+
+    const unverifiedPolicies = {
+      verified: false,
+      contracts: {
+        "0x1": { methods: [{ entrypoint: "transfer" }] },
+      },
+    } as unknown as ParsedSessionPolicies;
+
+    const chains = (
+      policiesByChain: Record<string, ParsedSessionPolicies>,
+    ): SessionChainPolicies =>
+      Object.entries(policiesByChain).map(([chainId, policies]) => ({
+        chainId,
+        rpcUrl: `https://${chainId}.example/rpc`,
+        policies,
+      }));
+
+    it("requires approval when any chain requires it", () => {
+      expect(
+        requiresSessionApproval(
+          undefined,
+          chains({ "0x1": verifiedPolicies, "0x2": unverifiedPolicies }),
+        ),
+      ).toBe(true);
+      expect(
+        requiresSessionApproval(
+          undefined,
+          chains({ "0x1": verifiedPolicies, "0x2": verifiedPolicies }),
+        ),
+      ).toBe(false);
+    });
+
+    it("gates auto-creation on the whole chain set", () => {
+      expect(
+        canAutoCreateSession(
+          verifiedPolicies,
+          chains({ "0x1": verifiedPolicies, "0x2": unverifiedPolicies }),
+        ),
+      ).toBe(false);
+      expect(
+        canAutoCreateSession(
+          verifiedPolicies,
+          chains({ "0x1": verifiedPolicies, "0x2": verifiedPolicies }),
+        ),
+      ).toBe(true);
+    });
+
+    it("creates one session per chain through createMultichainSession", async () => {
+      const createMultichainSession = vi
+        .fn()
+        .mockResolvedValue([{ chainId: "0x1" }, { chainId: "0x2" }]);
+      const createSession = vi.fn();
+      const controller = {
+        createSession,
+        createMultichainSession,
+      } as unknown as Controller;
+
+      const chainPolicies = chains({
+        "0x1": verifiedPolicies,
+        "0x2": verifiedPolicies,
+      });
+
+      const nowFn = () => BigInt(1_000);
+      await createVerifiedSession({
+        controller,
+        origin: "origin",
+        policies: verifiedPolicies,
+        chainPolicies,
+        nowFn,
+      });
+
+      expect(createSession).not.toHaveBeenCalled();
+      expect(createMultichainSession).toHaveBeenCalledTimes(1);
+      const [origin, expiresAt, inputs] = createMultichainSession.mock.calls[0];
+      expect(origin).toBe("origin");
+      expect(expiresAt).toBe(
+        BigInt(1_000) + DEFAULT_VERIFIED_SESSION_DURATION_S,
+      );
+      expect(inputs).toHaveLength(2);
+      expect(inputs[0].chainId).toBe("0x1");
+      expect(inputs[0].rpcUrl).toBe("https://0x1.example/rpc");
+      expect(inputs[0].policies.contracts["0x1"].methods[0].authorized).toBe(
+        true,
+      );
+    });
+
+    it("throws when a chain fails to create", async () => {
+      const createMultichainSession = vi
+        .fn()
+        .mockResolvedValue([
+          { chainId: "0x1" },
+          { chainId: "0x2", error: new Error("user cancelled") },
+        ]);
+      const controller = {
+        createMultichainSession,
+      } as unknown as Controller;
+
+      await expect(
+        createVerifiedSession({
+          controller,
+          origin: "origin",
+          policies: verifiedPolicies,
+          chainPolicies: chains({
+            "0x1": verifiedPolicies,
+            "0x2": verifiedPolicies,
+          }),
+        }),
+      ).rejects.toThrow("user cancelled");
+    });
+
+    it("throws when any chain requires approval", async () => {
+      const controller = {
+        createMultichainSession: vi.fn(),
+      } as unknown as Controller;
+
+      await expect(
+        createVerifiedSession({
+          controller,
+          origin: "origin",
+          policies: verifiedPolicies,
+          chainPolicies: chains({
+            "0x1": verifiedPolicies,
+            "0x2": unverifiedPolicies,
+          }),
+        }),
+      ).rejects.toThrow(/requires explicit approval/i);
     });
   });
 });

--- a/packages/keychain/src/utils/connection/session-creation.ts
+++ b/packages/keychain/src/utils/connection/session-creation.ts
@@ -51,6 +51,7 @@ export async function createVerifiedSession({
   chainPolicies,
   durationSeconds = DEFAULT_VERIFIED_SESSION_DURATION_S,
   nowFn = now,
+  onProgress,
 }: {
   controller: Controller;
   origin: string;
@@ -59,6 +60,8 @@ export async function createVerifiedSession({
   chainPolicies?: SessionChainPolicies;
   durationSeconds?: bigint;
   nowFn?: () => bigint;
+  /** Reports which chain is being signed during multichain creation. */
+  onProgress?: (chainId: string, index: number, total: number) => void;
 }): Promise<void> {
   if (requiresSessionApproval(policies, chainPolicies)) {
     throw new Error("Verified session creation requires explicit approval");
@@ -75,6 +78,7 @@ export async function createVerifiedSession({
         rpcUrl: chain.rpcUrl,
         policies: processPolicies(chain.policies, false),
       })),
+      onProgress,
     );
     const failed = results.find((r) => r.error);
     if (failed) {

--- a/packages/keychain/src/utils/connection/session-creation.ts
+++ b/packages/keychain/src/utils/connection/session-creation.ts
@@ -4,13 +4,23 @@ import {
   hasApprovalPolicies,
   type ParsedSessionPolicies,
 } from "@/hooks/session";
+import type { SessionChainPolicies } from "@/hooks/connection";
 import { processPolicies } from "@/utils/session/policies";
 
 export const DEFAULT_VERIFIED_SESSION_DURATION_S = BigInt(24 * 60 * 60);
 
 export function requiresSessionApproval(
   policies?: ParsedSessionPolicies | null,
+  chainPolicies?: SessionChainPolicies | null,
 ): boolean {
+  // Multichain approvals: any chain needing review sends the whole set to the
+  // approval UI so the user consents to every chain at once.
+  if (chainPolicies && chainPolicies.length > 0) {
+    return chainPolicies.some((chain) =>
+      requiresSessionApproval(chain.policies),
+    );
+  }
+
   if (!policies) {
     return false;
   }
@@ -26,7 +36,11 @@ export function requiresSessionApproval(
 
 export function canAutoCreateSession(
   policies?: ParsedSessionPolicies | null,
+  chainPolicies?: SessionChainPolicies | null,
 ): boolean {
+  if (chainPolicies && chainPolicies.length > 0) {
+    return !requiresSessionApproval(undefined, chainPolicies);
+  }
   return !policies || !requiresSessionApproval(policies);
 }
 
@@ -34,20 +48,41 @@ export async function createVerifiedSession({
   controller,
   origin,
   policies,
+  chainPolicies,
   durationSeconds = DEFAULT_VERIFIED_SESSION_DURATION_S,
   nowFn = now,
 }: {
   controller: Controller;
   origin: string;
   policies: ParsedSessionPolicies;
+  /** When set, creates one session per chain (multichain opt-in). */
+  chainPolicies?: SessionChainPolicies;
   durationSeconds?: bigint;
   nowFn?: () => bigint;
 }): Promise<void> {
-  if (requiresSessionApproval(policies)) {
+  if (requiresSessionApproval(policies, chainPolicies)) {
     throw new Error("Verified session creation requires explicit approval");
   }
 
   const expiresAt = durationSeconds + nowFn();
+
+  if (chainPolicies && chainPolicies.length > 0) {
+    const results = await controller.createMultichainSession(
+      origin,
+      expiresAt,
+      chainPolicies.map((chain) => ({
+        chainId: chain.chainId,
+        rpcUrl: chain.rpcUrl,
+        policies: processPolicies(chain.policies, false),
+      })),
+    );
+    const failed = results.find((r) => r.error);
+    if (failed) {
+      throw failed.error;
+    }
+    return;
+  }
+
   const processedPolicies = processPolicies(policies, false);
   await controller.createSession(origin, expiresAt, processedPolicies);
 }

--- a/packages/keychain/src/utils/controller.multichain.test.ts
+++ b/packages/keychain/src/utils/controller.multichain.test.ts
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ParsedSessionPolicies } from "@/hooks/session";
+
+const { cartridgeAccountNew } = vi.hoisted(() => ({
+  cartridgeAccountNew: vi.fn(),
+}));
+
+vi.mock("@cartridge/controller-wasm/controller", () => ({
+  CartridgeAccount: { new: cartridgeAccountNew },
+  CartridgeAccountMeta: vi.fn(),
+  ControllerFactory: {},
+  ErrorCode: { SessionAlreadyRegistered: 132 },
+}));
+
+import Controller from "./controller";
+
+const SEPOLIA = "0x534e5f5345504f4c4941";
+const APPCHAIN = "0x4341525452494447455f544553544e4554";
+
+const policies = {
+  verified: true,
+  contracts: {
+    "0x1": { methods: [{ entrypoint: "transfer", authorized: true }] },
+  },
+} as unknown as ParsedSessionPolicies;
+
+function buildController({
+  activeChainId = SEPOLIA,
+  createSession = vi.fn().mockResolvedValue({ chainId: activeChainId }),
+}: {
+  activeChainId?: string;
+  createSession?: ReturnType<typeof vi.fn>;
+} = {}) {
+  const controller = Object.create(Controller.prototype) as Controller;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (controller as any).cartridge = { createSession };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (controller as any).cartridgeMeta = {
+    chainId: () => activeChainId,
+    rpcUrl: () => "https://active.example/rpc",
+    classHash: () => "0xclass",
+    address: () => "0xaddress",
+    username: () => "user",
+    owner: () => ({}),
+  };
+  return { controller, createSession };
+}
+
+function mockEphemeralAccount(
+  createSession: ReturnType<typeof vi.fn>,
+  registerSession: ReturnType<typeof vi.fn> = vi.fn(),
+) {
+  const free = vi.fn();
+  cartridgeAccountNew.mockResolvedValue({
+    intoAccount: () => ({ createSession, registerSession, free }),
+    meta: () => ({}),
+  });
+  return { free };
+}
+
+describe("Controller.createMultichainSession", () => {
+  beforeEach(() => {
+    cartridgeAccountNew.mockReset();
+  });
+
+  it("creates the active chain session first, then the others", async () => {
+    const order: string[] = [];
+    const activeCreateSession = vi.fn().mockImplementation(async () => {
+      order.push("active");
+      return {};
+    });
+    const ephemeralCreateSession = vi.fn().mockImplementation(async () => {
+      order.push("ephemeral");
+      return {};
+    });
+    const { free } = mockEphemeralAccount(ephemeralCreateSession);
+    const { controller } = buildController({
+      createSession: activeCreateSession,
+    });
+
+    const results = await controller.createMultichainSession(
+      "app",
+      BigInt(2_000),
+      [
+        // Deliberately listed appchain-first: the active chain must still
+        // sign first.
+        { chainId: APPCHAIN, rpcUrl: "https://appchain.example/rpc", policies },
+        { chainId: SEPOLIA, rpcUrl: "https://sepolia.example/rpc", policies },
+      ],
+    );
+
+    expect(order).toEqual(["active", "ephemeral"]);
+    expect(results).toHaveLength(2);
+    expect(results.every((r) => !r.error)).toBe(true);
+    expect(results[0].chainId).toBe(SEPOLIA);
+    expect(results[1].chainId).toBe(APPCHAIN);
+    // Ephemeral accounts are freed, and the active chain's account state is
+    // re-materialized after touching other chains (appchain + restore).
+    expect(cartridgeAccountNew).toHaveBeenCalledTimes(2);
+    expect(cartridgeAccountNew.mock.calls[1][1]).toBe(
+      "https://active.example/rpc",
+    );
+    expect(free).toHaveBeenCalled();
+  });
+
+  it("collects per-chain failures without aborting the loop", async () => {
+    const activeCreateSession = vi.fn().mockResolvedValue({});
+    const ephemeralCreateSession = vi
+      .fn()
+      .mockRejectedValue(new Error("user cancelled"));
+    mockEphemeralAccount(ephemeralCreateSession);
+    const { controller } = buildController({
+      createSession: activeCreateSession,
+    });
+
+    const results = await controller.createMultichainSession(
+      "app",
+      BigInt(2_000),
+      [
+        { chainId: SEPOLIA, rpcUrl: "https://sepolia.example/rpc", policies },
+        { chainId: APPCHAIN, rpcUrl: "https://appchain.example/rpc", policies },
+      ],
+    );
+
+    expect(results).toHaveLength(2);
+    expect(results[0].error).toBeUndefined();
+    expect(results[1].chainId).toBe(APPCHAIN);
+    expect(results[1].error?.message).toBe("user cancelled");
+  });
+
+  it("reports signing progress per chain", async () => {
+    const progress: Array<[string, number, number]> = [];
+    mockEphemeralAccount(vi.fn().mockResolvedValue({}));
+    const { controller } = buildController();
+
+    await controller.createMultichainSession(
+      "app",
+      BigInt(2_000),
+      [
+        { chainId: SEPOLIA, rpcUrl: "https://sepolia.example/rpc", policies },
+        { chainId: APPCHAIN, rpcUrl: "https://appchain.example/rpc", policies },
+      ],
+      (chainId, index, total) => progress.push([chainId, index, total]),
+    );
+
+    expect(progress).toEqual([
+      [SEPOLIA, 0, 2],
+      [APPCHAIN, 1, 2],
+    ]);
+  });
+
+  it("does not touch ephemeral accounts for a single active-chain entry", async () => {
+    const { controller, createSession } = buildController();
+
+    const results = await controller.createMultichainSession(
+      "app",
+      BigInt(2_000),
+      [{ chainId: SEPOLIA, rpcUrl: "https://sepolia.example/rpc", policies }],
+    );
+
+    expect(createSession).toHaveBeenCalledTimes(1);
+    expect(cartridgeAccountNew).not.toHaveBeenCalled();
+    expect(results[0].error).toBeUndefined();
+  });
+});
+
+describe("Controller.registerSessionOnChains", () => {
+  beforeEach(() => {
+    cartridgeAccountNew.mockReset();
+  });
+
+  it("registers on every chain and treats already-registered as success", async () => {
+    const registerSession = vi
+      .fn()
+      .mockResolvedValueOnce({ transaction_hash: "0xtx1" })
+      .mockRejectedValueOnce({ code: 132, message: "already registered" });
+    mockEphemeralAccount(vi.fn(), registerSession);
+    const { controller } = buildController();
+
+    const results = await controller.registerSessionOnChains(
+      "app",
+      BigInt(2_000),
+      [
+        { chainId: APPCHAIN, rpcUrl: "https://appchain.example/rpc", policies },
+        { chainId: "0x777", rpcUrl: "https://other.example/rpc", policies },
+      ],
+      "0xpubkey",
+    );
+
+    expect(results).toHaveLength(2);
+    expect(results[0].transactionHash).toBe("0xtx1");
+    expect(results[0].error).toBeUndefined();
+    expect(results[1].error).toBeUndefined();
+  });
+
+  it("collects registration failures per chain", async () => {
+    const registerSession = vi
+      .fn()
+      .mockRejectedValue(new Error("insufficient funds"));
+    mockEphemeralAccount(vi.fn(), registerSession);
+    const { controller } = buildController();
+
+    const results = await controller.registerSessionOnChains(
+      "app",
+      BigInt(2_000),
+      [{ chainId: APPCHAIN, rpcUrl: "https://appchain.example/rpc", policies }],
+      "0xpubkey",
+    );
+
+    expect(results[0].error?.message).toBe("insufficient funds");
+  });
+});

--- a/packages/keychain/src/utils/controller.ts
+++ b/packages/keychain/src/utils/controller.ts
@@ -15,6 +15,7 @@ import {
   CartridgeAccount,
   CartridgeAccountMeta,
   ControllerFactory,
+  ErrorCode,
   ImportedControllerMetadata,
   ImportedSessionMetadata,
   JsAddSignerInput,
@@ -42,6 +43,24 @@ export interface ImportedControllerState {
   controller: ImportedControllerMetadata;
   session?: ImportedSessionMetadata;
 }
+
+export type MultichainSessionInput = {
+  chainId: string;
+  rpcUrl: string;
+  policies: ParsedSessionPolicies;
+};
+
+export type MultichainSessionResult = {
+  chainId: string;
+  session?: AuthorizedSession;
+  error?: Error;
+};
+
+export type MultichainRegisterResult = {
+  chainId: string;
+  transactionHash?: string;
+  error?: Error;
+};
 
 export default class Controller {
   private cartridge: CartridgeAccount;
@@ -142,6 +161,178 @@ export default class Controller {
       toWasmPolicies(policies),
       expiresAt,
     );
+  }
+
+  /**
+   * Creates one session per chain within a single approval flow.
+   *
+   * The session hash is chain-bound (its SNIP-12 domain embeds the chain id),
+   * so each chain requires its own owner signature — sequential by design
+   * since WebAuthn owners get one prompt per signature. Sessions are created
+   * on ephemeral per-chain accounts sharing this controller's identity (the
+   * same pattern as `switchChain`); the WASM persists each one under
+   * chain-scoped storage keys, so a later chain switch finds its session
+   * without re-approval.
+   *
+   * A failed chain does not abort the loop: already-created sessions stay
+   * valid and the caller can retry the remaining chains.
+   */
+  async createMultichainSession(
+    appId: string,
+    expiresAt: bigint,
+    chainSessions: MultichainSessionInput[],
+    onProgress?: (chainId: string, index: number, total: number) => void,
+  ): Promise<MultichainSessionResult[]> {
+    if (!this.cartridge) {
+      throw new Error("Account not found");
+    }
+
+    // Active chain first so the primary session lands even if the user
+    // cancels a later signature.
+    const activeChainId = BigInt(this.chainId());
+    const ordered = [...chainSessions].sort((a, b) => {
+      const aActive = BigInt(a.chainId) === activeChainId ? 0 : 1;
+      const bActive = BigInt(b.chainId) === activeChainId ? 0 : 1;
+      return aActive - bActive;
+    });
+
+    const results: MultichainSessionResult[] = [];
+    let usedEphemeralAccount = false;
+
+    for (const [index, chain] of ordered.entries()) {
+      const isActiveChain = BigInt(chain.chainId) === activeChainId;
+      onProgress?.(chain.chainId, index, ordered.length);
+      try {
+        if (isActiveChain) {
+          const session = await this.createSession(
+            appId,
+            expiresAt,
+            chain.policies,
+          );
+          results.push({ chainId: chain.chainId, session });
+        } else {
+          usedEphemeralAccount = true;
+          const session = await this.withEphemeralAccount(
+            chain.rpcUrl,
+            (account) =>
+              account.createSession(
+                appId,
+                toWasmPolicies(chain.policies),
+                expiresAt,
+              ),
+          );
+          results.push({ chainId: chain.chainId, session });
+        }
+      } catch (e) {
+        results.push({
+          chainId: chain.chainId,
+          error: e instanceof Error ? e : new Error(String(e)),
+        });
+      }
+    }
+
+    // Constructing a per-chain account may repoint the WASM's persisted
+    // "active" selector at the last chain touched, which would resurrect the
+    // controller on the wrong chain after a reload. Re-materialize the active
+    // chain's account to leave storage pointing where it started.
+    if (usedEphemeralAccount) {
+      try {
+        await this.withEphemeralAccount(this.rpcUrl(), async () => {});
+      } catch (e) {
+        console.error("Failed to restore active chain account state:", e);
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * Registers a session on-chain (`register_session`) on each given chain,
+   * sequentially, via ephemeral per-chain accounts. Used by the standalone
+   * `/session` flow where the dapp supplies the session public key; the
+   * active chain is expected to be registered through the regular execution
+   * flow and NOT included here.
+   *
+   * An already-registered session on a chain counts as success, which makes
+   * retries idempotent.
+   */
+  async registerSessionOnChains(
+    appId: string,
+    expiresAt: bigint,
+    chains: MultichainSessionInput[],
+    publicKey: string,
+    onProgress?: (chainId: string, index: number, total: number) => void,
+  ): Promise<MultichainRegisterResult[]> {
+    if (!this.cartridge) {
+      throw new Error("Account not found");
+    }
+
+    const results: MultichainRegisterResult[] = [];
+
+    for (const [index, chain] of chains.entries()) {
+      onProgress?.(chain.chainId, index, chains.length);
+      try {
+        const { transaction_hash } = await this.withEphemeralAccount(
+          chain.rpcUrl,
+          (account) =>
+            account.registerSession(
+              appId,
+              toWasmPolicies(chain.policies),
+              expiresAt,
+              publicKey,
+              undefined,
+            ),
+        );
+        results.push({
+          chainId: chain.chainId,
+          transactionHash: transaction_hash,
+        });
+      } catch (e) {
+        if (
+          (e as { code?: number })?.code === ErrorCode.SessionAlreadyRegistered
+        ) {
+          results.push({ chainId: chain.chainId });
+          continue;
+        }
+        results.push({
+          chainId: chain.chainId,
+          error: e instanceof Error ? e : new Error(String(e)),
+        });
+      }
+    }
+
+    if (chains.length > 0) {
+      try {
+        await this.withEphemeralAccount(this.rpcUrl(), async () => {});
+      } catch (e) {
+        console.error("Failed to restore active chain account state:", e);
+      }
+    }
+
+    return results;
+  }
+
+  // Builds a short-lived WASM account for another chain sharing this
+  // controller's identity (same owner/classHash/address), runs `fn`, and
+  // frees the WASM handles.
+  private async withEphemeralAccount<T>(
+    rpcUrl: string,
+    fn: (account: CartridgeAccount) => Promise<T>,
+  ): Promise<T> {
+    const accountWithMeta = await CartridgeAccount.new(
+      this.classHash(),
+      rpcUrl,
+      this.address(),
+      this.username(),
+      this.owner(),
+      import.meta.env.VITE_CARTRIDGE_API_URL,
+    );
+    const account = accountWithMeta.intoAccount();
+    try {
+      return await fn(account);
+    } finally {
+      account.free();
+    }
   }
 
   async skipSession(appId: string, policies: ParsedSessionPolicies) {


### PR DESCRIPTION
## Summary

Adds an explicit **`multichainSessions: ChainId[]`** opt-in to `ControllerOptions`: a single session approval flow creates one chain-bound session per opted-in chain, so multichain games (settlement chain + appchain, e.g. glitch-bomb) no longer force the user through two full approval flows.

The session hash's SNIP-12 domain embeds the chain id and the contract recomputes it from its own execution context, so one signature can never cover two chains — the flow therefore signs sequentially per chain (silent for embedded/social signers, back-to-back prompts for passkey owners) with no Cairo/DB/authorization-format change.

## Changes

- **SDK** (`packages/controller`): `multichainSessions` option + fail-fast validation (every chain must be configured, `policies`/`preset` required); chains resolved to `{chainId, rpcUrl}` and forwarded via a `session_chains` iframe URL param; `getPresetSessionPoliciesForChains` helper.
- **Keychain policy resolution**: `resolveChainPolicies` resolves one policy set per chain from the preset (or replicates manual policies), with an **explicit error** when the preset lacks a requested chain — never a silent fallback (security contract of the opt-in).
- **Keychain creation**: `Controller.createMultichainSession` loops sequentially — active chain first, then ephemeral per-chain WASM accounts (same pattern as `switchChain`) — restoring the active storage selector afterwards and collecting per-chain failures.
- **Approval UI**: one screen grouped by chain, signing progress (`Signing 1/2 — Sepolia`), and a "retry remaining chains" state that only re-signs missing chains. Auto-created verified sessions and `updateSession` get the same treatment.
- **Native flow**: `SessionProvider` gains a `chains` option, `switchStarknetChain` is implemented (registered sessions are chain-agnostic — validated on-chain), and the `/session` route registers `register_session` on every chain idempotently (`SessionAlreadyRegistered` counts as success).

## Behavior without the option

Strictly unchanged — locked in by the existing suites (646 keychain vitest + 68 SDK jest, all green) plus 24 new tests (per-chain resolution, missing-chain error, loop ordering/partial failure/progress, option validation, URL params) and 2 new Storybook stories.

## Known v1 limitations

- WebAuthn popup flow (Safari / Windows Chrome) degrades to the active chain only (the export blob carries a single session) — logged with a console warning.
- Spending-limit step and per-policy editing are disabled in multichain mode; "Skip" applies to the active chain only.
- Passkey owners see N consecutive prompts; a true single-signature design (merkle root over chain-bound session hashes) was specced and deliberately deferred — it requires a contract class change.

## Companion PR

- `cartridge-gg/internal`: `subscribeCreateSession` resolver fix (`.Only()` → ordered `.First()`) so a shared session key across N chains doesn't break the native flow's subscription.

## Manual verification (pending)

`examples/next` with sepolia + a Slot katana: connect → one approval screen → execute on both chains without new prompts → `switchStarknetChain` without re-approval. Requires a passkey environment; not runnable in CI (e2e disabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
