### PR TITLE
fix: keep SMS-only signup label generic

### DIFF
--- a/packages/keychain/src/components/connect/buttons/auth-button.tsx
+++ b/packages/keychain/src/components/connect/buttons/auth-button.tsx
@@ -116,6 +116,12 @@ export const AuthButton = forwardRef<HTMLButtonElement, AuthButtonProps>(
 
     const { isLoading, disabled, ...restProps } = props;
 
+    const isSmsOnlySignup =
+      !!username &&
+      !validation.exists &&
+      signupOptions?.length === 1 &&
+      signupOptions[0] === "sms";
+
     const option = useMemo(() => {
       // Login flow: use existing signers (only when account exists)
       if (
@@ -167,9 +173,12 @@ export const AuthButton = forwardRef<HTMLButtonElement, AuthButtonProps>(
       if (isLoading || waitingForConfirmation) {
         return <Spinner size="sm" />;
       }
+      if (isSmsOnlySignup) {
+        return null;
+      }
       const IconComponent = option?.Icon;
       return IconComponent ? <IconComponent size="sm" /> : null;
-    }, [isLoading, waitingForConfirmation, option]);
+    }, [isLoading, waitingForConfirmation, isSmsOnlySignup, option]);
 
     // Check if login has single signer (or all same auth type)
     const isSingleSignerLogin = useMemo(() => {
@@ -228,7 +237,7 @@ export const AuthButton = forwardRef<HTMLButtonElement, AuthButtonProps>(
 
       // Single signer signup/initial: show branded text immediately
       if (signupOptions?.length === 1 && option?.label) {
-        if (!isLogin && signupOptions[0] === "sms") {
+        if (isSmsOnlySignup) {
           return "sign up";
         }
         return isLogin
@@ -245,6 +254,7 @@ export const AuthButton = forwardRef<HTMLButtonElement, AuthButtonProps>(
       username,
       signupOptions,
       isSingleSignerLogin,
+      isSmsOnlySignup,
       usesWebauthnPopup,
     ]);
 

--- a/packages/keychain/src/components/connect/buttons/auth-button.tsx
+++ b/packages/keychain/src/components/connect/buttons/auth-button.tsx
@@ -228,6 +228,9 @@ export const AuthButton = forwardRef<HTMLButtonElement, AuthButtonProps>(
 
       // Single signer signup/initial: show branded text immediately
       if (signupOptions?.length === 1 && option?.label) {
+        if (!isLogin && signupOptions[0] === "sms") {
+          return "sign up";
+        }
         return isLogin
           ? `log in with ${option.label}`
           : `sign up with ${option.label}`;

--- a/packages/keychain/src/components/connect/create/CreateController.test.tsx
+++ b/packages/keychain/src/components/connect/create/CreateController.test.tsx
@@ -189,6 +189,48 @@ describe("CreateController", () => {
     });
   });
 
+  it("opens SMS signup directly when SMS is the only auth option", async () => {
+    const handleSubmit = vi.fn().mockResolvedValue(undefined);
+    const setAuthenticationStep = vi.fn();
+    mockUseCreateController.mockReturnValue({
+      isLoading: false,
+      error: undefined,
+      setError: vi.fn(),
+      handleSubmit,
+      authenticationStep: AuthenticationStep.FillForm,
+      setAuthenticationStep,
+      waitingForConfirmation: false,
+      changeWallet: false,
+      setChangeWallet: vi.fn(),
+      signupOptions: ["sms"],
+      authMethod: undefined,
+      setAuthMethod: vi.fn(),
+      shouldAutoCreateSession: true,
+      hasPolicies: true,
+    });
+
+    renderComponent();
+    const input = screen.getByPlaceholderText("Username");
+    fireEvent.change(input, { target: { value: "newuser" } });
+    fireEvent.blur(input);
+
+    const submitButton = screen.getByTestId("submit-button");
+    await waitFor(() => expect(submitButton).not.toBeDisabled());
+    expect(submitButton).toHaveTextContent("sign up");
+    expect(submitButton).not.toHaveTextContent("sign up with SMS");
+    fireEvent.submit(submitButton.closest("form")!);
+
+    await waitFor(() => {
+      expect(setAuthenticationStep).toHaveBeenCalledWith(
+        AuthenticationStep.SmsForm,
+      );
+    });
+    expect(handleSubmit).not.toHaveBeenCalled();
+    expect(setAuthenticationStep).not.toHaveBeenCalledWith(
+      AuthenticationStep.ChooseMethod,
+    );
+  });
+
   it("shows loading state during submission", async () => {
     mockUseCreateController.mockReturnValue({
       isLoading: true,

--- a/packages/keychain/src/components/connect/create/CreateController.test.tsx
+++ b/packages/keychain/src/components/connect/create/CreateController.test.tsx
@@ -218,6 +218,7 @@ describe("CreateController", () => {
     await waitFor(() => expect(submitButton).not.toBeDisabled());
     expect(submitButton).toHaveTextContent("sign up");
     expect(submitButton).not.toHaveTextContent("sign up with SMS");
+    expect(submitButton.querySelector("svg")).not.toBeInTheDocument();
     fireEvent.submit(submitButton.closest("form")!);
 
     await waitFor(() => {


### PR DESCRIPTION
SMS-only account creation now uses a fully generic primary button: plain "sign up" text with no SMS icon, while continuing directly into phone verification.
Existing SMS login copy and icon, plus other single-method branded signup buttons, remain unchanged.
Added regression coverage for the SMS-only presentation and direct signup route.
Validated with repository-wide lint, tests, and builds plus focused follow-up checks.