### PR TITLE
feat: add default credit card starterpack payments

### DIFF
--- a/examples/next/src/components/providers/StarknetProvider.tsx
+++ b/examples/next/src/components/providers/StarknetProvider.tsx
@@ -306,6 +306,9 @@ export const controllerConnector = new ControllerConnector({
   url: getKeychainUrl(),
   signupOptions,
   defaultPaymentMethod: "credit-card",
+  // Exercise the card UI before the production Coinflow integration is active.
+  // Sandbox payments intentionally do not grant spendable credits.
+  coinflowSandbox: true,
   // By default, preset policies take precedence over manually provided policies
   // Set shouldOverridePresetPolicies to true if you want your policies to override preset
   shouldOverridePresetPolicies: overridePolicies,

--- a/examples/next/src/components/providers/StarknetProvider.tsx
+++ b/examples/next/src/components/providers/StarknetProvider.tsx
@@ -305,6 +305,7 @@ export const controllerConnector = new ControllerConnector({
   defaultChainId, // if not mainnet, only the original signer will be shown
   url: getKeychainUrl(),
   signupOptions,
+  defaultPaymentMethod: "credit-card",
   // By default, preset policies take precedence over manually provided policies
   // Set shouldOverridePresetPolicies to true if you want your policies to override preset
   shouldOverridePresetPolicies: overridePolicies,

--- a/packages/controller/src/__tests__/keychainCompatibility.test.ts
+++ b/packages/controller/src/__tests__/keychainCompatibility.test.ts
@@ -87,6 +87,22 @@ describe("hosted keychain compatibility contract", () => {
     expect(mockIFrameOptions.url.searchParams.has("torii")).toBe(false);
   });
 
+  it("sends the configured default payment method additively", () => {
+    createKeychain({ defaultPaymentMethod: "credit-card" });
+
+    expect(
+      mockIFrameOptions.url.searchParams.get("default_payment_method"),
+    ).toBe("credit-card");
+  });
+
+  it("omits the default payment method when it is not configured", () => {
+    createKeychain();
+
+    expect(
+      mockIFrameOptions.url.searchParams.has("default_payment_method"),
+    ).toBe(false);
+  });
+
   it.each(["0.13.12", "0.13.13", "0.14.0-alpha.1"])(
     "keeps the same hosted bridge surface for Controller %s",
     (version) => {

--- a/packages/controller/src/__tests__/keychainCompatibility.test.ts
+++ b/packages/controller/src/__tests__/keychainCompatibility.test.ts
@@ -103,6 +103,22 @@ describe("hosted keychain compatibility contract", () => {
     ).toBe(false);
   });
 
+  it("sends the configured Coinflow sandbox mode additively", () => {
+    createKeychain({ coinflowSandbox: true });
+
+    expect(mockIFrameOptions.url.searchParams.get("coinflow_sandbox")).toBe(
+      "true",
+    );
+  });
+
+  it("omits Coinflow sandbox mode when it is not configured", () => {
+    createKeychain();
+
+    expect(mockIFrameOptions.url.searchParams.has("coinflow_sandbox")).toBe(
+      false,
+    );
+  });
+
   it.each(["0.13.12", "0.13.13", "0.14.0-alpha.1"])(
     "keeps the same hosted bridge surface for Controller %s",
     (version) => {

--- a/packages/controller/src/iframe/keychain.ts
+++ b/packages/controller/src/iframe/keychain.ts
@@ -44,6 +44,7 @@ export class KeychainIFrame extends IFrame<Keychain> {
     propagateSessionErrors,
     errorDisplayMode,
     defaultPaymentMethod,
+    coinflowSandbox,
     webauthnPopup,
     userChains,
     ...iframeOptions
@@ -62,6 +63,10 @@ export class KeychainIFrame extends IFrame<Keychain> {
 
     if (defaultPaymentMethod) {
       _url.searchParams.set("default_payment_method", defaultPaymentMethod);
+    }
+
+    if (coinflowSandbox !== undefined) {
+      _url.searchParams.set("coinflow_sandbox", String(coinflowSandbox));
     }
 
     if (version) {

--- a/packages/controller/src/iframe/keychain.ts
+++ b/packages/controller/src/iframe/keychain.ts
@@ -43,6 +43,7 @@ export class KeychainIFrame extends IFrame<Keychain> {
     encryptedBlob,
     propagateSessionErrors,
     errorDisplayMode,
+    defaultPaymentMethod,
     webauthnPopup,
     userChains,
     ...iframeOptions
@@ -57,6 +58,10 @@ export class KeychainIFrame extends IFrame<Keychain> {
 
     if (errorDisplayMode) {
       _url.searchParams.set("error_display_mode", errorDisplayMode);
+    }
+
+    if (defaultPaymentMethod) {
+      _url.searchParams.set("default_payment_method", defaultPaymentMethod);
     }
 
     if (version) {

--- a/packages/controller/src/types.ts
+++ b/packages/controller/src/types.ts
@@ -300,6 +300,8 @@ export type KeychainOptions = IFrameOptions & {
   signupOptions?: AuthOptions;
   /** Preferred fallback when no explicit choice or funded Controller token is available. */
   defaultPaymentMethod?: DefaultPaymentMethod;
+  /** Use Coinflow's sandbox checkout, including on mainnet. Sandbox payments do not grant spendable credits. */
+  coinflowSandbox?: boolean;
   /** When true, manually provided policies will override preset policies. Default is false. */
   shouldOverridePresetPolicies?: boolean;
   /** The project name of Slot instance. */

--- a/packages/controller/src/types.ts
+++ b/packages/controller/src/types.ts
@@ -280,6 +280,8 @@ export type ProviderOptions = {
   chains?: Chain[];
 };
 
+export type DefaultPaymentMethod = "credit-card";
+
 export type KeychainOptions = IFrameOptions & {
   policies?: SessionPolicies;
   /** The URL of keychain */
@@ -296,6 +298,8 @@ export type KeychainOptions = IFrameOptions & {
   feeSource?: FeeSource;
   /** Signup options (the order of the options is reflected in the UI. It's recommended to group socials and wallets together ) */
   signupOptions?: AuthOptions;
+  /** Preferred fallback when no explicit choice or funded Controller token is available. */
+  defaultPaymentMethod?: DefaultPaymentMethod;
   /** When true, manually provided policies will override preset policies. Default is false. */
   shouldOverridePresetPolicies?: boolean;
   /** The project name of Slot instance. */

--- a/packages/keychain/src/components/credits/AmountSelectionDrawer.tsx
+++ b/packages/keychain/src/components/credits/AmountSelectionDrawer.tsx
@@ -15,7 +15,6 @@ interface AmountSelectionDrawerProps {
   maxAmount?: number;
   isLoading?: boolean;
   onContinue: (amount: number) => void;
-  initialAmount?: number;
 }
 
 export function AmountSelectionDrawer({
@@ -25,9 +24,8 @@ export function AmountSelectionDrawer({
   maxAmount,
   isLoading,
   onContinue,
-  initialAmount,
 }: AmountSelectionDrawerProps) {
-  const [amount, setAmount] = useState(initialAmount ?? 0);
+  const [amount, setAmount] = useState(0);
   return (
     <Drawer isOpen={isOpen} onClose={onClose} className="gap-4">
       <DrawerContent title="Deposit USD" icon={<DepositIcon variant="solid" />}>
@@ -36,7 +34,6 @@ export function AmountSelectionDrawer({
           enableCustom={true}
           minAmount={minAmount}
           maxAmount={maxAmount}
-          initialAmount={initialAmount}
           onChange={setAmount}
         />
 

--- a/packages/keychain/src/components/credits/AmountSelectionDrawer.tsx
+++ b/packages/keychain/src/components/credits/AmountSelectionDrawer.tsx
@@ -15,6 +15,7 @@ interface AmountSelectionDrawerProps {
   maxAmount?: number;
   isLoading?: boolean;
   onContinue: (amount: number) => void;
+  initialAmount?: number;
 }
 
 export function AmountSelectionDrawer({
@@ -24,8 +25,9 @@ export function AmountSelectionDrawer({
   maxAmount,
   isLoading,
   onContinue,
+  initialAmount,
 }: AmountSelectionDrawerProps) {
-  const [amount, setAmount] = useState(0);
+  const [amount, setAmount] = useState(initialAmount ?? 0);
   return (
     <Drawer isOpen={isOpen} onClose={onClose} className="gap-4">
       <DrawerContent title="Deposit USD" icon={<DepositIcon variant="solid" />}>
@@ -34,6 +36,7 @@ export function AmountSelectionDrawer({
           enableCustom={true}
           minAmount={minAmount}
           maxAmount={maxAmount}
+          initialAmount={initialAmount}
           onChange={setAmount}
         />
 

--- a/packages/keychain/src/components/credits/AmountSelectionDrawer.tsx
+++ b/packages/keychain/src/components/credits/AmountSelectionDrawer.tsx
@@ -1,10 +1,5 @@
 import { useState } from "react";
-import {
-  Drawer,
-  DrawerContent,
-  DepositIcon,
-  Button,
-} from "@cartridge/controller-ui";
+import { Drawer, DrawerContent, Button } from "@cartridge/controller-ui";
 import { CREDITS_DESCRIPTION } from "@/components/inventory/token";
 import { AmountSelection } from "@/components/funding/AmountSelection";
 
@@ -28,7 +23,7 @@ export function AmountSelectionDrawer({
   const [amount, setAmount] = useState(0);
   return (
     <Drawer isOpen={isOpen} onClose={onClose} className="gap-4">
-      <DrawerContent title="Deposit USD" icon={<DepositIcon variant="solid" />}>
+      <DrawerContent title="Deposit USD">
         <AmountSelection
           lockSelection={isLoading}
           enableCustom={true}

--- a/packages/keychain/src/components/credits/Checkout.tsx
+++ b/packages/keychain/src/components/credits/Checkout.tsx
@@ -14,6 +14,7 @@ import { ControllerCheckout } from "@/components/purchase/checkout/controller";
 import { useCreditsContext } from "./provider";
 import { CoinflowCreditsCheckout } from "./CoinflowCreditsCheckout";
 import { CoinbaseCreditsCheckout } from "./CoinbaseCreditsCheckout";
+import { CoinflowSettlementPendingError } from "@/hooks/payments/coinflow";
 
 interface CheckoutProps {
   isOpen: boolean;
@@ -46,20 +47,28 @@ export function Checkout({
   onChangeAmount,
 }: CheckoutProps) {
   const { credits } = useTokens();
-  const { onDepositStarted, onDepositFinished, depositInProgress } =
-    useCreditsContext();
+  const {
+    onDepositStarted,
+    onDepositFinished,
+    depositInProgress,
+    depositRequest,
+  } = useCreditsContext();
 
   // Controller rail: execute() resolves only after the backend confirms the
   // deposit and grants the credits, so completing is immediately final.
   const onComplete = useCallback(async () => {
     await credits.refetch?.();
-    await onDepositFinished();
+    if (depositRequest?.attemptId) {
+      await onDepositFinished(depositRequest.attemptId);
+    }
     onClose();
-  }, [credits, onDepositFinished, onClose]);
+  }, [credits, onDepositFinished, onClose, depositRequest]);
 
   // Fiat rails re-render their completion trigger (e.g. the Coinbase status
   // effect) until the status view replaces them — run the settlement once.
   const settlingRef = useRef(false);
+  const activeAttemptIdRef = useRef(depositRequest?.attemptId);
+  activeAttemptIdRef.current = depositRequest?.attemptId;
   useEffect(() => {
     if (!isOpen) settlingRef.current = false;
   }, [isOpen]);
@@ -68,15 +77,34 @@ export function Checkout({
     async (settle: () => Promise<void>) => {
       if (settlingRef.current || !paymentMethod) return;
       settlingRef.current = true;
-      onDepositStarted(paymentMethod, amount);
+      const attemptId = onDepositStarted(paymentMethod, amount);
       try {
-        await settle();
+        // A Coinflow polling window expiring is not a terminal payment failure.
+        // Resume polling while this remains the active deposit attempt.
+        while (true) {
+          try {
+            await settle();
+            break;
+          } catch (error) {
+            if (
+              error instanceof CoinflowSettlementPendingError &&
+              activeAttemptIdRef.current === attemptId
+            ) {
+              continue;
+            }
+            if (activeAttemptIdRef.current !== attemptId) return;
+            throw error;
+          }
+        }
         await credits.refetch?.();
-        await onDepositFinished();
+        await onDepositFinished(attemptId);
       } catch (e) {
         // Refetch regardless — on a poll timeout the credits may still land.
         await credits.refetch?.();
-        await onDepositFinished(e instanceof Error ? e.message : String(e));
+        await onDepositFinished(
+          attemptId,
+          e instanceof Error ? e.message : String(e),
+        );
       }
     },
     [paymentMethod, amount, onDepositStarted, onDepositFinished, credits],

--- a/packages/keychain/src/components/credits/Checkout.tsx
+++ b/packages/keychain/src/components/credits/Checkout.tsx
@@ -1,10 +1,5 @@
 import { useCallback, useEffect, useRef } from "react";
-import {
-  Button,
-  Drawer,
-  DrawerContent,
-  DepositIcon,
-} from "@cartridge/controller-ui";
+import { Button, Drawer, DrawerContent } from "@cartridge/controller-ui";
 import { useTokens } from "@/hooks/token";
 import { ConfirmingTransaction } from "@/components/purchase/pending/confirming-transaction";
 import { ErrorCard } from "@/components/purchase/checkout/onchain/error";
@@ -118,10 +113,7 @@ export function Checkout({
     const { status } = depositInProgress;
     return (
       <Drawer isOpen={isOpen} onClose={onClose} className="gap-4">
-        <DrawerContent
-          title="Deposit USD"
-          icon={<DepositIcon variant="solid" />}
-        >
+        <DrawerContent title="Deposit USD">
           <div className="flex flex-col gap-4">
             {status === "error" ? (
               <ErrorCard
@@ -187,7 +179,7 @@ export function Checkout({
   // Controller (USDC deposit) — review + deposit live in ControllerCheckout.
   return (
     <Drawer isOpen={isOpen} onClose={onClose} className="gap-4">
-      <DrawerContent title="Deposit USD" icon={<DepositIcon variant="solid" />}>
+      <DrawerContent title="Deposit USD">
         <ControllerRailProvider amount={amount} onComplete={onComplete}>
           <ControllerCheckout
             paymentMethod={paymentMethod}

--- a/packages/keychain/src/components/credits/CoinbaseCreditsCheckout.tsx
+++ b/packages/keychain/src/components/credits/CoinbaseCreditsCheckout.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Drawer, DrawerContent, DepositIcon } from "@cartridge/controller-ui";
+import { Drawer, DrawerContent } from "@cartridge/controller-ui";
 import { useConnection } from "@/hooks/connection";
 import {
   CoinbaseRailProvider,
@@ -211,10 +211,7 @@ export function CoinbaseCreditsCheckout({
           rather than aborting the whole deposit. */}
       {verifying ? null : phase === "review" ? (
         <Drawer isOpen={isOpen} onClose={onClose} className="gap-4">
-          <DrawerContent
-            title="Deposit USD"
-            icon={<DepositIcon variant="solid" />}
-          >
+          <DrawerContent title="Deposit USD">
             <CheckoutReviewContent
               paymentMethod={paymentMethod}
               amount={amount}

--- a/packages/keychain/src/components/credits/CoinflowCreditsCheckout.tsx
+++ b/packages/keychain/src/components/credits/CoinflowCreditsCheckout.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Drawer, DrawerContent, DepositIcon } from "@cartridge/controller-ui";
+import { Drawer, DrawerContent } from "@cartridge/controller-ui";
 import { usdToCredits, MIN_CREDITS_PURCHASE_USD } from "@/utils/credits";
 import { ErrorCard } from "@/components/purchase/checkout/onchain/error";
 import {
@@ -106,10 +106,7 @@ export function CoinflowCreditsCheckout({
           rather than aborting the whole deposit. */}
       {verifying ? null : phase === "review" ? (
         <Drawer isOpen={isOpen} onClose={onClose} className="gap-4">
-          <DrawerContent
-            title="Deposit USD"
-            icon={<DepositIcon variant="solid" />}
-          >
+          <DrawerContent title="Deposit USD">
             <CheckoutReviewContent
               paymentMethod={paymentMethod}
               amount={amount}

--- a/packages/keychain/src/components/credits/DepositCredits.tsx
+++ b/packages/keychain/src/components/credits/DepositCredits.tsx
@@ -7,6 +7,7 @@ import {
 import { AmountSelectionDrawer } from "./AmountSelectionDrawer";
 import { Checkout } from "./Checkout";
 import { useCreditsContext } from "./provider";
+import { useConnection } from "@/hooks/connection";
 import {
   MIN_CREDITS_PURCHASE_USD,
   MAX_CREDITS_PURCHASE_USD,
@@ -21,17 +22,29 @@ export function DepositCredits({ isOpen, onClose }: DepositCreditsProps) {
   const [paymentMethod, setPaymentMethod] =
     useState<PaymentMethodSelection | null>(null);
   const [amount, setAmount] = useState(0);
-  const { depositInProgress } = useCreditsContext();
+  const { depositInProgress, depositRequest } = useCreditsContext();
+  const { defaultPaymentMethod } = useConnection();
 
-  const { isUS } = useGeoLocation();
+  const { isUS, countryCodeLoaded } = useGeoLocation();
+  const configuredCard = defaultPaymentMethod === "credit-card";
 
   const isController = paymentMethod?.type == "controller";
 
   // initialize on open and close
   useEffect(() => {
-    setPaymentMethod(null);
-    setAmount(0);
-  }, [isOpen]);
+    if (!isOpen) {
+      setPaymentMethod(null);
+      setAmount(0);
+      return;
+    }
+    const preferred = depositRequest?.preferredMethod;
+    setPaymentMethod(
+      preferred?.type === "coinflow" && (!countryCodeLoaded || !isUS)
+        ? null
+        : (preferred ?? null),
+    );
+    setAmount(depositRequest?.defaultAmount ?? 0);
+  }, [isOpen, depositRequest, countryCodeLoaded, isUS]);
 
   const step = useMemo(() => {
     if (depositInProgress) return "checkout";
@@ -52,15 +65,20 @@ export function DepositCredits({ isOpen, onClose }: DepositCreditsProps) {
         setSelected={(selection: PaymentMethodSelection) => {
           setPaymentMethod(selection);
         }}
-        showFiatOptions={isUS && false} // disabled cards
+        showFiatOptions={isUS && configuredCard}
+        enableCoinflow={configuredCard}
         showController={true}
         showCrypto={false}
       />
 
       <AmountSelectionDrawer
         isOpen={isOpen && step == "amount"}
-        minAmount={isController ? 1 : MIN_CREDITS_PURCHASE_USD}
+        minAmount={
+          depositRequest?.minimumAmount ??
+          (isController ? 1 : MIN_CREDITS_PURCHASE_USD)
+        }
         maxAmount={MAX_CREDITS_PURCHASE_USD}
+        initialAmount={depositRequest?.defaultAmount}
         onClose={() => {
           if (step == "amount") {
             onClose();

--- a/packages/keychain/src/components/credits/DepositCredits.tsx
+++ b/packages/keychain/src/components/credits/DepositCredits.tsx
@@ -43,7 +43,7 @@ export function DepositCredits({ isOpen, onClose }: DepositCreditsProps) {
         ? null
         : (preferred ?? null),
     );
-    setAmount(depositRequest?.defaultAmount ?? 0);
+    setAmount(0);
   }, [isOpen, depositRequest, countryCodeLoaded, isUS]);
 
   const step = useMemo(() => {
@@ -78,7 +78,6 @@ export function DepositCredits({ isOpen, onClose }: DepositCreditsProps) {
           (isController ? 1 : MIN_CREDITS_PURCHASE_USD)
         }
         maxAmount={MAX_CREDITS_PURCHASE_USD}
-        initialAmount={depositRequest?.defaultAmount}
         onClose={() => {
           if (step == "amount") {
             onClose();

--- a/packages/keychain/src/components/credits/provider.test.tsx
+++ b/packages/keychain/src/components/credits/provider.test.tsx
@@ -1,0 +1,94 @@
+import { act, renderHook } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CreditsProvider, useCreditsContext } from "./provider";
+
+vi.mock("./DepositCredits", () => ({ DepositCredits: () => null }));
+
+describe("CreditsProvider", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <CreditsProvider>{children}</CreditsProvider>
+  );
+
+  it("consumes a deposit success callback exactly once", async () => {
+    const onSuccess = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useCreditsContext(), { wrapper });
+
+    act(() => {
+      result.current.initiateCreditsDeposit({
+        preferredMethod: { type: "coinflow" },
+        defaultAmount: 2,
+        minimumAmount: 2,
+        purchaseKey: "purchase-1",
+        onSuccess,
+      });
+      result.current.onDepositStarted({ type: "coinflow" }, 2);
+    });
+
+    await act(async () => {
+      const attemptId = result.current.depositRequest!.attemptId;
+      await result.current.onDepositFinished(attemptId);
+      await result.current.onDepositFinished(attemptId);
+    });
+
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(result.current.depositInProgress?.status).toBe("success");
+  });
+
+  it("surfaces an automatic purchase failure as a deposit error", async () => {
+    const { result } = renderHook(() => useCreditsContext(), { wrapper });
+
+    act(() => {
+      result.current.initiateCreditsDeposit({
+        onSuccess: async () => {
+          throw new Error("Credits did not settle");
+        },
+      });
+      result.current.onDepositStarted({ type: "coinflow" }, 2);
+    });
+
+    await act(async () => {
+      await result.current.onDepositFinished(
+        result.current.depositRequest!.attemptId,
+      );
+    });
+
+    expect(result.current.depositInProgress).toMatchObject({
+      status: "error",
+      error: "Credits did not settle",
+    });
+  });
+
+  it("does not let an older settlement consume a newer attempt", async () => {
+    const firstSuccess = vi.fn().mockResolvedValue(undefined);
+    const secondSuccess = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useCreditsContext(), { wrapper });
+
+    act(() => {
+      result.current.initiateCreditsDeposit({ onSuccess: firstSuccess });
+    });
+    const firstAttemptId = result.current.depositRequest!.attemptId;
+    const finishFirstAttempt = result.current.onDepositFinished;
+
+    act(() => {
+      result.current.initiateCreditsDeposit({ onSuccess: secondSuccess });
+    });
+    const secondAttemptId = result.current.depositRequest!.attemptId;
+
+    await act(async () => {
+      await finishFirstAttempt(firstAttemptId);
+    });
+    expect(firstSuccess).toHaveBeenCalledTimes(1);
+    expect(result.current.depositRequest).toMatchObject({
+      attemptId: secondAttemptId,
+      onSuccess: secondSuccess,
+    });
+
+    await act(async () => {
+      await result.current.onDepositFinished(secondAttemptId);
+    });
+    expect(secondSuccess).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/keychain/src/components/credits/provider.test.tsx
+++ b/packages/keychain/src/components/credits/provider.test.tsx
@@ -19,8 +19,7 @@ describe("CreditsProvider", () => {
     act(() => {
       result.current.initiateCreditsDeposit({
         preferredMethod: { type: "coinflow" },
-        defaultAmount: 2,
-        minimumAmount: 2,
+        minimumAmount: 5,
         purchaseKey: "purchase-1",
         onSuccess,
       });

--- a/packages/keychain/src/components/credits/provider.tsx
+++ b/packages/keychain/src/components/credits/provider.tsx
@@ -3,6 +3,7 @@ import {
   createContext,
   useCallback,
   useContext,
+  useRef,
   useState,
 } from "react";
 import { DepositCredits } from "./DepositCredits";
@@ -10,29 +11,44 @@ import { PaymentMethodSelection } from "../purchase/checkout/onchain/wallet-draw
 
 export type CreditDepositStatus = "processing" | "success" | "error" | "idle";
 
+export type CreditsDepositRequest = {
+  preferredMethod?: PaymentMethodSelection;
+  defaultAmount?: number;
+  minimumAmount?: number;
+  purchaseKey?: string;
+  onSuccess?: () => Promise<void>;
+};
+
+export type ActiveCreditsDepositRequest = CreditsDepositRequest & {
+  attemptId: string;
+};
+
 export type CreditsContextValue = {
-  initiateCreditsDeposit: (onSuccessCallback?: () => Promise<void>) => void;
+  initiateCreditsDeposit: (request?: CreditsDepositRequest) => void;
   onDepositStarted: (
     paymentMethod: PaymentMethodSelection,
     amount: number,
-  ) => void;
-  onDepositFinished: (error?: string) => Promise<void>;
+  ) => string;
+  onDepositFinished: (attemptId: string, error?: string) => Promise<void>;
   depositInProgress: null | {
     paymentMethod: PaymentMethodSelection;
     amount: number;
+    attemptId: string;
     status: CreditDepositStatus;
     /** Failure/timeout message when status is "error". */
     error?: string;
   };
+  depositRequest?: ActiveCreditsDepositRequest;
 };
 
 type DepositInProgress = CreditsContextValue["depositInProgress"];
 
 export const CreditsContext = createContext<CreditsContextValue>({
   initiateCreditsDeposit: () => {},
-  onDepositStarted: () => {},
+  onDepositStarted: () => "",
   onDepositFinished: async () => {},
   depositInProgress: null,
+  depositRequest: undefined,
 });
 
 export function CreditsProvider({ children }: PropsWithChildren) {
@@ -41,48 +57,77 @@ export function CreditsProvider({ children }: PropsWithChildren) {
   const [depositInProgress, setDepositInProgress] =
     useState<DepositInProgress | null>(null);
 
-  const [depositSuccessCallback, setDepositSuccessCallback] = useState<
-    (() => Promise<void>) | undefined
-  >(undefined);
+  const [depositRequest, setDepositRequest] =
+    useState<ActiveCreditsDepositRequest>();
+  const attemptCounterRef = useRef(0);
+  const consumedAttemptsRef = useRef(new Set<string>());
   const initiateCreditsDeposit = useCallback(
-    (onSuccessCallback?: () => Promise<void>) => {
-      setDepositSuccessCallback(() => onSuccessCallback);
+    (request?: CreditsDepositRequest) => {
+      attemptCounterRef.current += 1;
+      setDepositRequest({
+        ...request,
+        attemptId: `credits-deposit-${attemptCounterRef.current}`,
+      });
       setIsDepositOpen(true);
     },
     [],
   );
 
   const onDepositStarted = useCallback(
-    async (paymentMethod: PaymentMethodSelection, amount: number) => {
+    (paymentMethod: PaymentMethodSelection, amount: number) => {
+      const attemptId =
+        depositRequest?.attemptId ??
+        `credits-deposit-${attemptCounterRef.current}`;
       setDepositInProgress({
         paymentMethod,
         amount,
+        attemptId,
         status: "processing",
       });
+      return attemptId;
     },
-    [],
+    [depositRequest],
   );
 
   const onDepositFinished = useCallback(
-    async (error?: string) => {
+    async (attemptId: string, error?: string) => {
+      if (!attemptId || depositRequest?.attemptId !== attemptId) return;
+      let completionError = error;
+      if (!completionError && !consumedAttemptsRef.current.has(attemptId)) {
+        consumedAttemptsRef.current.add(attemptId);
+        const callback = depositRequest?.onSuccess;
+        // Consume before awaiting so duplicate settlement signals cannot debit
+        // the originating bundle twice.
+        setDepositRequest((current) =>
+          current?.attemptId === attemptId
+            ? { ...current, onSuccess: undefined }
+            : current,
+        );
+        try {
+          await callback?.();
+        } catch (callbackError) {
+          completionError =
+            callbackError instanceof Error
+              ? callbackError.message
+              : String(callbackError);
+        }
+      }
+
       setDepositInProgress((prev) => {
         // prev is null when the user closed the status view before settlement
         // finished — stay closed, but still run the success side effects.
-        if (!prev) return null;
+        if (!prev || prev.attemptId !== attemptId) return prev;
         return {
           ...prev,
-          status: error ? "error" : "success",
-          error,
+          status: completionError ? "error" : "success",
+          error: completionError,
         };
       });
-      if (!error) {
-        await depositSuccessCallback?.();
-      }
     },
-    [depositSuccessCallback, setDepositInProgress],
+    [depositRequest, setDepositInProgress],
   );
 
-  // Deliberately keep depositSuccessCallback across close: a fiat settlement
+  // Deliberately keep the deposit request across close: a fiat settlement
   // can outlive the drawer (the user may close while it's processing), and the
   // waiting flow (e.g. bundle purchase) still wants its balance refreshed when
   // the credits land. The callback is replaced on the next initiateCreditsDeposit.
@@ -98,6 +143,7 @@ export function CreditsProvider({ children }: PropsWithChildren) {
         onDepositStarted,
         onDepositFinished,
         depositInProgress,
+        depositRequest,
       }}
     >
       {children}

--- a/packages/keychain/src/components/credits/provider.tsx
+++ b/packages/keychain/src/components/credits/provider.tsx
@@ -13,7 +13,6 @@ export type CreditDepositStatus = "processing" | "success" | "error" | "idle";
 
 export type CreditsDepositRequest = {
   preferredMethod?: PaymentMethodSelection;
-  defaultAmount?: number;
   minimumAmount?: number;
   purchaseKey?: string;
   onSuccess?: () => Promise<void>;

--- a/packages/keychain/src/components/funding/AmountSelection.test.tsx
+++ b/packages/keychain/src/components/funding/AmountSelection.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AmountSelection } from "./AmountSelection";
+
+describe("AmountSelection", () => {
+  it("selects the smallest configured amount that covers the minimum", async () => {
+    const onChange = vi.fn();
+
+    render(<AmountSelection minAmount={15} onChange={onChange} />);
+
+    await waitFor(() => expect(onChange).toHaveBeenLastCalledWith(20));
+    expect(screen.getByRole("button", { name: "$10" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "$20" })).toBeEnabled();
+  });
+
+  it("uses the required custom amount when no configured amount is large enough", async () => {
+    const onChange = vi.fn();
+
+    render(<AmountSelection minAmount={70} onChange={onChange} />);
+
+    await waitFor(() => expect(onChange).toHaveBeenLastCalledWith(70));
+    expect(screen.getByRole("spinbutton")).toHaveValue(70);
+  });
+});

--- a/packages/keychain/src/components/funding/AmountSelection.tsx
+++ b/packages/keychain/src/components/funding/AmountSelection.tsx
@@ -14,6 +14,7 @@ type AmountSelectionProps = {
   minAmount?: number;
   maxAmount?: number;
   onChange: (creditAmount: number) => void;
+  initialAmount?: number;
 };
 
 export function AmountSelection({
@@ -23,13 +24,25 @@ export function AmountSelection({
   minAmount,
   maxAmount,
   onChange,
+  initialAmount,
 }: AmountSelectionProps) {
   const [selectedAmount, setSelectedAmount] = useState<number | undefined>(
-    creditAmounts[0],
+    initialAmount ?? creditAmounts[0],
   );
-  const [custom, setCustom] = useState<boolean>(false);
+  const [custom, setCustom] = useState<boolean>(
+    initialAmount !== undefined && !creditAmounts.includes(initialAmount),
+  );
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const initialAmountIsPreset =
+    initialAmount !== undefined && creditAmounts.includes(initialAmount);
+
+  useEffect(() => {
+    if (initialAmount === undefined) return;
+    setSelectedAmount(initialAmount);
+    setCustom(!initialAmountIsPreset);
+    setError(null);
+  }, [initialAmount, initialAmountIsPreset]);
 
   useEffect(() => {
     onChange(selectedAmount && !error ? selectedAmount : 0);
@@ -49,28 +62,31 @@ export function AmountSelection({
   return (
     <div className="flex flex-col gap-4">
       <div className="grid grid-cols-2 gap-3 text-sm">
-        {creditAmounts.map((value) => (
-          <Button
-            key={value}
-            variant="secondary"
-            className={cn(
-              "font-sans font-medium w-full tracking-normal",
-              value === selectedAmount && !custom
-                ? "bg-background-300 text-foreground-100 hover:bg-background-400 hover:text-foreground-100 "
-                : "bg-background-100 text-foreground-300 hover:bg-background-300 hover:text-foreground-100 ",
-            )}
-            disabled={lockSelection}
-            onClick={() => {
-              setCustom(false);
-              setSelectedAmount(value);
-              // Presets are always in range — drop any error left over from
-              // the custom input, or the sync effect keeps emitting 0.
-              setError(null);
-            }}
-          >
-            {`$${value}`}
-          </Button>
-        ))}
+        {creditAmounts.map((value) => {
+          const isOutOfRange =
+            (minAmount !== undefined && value < minAmount) ||
+            (maxAmount !== undefined && value > maxAmount);
+          return (
+            <Button
+              key={value}
+              variant="secondary"
+              className={cn(
+                "font-sans font-medium w-full tracking-normal",
+                value === selectedAmount && !custom
+                  ? "bg-background-300 text-foreground-100 hover:bg-background-400 hover:text-foreground-100 "
+                  : "bg-background-100 text-foreground-300 hover:bg-background-300 hover:text-foreground-100 ",
+              )}
+              disabled={lockSelection || isOutOfRange}
+              onClick={() => {
+                setCustom(false);
+                setSelectedAmount(value);
+                setError(null);
+              }}
+            >
+              {`$${value}`}
+            </Button>
+          );
+        })}
         {enableCustom && (
           <Button
             variant="secondary"
@@ -96,14 +112,13 @@ export function AmountSelection({
             ref={inputRef}
             className="pl-8 flex-1"
             type="number"
-            inputMode="numeric"
-            pattern="[0-9]*"
-            step="1"
+            inputMode="decimal"
+            step="0.01"
             value={selectedAmount ?? ""}
             disabled={lockSelection}
             onChange={(e) => {
               const clean = e.target.value.replace(/^0+/, "");
-              const amount = clean ? Number.parseInt(clean, 10) : undefined;
+              const amount = clean ? Number.parseFloat(clean) : undefined;
               setSelectedAmount(amount);
               const min = minAmount ?? DEFAULT_MIN_AMOUNT;
               const max = maxAmount ?? DEFAULT_MAX_AMOUNT;

--- a/packages/keychain/src/components/funding/AmountSelection.tsx
+++ b/packages/keychain/src/components/funding/AmountSelection.tsx
@@ -14,7 +14,6 @@ type AmountSelectionProps = {
   minAmount?: number;
   maxAmount?: number;
   onChange: (creditAmount: number) => void;
-  initialAmount?: number;
 };
 
 export function AmountSelection({
@@ -24,25 +23,32 @@ export function AmountSelection({
   minAmount,
   maxAmount,
   onChange,
-  initialAmount,
 }: AmountSelectionProps) {
+  const firstAvailablePreset = creditAmounts.find(
+    (value) =>
+      (minAmount === undefined || value >= minAmount) &&
+      (maxAmount === undefined || value <= maxAmount),
+  );
   const [selectedAmount, setSelectedAmount] = useState<number | undefined>(
-    initialAmount ?? creditAmounts[0],
+    firstAvailablePreset ?? minAmount ?? creditAmounts[0],
   );
   const [custom, setCustom] = useState<boolean>(
-    initialAmount !== undefined && !creditAmounts.includes(initialAmount),
+    firstAvailablePreset === undefined,
   );
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-  const initialAmountIsPreset =
-    initialAmount !== undefined && creditAmounts.includes(initialAmount);
 
   useEffect(() => {
-    if (initialAmount === undefined) return;
-    setSelectedAmount(initialAmount);
-    setCustom(!initialAmountIsPreset);
+    const selectionIsInRange =
+      selectedAmount !== undefined &&
+      (minAmount === undefined || selectedAmount >= minAmount) &&
+      (maxAmount === undefined || selectedAmount <= maxAmount);
+    if (selectionIsInRange) return;
+
+    setSelectedAmount(firstAvailablePreset ?? minAmount);
+    setCustom(firstAvailablePreset === undefined);
     setError(null);
-  }, [initialAmount, initialAmountIsPreset]);
+  }, [firstAvailablePreset, maxAmount, minAmount, selectedAmount]);
 
   useEffect(() => {
     onChange(selectedAmount && !error ? selectedAmount : 0);
@@ -112,13 +118,14 @@ export function AmountSelection({
             ref={inputRef}
             className="pl-8 flex-1"
             type="number"
-            inputMode="decimal"
-            step="0.01"
+            inputMode="numeric"
+            pattern="[0-9]*"
+            step="1"
             value={selectedAmount ?? ""}
             disabled={lockSelection}
             onChange={(e) => {
               const clean = e.target.value.replace(/^0+/, "");
-              const amount = clean ? Number.parseFloat(clean) : undefined;
+              const amount = clean ? Number.parseInt(clean, 10) : undefined;
               setSelectedAmount(amount);
               const min = minAmount ?? DEFAULT_MIN_AMOUNT;
               const max = maxAmount ?? DEFAULT_MAX_AMOUNT;

--- a/packages/keychain/src/components/provider/connection.tsx
+++ b/packages/keychain/src/components/provider/connection.tsx
@@ -28,6 +28,7 @@ export type ConnectionContextValue = {
   namespace: string | null;
   propagateError: boolean;
   defaultPaymentMethod?: DefaultPaymentMethod;
+  coinflowSandbox: boolean;
   webauthnPopup: {
     create: boolean;
     get: boolean;

--- a/packages/keychain/src/components/provider/connection.tsx
+++ b/packages/keychain/src/components/provider/connection.tsx
@@ -3,6 +3,7 @@ import { ParsedSessionPolicies } from "@/hooks/session";
 import Controller from "@/utils/controller";
 import {
   type Chain,
+  type DefaultPaymentMethod,
   ExternalWallet,
   ExternalWalletResponse,
   ExternalWalletType,
@@ -26,6 +27,7 @@ export type ConnectionContextValue = {
   toriiUrl: string | null;
   namespace: string | null;
   propagateError: boolean;
+  defaultPaymentMethod?: DefaultPaymentMethod;
   webauthnPopup: {
     create: boolean;
     get: boolean;

--- a/packages/keychain/src/components/purchase/checkout/coinflow/form.test.tsx
+++ b/packages/keychain/src/components/purchase/checkout/coinflow/form.test.tsx
@@ -1,0 +1,145 @@
+import type { InputHTMLAttributes } from "react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CoinflowForm, type CoinflowFormHandle } from "./form";
+
+const mocks = vi.hoisted(() => ({
+  cardCheckout: vi.fn(),
+  tokenize: vi.fn(),
+  identity: {
+    isIdentityVerified: true,
+    userData: { firstName: "Ada", lastName: "Lovelace" },
+  } as {
+    isIdentityVerified: boolean;
+    userData: { firstName?: string; lastName?: string };
+  },
+}));
+
+vi.mock("@coinflowlabs/react", async () => {
+  const React = await import("react");
+  return {
+    MerchantStyle: { Sharp: "sharp" },
+    CoinflowCardForm: React.forwardRef(
+      ({ onLoad }: { onLoad?: () => void }, ref) => {
+        React.useImperativeHandle(ref, () => ({
+          tokenize: mocks.tokenize,
+        }));
+        React.useEffect(() => onLoad?.(), [onLoad]);
+        return <div data-testid="coinflow-card-form" />;
+      },
+    ),
+  };
+});
+
+vi.mock("@cartridge/controller-ui", () => ({
+  Input: (props: InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+  Skeleton: () => <div data-testid="skeleton" />,
+}));
+
+vi.mock("@/components/identity/provider", () => ({
+  useIdentityContext: () => mocks.identity,
+}));
+
+vi.mock("@/components/purchase/checkout/rails", () => ({
+  useCoinflowRail: () => ({
+    intent: { id: "payment-1", merchantId: "merchant-1" },
+    env: "sandbox",
+    onComplete: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/connection", () => ({
+  useControllerTheme: () => undefined,
+}));
+
+vi.mock("@/utils/api", () => ({
+  useCoinflowCardCheckoutMutation: () => ({
+    mutateAsync: mocks.cardCheckout,
+  }),
+}));
+
+describe("CoinflowForm", () => {
+  beforeEach(() => {
+    mocks.cardCheckout.mockReset().mockResolvedValue({});
+    mocks.tokenize.mockReset().mockResolvedValue({
+      token: "card-token",
+      expMonth: 12,
+      expYear: 2030,
+    });
+    mocks.identity = {
+      isIdentityVerified: true,
+      userData: { firstName: "Ada", lastName: "Lovelace" },
+    };
+  });
+
+  it("prefills verified Prove names and exposes billing autofill fields", async () => {
+    render(<CoinflowForm />);
+
+    expect(await screen.findByPlaceholderText("First name")).toHaveValue("Ada");
+    expect(screen.getByPlaceholderText("Last name")).toHaveValue("Lovelace");
+    expect(screen.getByPlaceholderText("Address")).toHaveAttribute(
+      "autocomplete",
+      "billing address-line1",
+    );
+    expect(screen.getByPlaceholderText("City")).toHaveAttribute(
+      "autocomplete",
+      "billing address-level2",
+    );
+    expect(screen.getByPlaceholderText("State")).toHaveAttribute(
+      "autocomplete",
+      "billing address-level1",
+    );
+    expect(screen.getByPlaceholderText("Postal code")).toHaveAttribute(
+      "autocomplete",
+      "billing postal-code",
+    );
+    expect(screen.queryByPlaceholderText(/Country/)).not.toBeInTheDocument();
+  });
+
+  it("submits the fixed US country and preserves a user-edited name", async () => {
+    mocks.identity = { isIdentityVerified: false, userData: {} };
+    let handle: CoinflowFormHandle | undefined;
+    const { rerender } = render(
+      <CoinflowForm onStateChange={(next) => (handle = next)} />,
+    );
+
+    fireEvent.change(await screen.findByPlaceholderText("First name"), {
+      target: { value: "Grace" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Address"), {
+      target: { value: "123 Main St" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("City"), {
+      target: { value: "New York" },
+    });
+
+    mocks.identity = {
+      isIdentityVerified: true,
+      userData: { firstName: "Ada", lastName: "Lovelace" },
+    };
+    rerender(<CoinflowForm onStateChange={(next) => (handle = next)} />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("First name")).toHaveValue("Grace");
+      expect(screen.getByPlaceholderText("Last name")).toHaveValue("Lovelace");
+      expect(handle?.isFormValid).toBe(true);
+    });
+
+    await act(async () => handle?.submit());
+
+    expect(mocks.cardCheckout).toHaveBeenCalledWith({
+      input: expect.objectContaining({
+        firstName: "Grace",
+        lastName: "Lovelace",
+        country: "US",
+        city: "New York",
+      }),
+    });
+  });
+});

--- a/packages/keychain/src/components/purchase/checkout/coinflow/form.tsx
+++ b/packages/keychain/src/components/purchase/checkout/coinflow/form.tsx
@@ -9,8 +9,10 @@ import { useCoinflowRail } from "../rails";
 import { Input, Skeleton } from "@cartridge/controller-ui";
 import { useControllerTheme } from "@/hooks/connection";
 import { useCoinflowCardCheckoutMutation } from "@/utils/api";
+import { useIdentityContext } from "@/components/identity/provider";
 
 const COINFLOW_PRIMARY_FALLBACK = "#fbcb4a";
+const COINFLOW_COUNTRY = "US";
 
 // Match Coinflow's iframe to the keychain Input component so the card
 // fields read as a single form with the surrounding inputs. Pulled from
@@ -48,6 +50,7 @@ export function CoinflowForm({ onStateChange }: CoinflowFormProps) {
     env: coinflowEnv,
     onComplete,
   } = useCoinflowRail();
+  const { userData, isIdentityVerified } = useIdentityContext();
   const controllerTheme = useControllerTheme();
   const coinflowTheme = useMemo<MerchantTheme>(() => {
     const primary = controllerTheme?.colors?.primary;
@@ -59,9 +62,14 @@ export function CoinflowForm({ onStateChange }: CoinflowFormProps) {
   }, [controllerTheme]);
 
   const cardFormRef = useRef<CardFormRef>(null);
-  const [firstName, setFirstName] = useState("");
-  const [lastName, setLastName] = useState("");
-  const [country, setCountry] = useState("US");
+  const verifiedFirstName = isIdentityVerified
+    ? (userData.firstName?.trim() ?? "")
+    : "";
+  const verifiedLastName = isIdentityVerified
+    ? (userData.lastName?.trim() ?? "")
+    : "";
+  const [firstName, setFirstName] = useState(verifiedFirstName);
+  const [lastName, setLastName] = useState(verifiedLastName);
   const [zip, setZip] = useState("");
   const [address1, setAddress1] = useState("");
   const [city, setCity] = useState("");
@@ -71,6 +79,17 @@ export function CoinflowForm({ onStateChange }: CoinflowFormProps) {
   const [error, setError] = useState<Error | null>(null);
 
   const { mutateAsync: cardCheckout } = useCoinflowCardCheckoutMutation();
+
+  // Prove data can arrive after the payment form mounts. Fill blank fields
+  // once it is verified, but never overwrite a name the user already edited.
+  useEffect(() => {
+    if (verifiedFirstName) {
+      setFirstName((current) => current || verifiedFirstName);
+    }
+    if (verifiedLastName) {
+      setLastName((current) => current || verifiedLastName);
+    }
+  }, [verifiedFirstName, verifiedLastName]);
 
   const handleSubmit = useCallback(async () => {
     if (!coinflowIntent || !cardFormRef.current) return;
@@ -93,7 +112,7 @@ export function CoinflowForm({ onStateChange }: CoinflowFormProps) {
           expYear,
           firstName,
           lastName,
-          country,
+          country: COINFLOW_COUNTRY,
           zip,
           address1,
           city,
@@ -112,7 +131,6 @@ export function CoinflowForm({ onStateChange }: CoinflowFormProps) {
     cardCheckout,
     firstName,
     lastName,
-    country,
     zip,
     address1,
     city,
@@ -129,9 +147,8 @@ export function CoinflowForm({ onStateChange }: CoinflowFormProps) {
       !!lastName &&
       !!address1 &&
       !!city &&
-      !!country &&
       !isSubmitting,
-    [isFormReady, firstName, lastName, address1, city, country, isSubmitting],
+    [isFormReady, firstName, lastName, address1, city, isSubmitting],
   );
 
   useEffect(() => {
@@ -166,10 +183,7 @@ export function CoinflowForm({ onStateChange }: CoinflowFormProps) {
             <Skeleton className="h-10 flex-1 rounded" />
             <Skeleton className="h-10 flex-1 rounded" />
           </div>
-          <div className="flex gap-3">
-            <Skeleton className="h-10 flex-1 rounded" />
-            <Skeleton className="h-10 flex-1 rounded" />
-          </div>
+          <Skeleton className="h-10 w-full rounded" />
         </div>
       )}
 
@@ -183,11 +197,15 @@ export function CoinflowForm({ onStateChange }: CoinflowFormProps) {
           </label>
           <div className="flex gap-3">
             <Input
+              name="billing-first-name"
+              autoComplete="billing cc-given-name"
               placeholder="First name"
               value={firstName}
               onChange={(e) => setFirstName(e.target.value)}
             />
             <Input
+              name="billing-last-name"
+              autoComplete="billing cc-family-name"
               placeholder="Last name"
               value={lastName}
               onChange={(e) => setLastName(e.target.value)}
@@ -213,17 +231,23 @@ export function CoinflowForm({ onStateChange }: CoinflowFormProps) {
             Billing address
           </label>
           <Input
+            name="billing-address-line1"
+            autoComplete="billing address-line1"
             placeholder="Address"
             value={address1}
             onChange={(e) => setAddress1(e.target.value)}
           />
           <div className="flex gap-3">
             <Input
+              name="billing-city"
+              autoComplete="billing address-level2"
               placeholder="City"
               value={city}
               onChange={(e) => setCity(e.target.value)}
             />
             <Input
+              name="billing-state"
+              autoComplete="billing address-level1"
               placeholder="State"
               value={state}
               onChange={(e) => setState(e.target.value)}
@@ -231,26 +255,13 @@ export function CoinflowForm({ onStateChange }: CoinflowFormProps) {
           </div>
         </div>
 
-        <div className="flex flex-col gap-2">
-          <label className="text-xs text-foreground-300 font-medium">
-            Country or region
-          </label>
-          <div className="flex gap-3">
-            <Input
-              placeholder="Country (ISO 3166-1 alpha-2, e.g. US)"
-              value={country}
-              onChange={(e) =>
-                setCountry(e.target.value.toUpperCase().slice(0, 2))
-              }
-              maxLength={2}
-            />
-            <Input
-              placeholder="Postal code"
-              value={zip}
-              onChange={(e) => setZip(e.target.value)}
-            />
-          </div>
-        </div>
+        <Input
+          name="billing-postal-code"
+          autoComplete="billing postal-code"
+          placeholder="Postal code"
+          value={zip}
+          onChange={(e) => setZip(e.target.value)}
+        />
       </div>
     </>
   );

--- a/packages/keychain/src/components/purchase/checkout/onchain/index.tsx
+++ b/packages/keychain/src/components/purchase/checkout/onchain/index.tsx
@@ -428,6 +428,7 @@ export function OnchainCheckout() {
     !!creditsQuote &&
     !hasSufficientCredits &&
     !isCreditsQuoteLoading;
+  const showConfiguredCreditsTopup = configuredCard && showInsufficientCredits;
 
   const globalDisabled = useMemo(() => {
     if (isCreditsSelected) {
@@ -956,8 +957,16 @@ export function OnchainCheckout() {
                 {showInsufficientCredits && (
                   <ErrorCard
                     variant="warning"
-                    title="Insufficient Credits"
-                    message="You need more credits to complete this purchase."
+                    title={
+                      showConfiguredCreditsTopup
+                        ? "Insufficient Balance"
+                        : "Insufficient Credits"
+                    }
+                    message={
+                      showConfiguredCreditsTopup
+                        ? "You need to deposit funds to complete this purchase."
+                        : "You need more credits to complete this purchase."
+                    }
                   />
                 )}
 
@@ -977,11 +986,13 @@ export function OnchainCheckout() {
                   />
                 )}
 
-                <WalletSelector
-                  method={selectedMethod}
-                  bridgeFrom={bridgeFrom}
-                  onClick={handleWalletSelect}
-                />
+                {!showConfiguredCreditsTopup && (
+                  <WalletSelector
+                    method={selectedMethod}
+                    bridgeFrom={bridgeFrom}
+                    onClick={handleWalletSelect}
+                  />
+                )}
 
                 <OnchainCostBreakdown quote={quote} />
 

--- a/packages/keychain/src/components/purchase/checkout/onchain/index.tsx
+++ b/packages/keychain/src/components/purchase/checkout/onchain/index.tsx
@@ -644,7 +644,6 @@ export function OnchainCheckout() {
         preferredMethod: configuredCoinflowAvailable
           ? { type: "coinflow" }
           : undefined,
-        defaultAmount: topupAmount,
         minimumAmount: topupAmount,
         purchaseKey: originatingPurchaseKey,
         onSuccess: async () => {

--- a/packages/keychain/src/components/purchase/checkout/onchain/index.tsx
+++ b/packages/keychain/src/components/purchase/checkout/onchain/index.tsx
@@ -50,11 +50,24 @@ import { num } from "starknet";
 import { useIdentityContext } from "@/components/identity/provider";
 import { AgeGate } from "@/components/identity/AgeGate";
 import { useCreditsContext } from "@/components/credits/provider";
+import {
+  MAX_CREDITS_PURCHASE_USD,
+  MIN_CREDITS_PURCHASE_USD,
+} from "@/utils/credits";
+import {
+  clearPaymentPreference,
+  readPaymentPreference,
+  resolveInitialPaymentMethod,
+} from "@/utils/payment-preference";
+import {
+  CreditsBalancePendingError,
+  waitForCreditsBalance,
+} from "@/utils/credits-settlement";
 
 export function OnchainCheckout() {
   const advancedView = useAdvancedView();
   const { navigate } = useNavigation();
-  const { controller } = useConnection();
+  const { controller, origin, defaultPaymentMethod } = useConnection();
   const {
     isStarterpackLoading,
     starterpackDetails,
@@ -63,6 +76,9 @@ export function OnchainCheckout() {
     setDisplayError,
     socialClaimOptions,
     socialClaimConditions,
+    registryAddress,
+    bundleId,
+    starterpackId,
   } = useStarterpackContext();
   const {
     isFetchingConversion,
@@ -113,6 +129,9 @@ export function OnchainCheckout() {
     isCreditsLoading,
     onCreditsPurchase,
     refetchCreditsBalance,
+    creditsBalance,
+    isCreditsBalanceLoading,
+    creditsBalanceError,
   } = useCreditPurchaseContext();
   const { initiateCreditsDeposit } = useCreditsContext();
 
@@ -134,6 +153,7 @@ export function OnchainCheckout() {
     "coinflow" | "apple-pay" | null
   >(null);
   const { isUS, countryCodeLoaded } = useGeoLocation();
+  const configuredCard = defaultPaymentMethod === "credit-card";
 
   const handleIconTripleClick = useTripleClick({
     featureName: isUS ? "coinflow-support" : undefined,
@@ -258,7 +278,7 @@ export function OnchainCheckout() {
     quantity,
   });
 
-  const { isCheckingFallback } = useTokenFallback({
+  const { isCheckingFallback, status: tokenFundingStatus } = useTokenFallback({
     controller,
     starterpackDetails: starterpackDetails as
       | Parameters<typeof useTokenFallback>[0]["starterpackDetails"]
@@ -271,9 +291,134 @@ export function OnchainCheckout() {
     quantity,
     isCoinflowSelected,
     isApplePaySelected,
+    isCreditsSelected,
     selectedPlatform,
     setSelectedToken,
   });
+
+  const configuredCoinflowAvailable =
+    countryCodeLoaded && isUS && (isCoinflowEnabled || configuredCard);
+  const rememberedPaymentMethod = useMemo(() => {
+    if (!controller || !origin) return undefined;
+    try {
+      return readPaymentPreference({
+        origin,
+        chainId: controller.chainId(),
+        configuredDefault: configuredCard,
+      });
+    } catch {
+      return undefined;
+    }
+  }, [controller, origin, configuredCard]);
+
+  const initialResolutionKey = useMemo(() => {
+    if (!controller || !origin || !registryAddress || !starterpackDetails) {
+      return "";
+    }
+    const details = starterpackDetails as { id?: string | number };
+    const purchaseIdentity =
+      bundleId !== undefined
+        ? `bundle:${bundleId}`
+        : `starterpack:${starterpackId ?? details.id ?? "unknown"}`;
+    return [
+      origin,
+      controller.address(),
+      controller.chainId(),
+      registryAddress,
+      purchaseIdentity,
+    ].join(":");
+  }, [
+    controller,
+    origin,
+    registryAddress,
+    starterpackDetails,
+    bundleId,
+    starterpackId,
+  ]);
+  const resolutionRef = useRef<{ key: string; applied: boolean }>({
+    key: "",
+    applied: false,
+  });
+  const [isInitialPaymentResolved, setIsInitialPaymentResolved] =
+    useState(false);
+
+  useEffect(() => {
+    if (!initialResolutionKey || !quote) return;
+    if (resolutionRef.current.key !== initialResolutionKey) {
+      resolutionRef.current = { key: initialResolutionKey, applied: false };
+      setIsInitialPaymentResolved(false);
+    }
+    if (resolutionRef.current.applied) return;
+
+    if (quote.totalCost === 0n) {
+      resolutionRef.current.applied = true;
+      setIsInitialPaymentResolved(true);
+      return;
+    }
+
+    const creditsResolution =
+      isCreditsQuoteLoading ||
+      isCreditsBalanceLoading ||
+      (!creditsQuote && !creditsQuoteError)
+        ? "pending"
+        : creditsQuoteError || creditsBalanceError || !creditsQuote
+          ? "unavailable"
+          : "available";
+
+    const resolution = resolveInitialPaymentMethod({
+      remembered: rememberedPaymentMethod,
+      configuredDefault: configuredCard,
+      funding: tokenFundingStatus,
+      credits: creditsResolution,
+      hasSufficientCredits,
+      cardTopupAvailable: configuredCoinflowAvailable,
+      directCardAvailable:
+        configuredCoinflowAvailable && isCoinflowStarterpackSupported,
+    });
+    if (resolution.status === "pending") return;
+
+    resolutionRef.current.applied = true;
+    if (resolution.method === "credits") {
+      onCreditsSelect({ persist: false });
+    } else if (resolution.method === "coinflow") {
+      onCoinflowSelect({ persist: false });
+    } else {
+      clearSelectedWallet({ persist: false });
+    }
+    if (resolution.showMethodPicker) {
+      if (rememberedPaymentMethod && controller && origin) {
+        try {
+          clearPaymentPreference({
+            origin,
+            chainId: controller.chainId(),
+          });
+        } catch {
+          // localStorage may be unavailable
+        }
+      }
+      setIsDrawerOpen(true);
+    }
+    setIsInitialPaymentResolved(true);
+  }, [
+    initialResolutionKey,
+    quote,
+    isCreditsQuoteLoading,
+    isCreditsBalanceLoading,
+    creditsQuote,
+    creditsQuoteError,
+    creditsBalanceError,
+    rememberedPaymentMethod,
+    configuredCard,
+    tokenFundingStatus,
+    hasSufficientCredits,
+    configuredCoinflowAvailable,
+    isCoinflowStarterpackSupported,
+    onCreditsSelect,
+    onCoinflowSelect,
+    clearSelectedWallet,
+    controller,
+    origin,
+  ]);
 
   // Insufficient credits doesn't disable the CTA — it turns into "Buy
   // Credits" and opens the top-up drawer (mirrors the Apple Pay
@@ -289,6 +434,8 @@ export function OnchainCheckout() {
       return (
         isCreditsQuoteLoading ||
         !!creditsQuoteError ||
+        isCreditsBalanceLoading ||
+        !!creditsBalanceError ||
         !creditsQuote ||
         isCreditsLoading
       );
@@ -333,7 +480,9 @@ export function OnchainCheckout() {
     isCoinflowLoading,
     isCreditsSelected,
     isCreditsQuoteLoading,
+    isCreditsBalanceLoading,
     creditsQuoteError,
+    creditsBalanceError,
     creditsQuote,
     isCreditsLoading,
   ]);
@@ -422,6 +571,31 @@ export function OnchainCheckout() {
     }
   }, [controller, loginWithWebauthnPopup, clearError, refetchUserData]);
 
+  const purchaseKey = useMemo(
+    () =>
+      quote && creditsQuote
+        ? [
+            initialResolutionKey,
+            quantity,
+            quote.totalCost.toString(),
+            creditsQuote.requiredCredits,
+          ].join(":")
+        : "",
+    [initialResolutionKey, quantity, quote, creditsQuote],
+  );
+  const activePurchaseKeyRef = useRef("");
+  useEffect(() => {
+    activePurchaseKeyRef.current = purchaseKey;
+    return () => {
+      // Compare before clearing so StrictMode cleanup cannot invalidate a newer
+      // fingerprint installed by a subsequent effect.
+      if (activePurchaseKeyRef.current === purchaseKey) {
+        activePurchaseKeyRef.current = "";
+      }
+    };
+  }, [purchaseKey]);
+  const autoCreditsPurchaseRef = useRef<string>();
+
   const purchaseInFlightRef = useRef(false);
   const handlePurchase = useCallback(async () => {
     if (purchaseInFlightRef.current) return;
@@ -445,10 +619,75 @@ export function OnchainCheckout() {
       return;
     }
     if (method === "credits" && !hasSufficientCredits) {
-      // Not enough credits — the CTA reads "Deposit USD": open the top-up
-      // drawer and refresh the balance once the deposit lands.
-      initiateCreditsDeposit(async () => {
-        await refetchCreditsBalance();
+      if (!creditsQuote || !purchaseKey) return;
+      const requiredCredits = BigInt(creditsQuote.requiredCredits);
+      const shortfall =
+        requiredCredits > creditsBalance
+          ? requiredCredits - creditsBalance
+          : 0n;
+      // $1 = 1e8 raw credit units. Round upward to a cent so the top-up can
+      // never land a fraction below the authoritative bundle quote.
+      const shortfallUsd = Number((shortfall + 999_999n) / 1_000_000n) / 100;
+      const topupAmount = Math.max(MIN_CREDITS_PURCHASE_USD, shortfallUsd);
+      if (topupAmount > MAX_CREDITS_PURCHASE_USD) {
+        setDisplayError(
+          new Error(
+            `The required credit top-up exceeds the $${MAX_CREDITS_PURCHASE_USD.toLocaleString()} card limit. Choose another payment method.`,
+          ),
+        );
+        setIsDrawerOpen(true);
+        return;
+      }
+      const originatingPurchaseKey = purchaseKey;
+
+      initiateCreditsDeposit({
+        preferredMethod: configuredCoinflowAvailable
+          ? { type: "coinflow" }
+          : undefined,
+        defaultAmount: topupAmount,
+        minimumAmount: topupAmount,
+        purchaseKey: originatingPurchaseKey,
+        onSuccess: async () => {
+          if (activePurchaseKeyRef.current !== originatingPurchaseKey) {
+            throw new Error(
+              "The bundle changed while credits were being added. Your credits are available for a new purchase.",
+            );
+          }
+          if (autoCreditsPurchaseRef.current === originatingPurchaseKey) return;
+          autoCreditsPurchaseRef.current = originatingPurchaseKey;
+
+          try {
+            await waitForCreditsBalance({
+              requiredCredits,
+              // On Sepolia, Controller-funded credits are immediately usable,
+              // while Coinflow sandbox payments never grant spendable credits.
+              // Read once so the former succeeds without polling the latter.
+              timeoutMs: isCoinflowSandbox ? 0 : undefined,
+              refetchBalance: async () => {
+                if (activePurchaseKeyRef.current !== originatingPurchaseKey) {
+                  throw new Error(
+                    "The bundle changed while credits were being added. Your credits are available for a new purchase.",
+                  );
+                }
+                return refetchCreditsBalance();
+              },
+            });
+          } catch (error) {
+            autoCreditsPurchaseRef.current = undefined;
+            if (
+              isCoinflowSandbox &&
+              error instanceof CreditsBalancePendingError
+            ) {
+              throw new Error(
+                "Sandbox card payments do not add spendable credits, so the bundle was not purchased.",
+              );
+            }
+            throw error;
+          }
+
+          await onCreditsPurchase();
+          navigate("/purchase/success", { reset: true });
+        },
       });
       return;
     }
@@ -547,6 +786,12 @@ export function OnchainCheckout() {
     initiateCreditsDeposit,
     refetchCreditsBalance,
     onCreditsPurchase,
+    creditsQuote,
+    creditsBalance,
+    purchaseKey,
+    configuredCoinflowAvailable,
+    isCoinflowSandbox,
+    setDisplayError,
   ]);
 
   const handleBridge = useCallback(async () => {
@@ -560,40 +805,6 @@ export function OnchainCheckout() {
     }
   }, [onSendDeposit, navigate, clearError, setDisplayError]);
 
-  // Restore last payment method from localStorage
-  const hasRestoredMethod = useRef(false);
-  useEffect(() => {
-    if (hasRestoredMethod.current || !controller || !quote) return;
-    hasRestoredMethod.current = true;
-    try {
-      const lastMethod = localStorage.getItem(
-        `@cartridge/lastPaymentMethod:${controller.chainId()}`,
-      );
-      if (
-        lastMethod === "coinflow" &&
-        isCoinflowEnabled &&
-        isCoinflowStarterpackSupported &&
-        isUS
-      ) {
-        onCoinflowSelect();
-      } else if (lastMethod === "credits") {
-        // No client-side gate: if the bundle isn't approved for credits the
-        // quote rejects and the checkout surfaces the backend message.
-        onCreditsSelect();
-      }
-    } catch {
-      // localStorage may be unavailable
-    }
-  }, [
-    controller,
-    quote,
-    isCoinflowEnabled,
-    isCoinflowStarterpackSupported,
-    onCoinflowSelect,
-    onCreditsSelect,
-    isUS,
-  ]);
-
   useEffect(() => {
     clearError();
     return () => clearError();
@@ -603,7 +814,12 @@ export function OnchainCheckout() {
     return <AgeGate />;
   }
 
-  if (isStarterpackLoading || !quote || !countryCodeLoaded) {
+  if (
+    isStarterpackLoading ||
+    !quote ||
+    !countryCodeLoaded ||
+    (!isFree && !isInitialPaymentResolved)
+  ) {
     return <LoadingState />;
   }
 
@@ -818,6 +1034,7 @@ export function OnchainCheckout() {
         onClose={() => setIsDrawerOpen(false)}
         setSelected={handlePaymentMethodSelect}
         showFiatOptions={isUS}
+        enableCoinflow={configuredCard}
         showCredits={false} // credits available from controller
         showController={true}
       />

--- a/packages/keychain/src/components/purchase/checkout/onchain/wallet-drawer.tsx
+++ b/packages/keychain/src/components/purchase/checkout/onchain/wallet-drawer.tsx
@@ -76,6 +76,8 @@ interface WalletSelectionDrawerProps {
   showController?: boolean;
   showCrypto?: boolean;
   showCredits?: boolean;
+  /** Allow a dapp-configured Coinflow flow without the local developer flag. */
+  enableCoinflow?: boolean;
 }
 
 export function WalletSelectionDrawer({
@@ -86,8 +88,10 @@ export function WalletSelectionDrawer({
   showController = false,
   showCrypto = true,
   showCredits = false,
+  enableCoinflow = false,
 }: WalletSelectionDrawerProps) {
-  const isCoinflowEnabled = useFeature("coinflow-support");
+  const featureCoinflowEnabled = useFeature("coinflow-support");
+  const isCoinflowEnabled = enableCoinflow || featureCoinflowEnabled;
   const { isUS } = useGeoLocation();
   const advancedView = useAdvancedView();
 

--- a/packages/keychain/src/components/session.test.tsx
+++ b/packages/keychain/src/components/session.test.tsx
@@ -66,6 +66,7 @@ describe("Session", () => {
       toriiUrl: null,
       namespace: null,
       propagateError: false,
+      coinflowSandbox: false,
       webauthnPopup: {
         create: false,
         get: false,

--- a/packages/keychain/src/context/starterpack/credit-purchase.tsx
+++ b/packages/keychain/src/context/starterpack/credit-purchase.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   ReactNode,
 } from "react";
 import { useConnection } from "@/hooks/connection";
@@ -45,7 +46,9 @@ export interface CreditPurchaseContextType {
   creditsQuoteError: Error | undefined;
   /** Raw credit balance in 1e8-per-USD units (same unit as requiredCredits). */
   creditsBalance: bigint;
-  refetchCreditsBalance: () => Promise<unknown>;
+  refetchCreditsBalance: () => Promise<bigint>;
+  isCreditsBalanceLoading: boolean;
+  creditsBalanceError: Error | undefined;
   hasSufficientCredits: boolean;
   isCreditsLoading: boolean;
   creditsFulfillment: CreditsBundleFulfillment | undefined;
@@ -120,12 +123,26 @@ export const CreditPurchaseProvider = ({
 
   // Credit balance — raw 1e8-per-USD units, same unit as the quote's
   // requiredCredits, so the sufficiency check needs no conversion.
-  const { balance: rawCreditBalance, refetch: refetchCreditsBalance } =
-    useCreditBalance({
-      username: controller?.username(),
-      interval: undefined,
-    });
+  const {
+    balance: rawCreditBalance,
+    refetch: refetchRawCreditsBalance,
+    isLoading: isCreditsBalanceLoading,
+    error: creditsBalanceError,
+  } = useCreditBalance({
+    username: controller?.username(),
+    interval: undefined,
+  });
   const creditsBalance = rawCreditBalance.value;
+  const creditsBalanceRef = useRef(creditsBalance);
+  creditsBalanceRef.current = creditsBalance;
+
+  const refetchCreditsBalance = useCallback(async (): Promise<bigint> => {
+    const result = (await refetchRawCreditsBalance()) as {
+      data?: { account?: { credits?: { amount?: string } } | null };
+    };
+    const amount = result.data?.account?.credits?.amount;
+    return amount === undefined ? creditsBalanceRef.current : BigInt(amount);
+  }, [refetchRawCreditsBalance]);
   const hasSufficientCredits = useMemo(() => {
     if (!creditsQuote) return false;
     return creditsBalance >= BigInt(creditsQuote.requiredCredits);
@@ -247,6 +264,8 @@ export const CreditPurchaseProvider = ({
     creditsQuoteError: (creditsQuoteError as Error) ?? undefined,
     creditsBalance,
     refetchCreditsBalance,
+    isCreditsBalanceLoading,
+    creditsBalanceError: creditsBalanceError ?? undefined,
     hasSufficientCredits,
     isCreditsLoading,
     creditsFulfillment,

--- a/packages/keychain/src/context/starterpack/onchain-purchase.tsx
+++ b/packages/keychain/src/context/starterpack/onchain-purchase.tsx
@@ -43,11 +43,17 @@ import {
 import { useSocialClaimConnection } from "@/hooks/starterpack/social";
 import { Explorer } from "@/hooks/starterpack/layerswap";
 import { CREDITS_TOKEN } from "@/components/purchase/review/cost";
+import {
+  clearPaymentPreference,
+  writePaymentPreference,
+  type PaymentPreference,
+} from "@/utils/payment-preference";
 
 export type { TokenOption } from "@/hooks/starterpack";
 
 /** Non-wallet payment rails selectable in the checkout. */
 export type PurchaseRail = "apple-pay" | "coinflow" | "credits";
+export type PaymentSelectionOptions = { persist?: boolean };
 
 export interface OnchainPurchaseContextType {
   // Purchase items
@@ -66,7 +72,7 @@ export interface OnchainPurchaseContextType {
   selectedWallet: ExternalWallet | undefined;
   selectedPlatform: ExternalPlatform | undefined;
   walletAddress: string | undefined;
-  clearSelectedWallet: () => void;
+  clearSelectedWallet: (options?: PaymentSelectionOptions) => void;
 
   // Token selection
   availableTokens: TokenOption[];
@@ -129,8 +135,8 @@ export interface OnchainPurchaseContextType {
   onSendDeposit: () => Promise<void>;
   waitForDeposit: (swapId: string) => Promise<string>;
   onApplePaySelect: () => void;
-  onCoinflowSelect: () => void;
-  onCreditsSelect: () => void;
+  onCoinflowSelect: (options?: PaymentSelectionOptions) => void;
+  onCreditsSelect: (options?: PaymentSelectionOptions) => void;
   onCreateCoinbaseOrder: (opts?: {
     force?: boolean;
   }) => Promise<CoinbaseOrderResult | undefined>;
@@ -208,30 +214,32 @@ export const OnchainPurchaseProvider = ({
   });
 
   const savePaymentMethod = useCallback(
-    (method: string) => {
-      if (!controller) return;
+    (method: PaymentPreference) => {
+      if (!controller || !origin) return;
       try {
-        localStorage.setItem(
-          `@cartridge/lastPaymentMethod:${controller.chainId()}`,
+        writePaymentPreference({
+          origin,
+          chainId: controller.chainId(),
           method,
-        );
+        });
       } catch {
         // localStorage may be unavailable
       }
     },
-    [controller],
+    [controller, origin],
   );
 
   const clearPaymentMethod = useCallback(() => {
-    if (!controller) return;
+    if (!controller || !origin) return;
     try {
+      clearPaymentPreference({ origin, chainId: controller.chainId() });
       localStorage.removeItem(
         `@cartridge/lastPaymentMethod:${controller.chainId()}`,
       );
     } catch {
       // localStorage may be unavailable
     }
-  }, [controller]);
+  }, [controller, origin]);
 
   // Get onchain starterpack details if available
   const onchainDetails =
@@ -266,12 +274,17 @@ export const OnchainPurchaseProvider = ({
     }
   }, [selectedToken, resetTokenSelection]);
 
-  const clearSelectedWallet = useCallback(() => {
-    clearSelectedWalletInternal();
-    setSelectedRail(null);
-    clearCreditsToken();
-    clearPaymentMethod();
-  }, [clearSelectedWalletInternal, clearCreditsToken, clearPaymentMethod]);
+  const clearSelectedWallet = useCallback(
+    (options?: PaymentSelectionOptions) => {
+      clearSelectedWalletInternal();
+      setSelectedRail(null);
+      clearCreditsToken();
+      if (options?.persist !== false) {
+        savePaymentMethod("controller");
+      }
+    },
+    [clearSelectedWalletInternal, clearCreditsToken, savePaymentMethod],
+  );
 
   const onExternalConnect = useCallback(
     async (
@@ -353,7 +366,28 @@ export const OnchainPurchaseProvider = ({
     setCoinbaseLsSwapId(undefined);
   }, [resetCoinbaseOrder]);
 
-  // Handle Apple Pay selection from URL (returning from verification)
+  // Reset state when starterpack changes
+  useEffect(() => {
+    resetCoinbasePurchase();
+    resetTokenSelection();
+    setSelectedRail(null);
+    clearSelectedWalletInternal();
+    resetQuantity();
+    setPurchaseItems([]);
+    setPurchaseDescription(undefined);
+    setIssueSignature(undefined);
+  }, [
+    bundleId,
+    starterpackId,
+    resetTokenSelection,
+    clearSelectedWalletInternal,
+    resetQuantity,
+    resetCoinbasePurchase,
+  ]);
+
+  // Handle Apple Pay selection from URL (returning from verification). Keep
+  // this after the starterpack reset so a return navigation that also changes
+  // the purchase identity re-applies the verified rail.
   useEffect(() => {
     const isAndroid =
       typeof navigator !== "undefined" && /Android/i.test(navigator.userAgent);
@@ -365,22 +399,6 @@ export const OnchainPurchaseProvider = ({
       clearSelectedWalletInternal();
     }
   }, [location.search, clearSelectedWalletInternal, resetCoinbasePurchase]);
-
-  // Reset state when starterpack changes
-  useEffect(() => {
-    resetCoinbasePurchase();
-    resetTokenSelection();
-    resetQuantity();
-    setPurchaseItems([]);
-    setPurchaseDescription(undefined);
-    setIssueSignature(undefined);
-  }, [
-    bundleId,
-    starterpackId,
-    resetTokenSelection,
-    resetQuantity,
-    resetCoinbasePurchase,
-  ]);
 
   // Update purchase items and USD amount when starterpack details change
   useEffect(() => {
@@ -767,7 +785,7 @@ export const OnchainPurchaseProvider = ({
       if (rail !== "credits") {
         clearCreditsToken();
       }
-      if (opts?.persist) {
+      if (opts?.persist && rail !== "apple-pay") {
         savePaymentMethod(rail);
       }
     },
@@ -785,12 +803,14 @@ export const OnchainPurchaseProvider = ({
   );
 
   const onCoinflowSelect = useCallback(
-    () => selectRail("coinflow", { persist: true }),
+    (options?: PaymentSelectionOptions) =>
+      selectRail("coinflow", { persist: options?.persist !== false }),
     [selectRail],
   );
 
   const onCreditsSelect = useCallback(
-    () => selectRail("credits", { persist: true }),
+    (options?: PaymentSelectionOptions) =>
+      selectRail("credits", { persist: options?.persist !== false }),
     [selectRail],
   );
 

--- a/packages/keychain/src/hooks/connection.test.ts
+++ b/packages/keychain/src/hooks/connection.test.ts
@@ -5,6 +5,8 @@ import {
   isOriginVerified,
   isSameRpcUrl,
   parseControllerVersion,
+  parseDefaultPaymentMethod,
+  resolveDefaultPaymentMethod,
   resolvePolicies,
   verifyStandaloneOrigin,
 } from "./connection";
@@ -29,6 +31,30 @@ describe("parseControllerVersion", () => {
   it("rejects missing or invalid versions", () => {
     expect(parseControllerVersion(null)).toBeUndefined();
     expect(parseControllerVersion("not-semver")).toBeUndefined();
+  });
+});
+
+describe("parseDefaultPaymentMethod", () => {
+  it("accepts the supported payment method", () => {
+    expect(parseDefaultPaymentMethod("credit-card")).toBe("credit-card");
+  });
+
+  it("ignores missing and unknown payment methods", () => {
+    expect(parseDefaultPaymentMethod(null)).toBeUndefined();
+    expect(parseDefaultPaymentMethod("crypto")).toBeUndefined();
+  });
+
+  it("preserves a valid value across internal navigation", () => {
+    expect(resolveDefaultPaymentMethod(null, "credit-card")).toBe(
+      "credit-card",
+    );
+    expect(resolveDefaultPaymentMethod("crypto", "credit-card")).toBe(
+      "credit-card",
+    );
+  });
+
+  it("rejects invalid persisted values", () => {
+    expect(resolveDefaultPaymentMethod(null, "crypto")).toBeUndefined();
   });
 });
 

--- a/packages/keychain/src/hooks/connection.test.ts
+++ b/packages/keychain/src/hooks/connection.test.ts
@@ -6,6 +6,7 @@ import {
   isSameRpcUrl,
   parseControllerVersion,
   parseDefaultPaymentMethod,
+  resolveCoinflowSandbox,
   resolveDefaultPaymentMethod,
   resolvePolicies,
   verifyStandaloneOrigin,
@@ -55,6 +56,19 @@ describe("parseDefaultPaymentMethod", () => {
 
   it("rejects invalid persisted values", () => {
     expect(resolveDefaultPaymentMethod(null, "crypto")).toBeUndefined();
+  });
+});
+
+describe("resolveCoinflowSandbox", () => {
+  it("accepts explicit true and false values", () => {
+    expect(resolveCoinflowSandbox("true", false)).toBe(true);
+    expect(resolveCoinflowSandbox("false", true)).toBe(false);
+  });
+
+  it("preserves the previous value when the parameter is absent or invalid", () => {
+    expect(resolveCoinflowSandbox(null, true)).toBe(true);
+    expect(resolveCoinflowSandbox("invalid", true)).toBe(true);
+    expect(resolveCoinflowSandbox(null)).toBe(false);
   });
 });
 

--- a/packages/keychain/src/hooks/connection.ts
+++ b/packages/keychain/src/hooks/connection.ts
@@ -87,6 +87,8 @@ type ResolvedUrlParams = {
   propagateError: boolean;
   /** Optional so snapshots persisted before this field existed stay valid. */
   defaultPaymentMethod?: DefaultPaymentMethod;
+  /** Optional so snapshots persisted before this field existed stay valid. */
+  coinflowSandbox?: boolean;
   errorDisplayMode?: "modal" | "notification" | "silent";
   /** Chains the dapp explicitly configured (SDK `chains` param). Optional so
    *  url-param snapshots persisted before this field existed stay valid. */
@@ -120,6 +122,15 @@ export function resolveDefaultPaymentMethod(
   return (
     parseDefaultPaymentMethod(value) ?? parseDefaultPaymentMethod(previousValue)
   );
+}
+
+export function resolveCoinflowSandbox(
+  value?: string | null,
+  previousValue?: boolean,
+): boolean {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return previousValue ?? false;
 }
 
 // Stable fallback so consumers keyed on `configuredChains` identity don't re-run.
@@ -614,6 +625,10 @@ export function useConnectionValue() {
       urlParams.get("default_payment_method"),
       urlParamsRef.current?.defaultPaymentMethod,
     );
+    const coinflowSandbox = resolveCoinflowSandbox(
+      urlParams.get("coinflow_sandbox"),
+      urlParamsRef.current?.coinflowSandbox,
+    );
     const errorDisplayMode = urlParams.get("error_display_mode") as
       | "modal"
       | "notification"
@@ -675,6 +690,7 @@ export function useConnectionValue() {
       propagateError:
         propagateError || urlParamsRef.current?.propagateError || false,
       defaultPaymentMethod,
+      coinflowSandbox,
       errorDisplayMode:
         errorDisplayMode || urlParamsRef.current?.errorDisplayMode || undefined,
       chains: chains ?? urlParamsRef.current?.chains ?? [],
@@ -1229,6 +1245,7 @@ export function useConnectionValue() {
     tokens: urlParams.tokens,
     propagateError: urlParams.propagateError,
     defaultPaymentMethod: urlParams.defaultPaymentMethod,
+    coinflowSandbox: urlParams.coinflowSandbox ?? false,
     webauthnPopup,
     configuredChains: urlParams.chains ?? NO_CONFIGURED_CHAINS,
     preset: urlParams.preset,

--- a/packages/keychain/src/hooks/connection.ts
+++ b/packages/keychain/src/hooks/connection.ts
@@ -24,6 +24,7 @@ import {
   WalletAdapter,
   WalletBridge,
   type Chain,
+  type DefaultPaymentMethod,
 } from "@cartridge/controller";
 import { AsyncMethodReturns } from "@cartridge/penpal";
 import {
@@ -84,6 +85,8 @@ type ResolvedUrlParams = {
   ref: string | null;
   refGroup: string | null;
   propagateError: boolean;
+  /** Optional so snapshots persisted before this field existed stay valid. */
+  defaultPaymentMethod?: DefaultPaymentMethod;
   errorDisplayMode?: "modal" | "notification" | "silent";
   /** Chains the dapp explicitly configured (SDK `chains` param). Optional so
    *  url-param snapshots persisted before this field existed stay valid. */
@@ -102,6 +105,21 @@ export function parseControllerVersion(
   } catch {
     return undefined;
   }
+}
+
+export function parseDefaultPaymentMethod(
+  value?: string | null,
+): DefaultPaymentMethod | undefined {
+  return value === "credit-card" ? value : undefined;
+}
+
+export function resolveDefaultPaymentMethod(
+  value?: string | null,
+  previousValue?: string | null,
+): DefaultPaymentMethod | undefined {
+  return (
+    parseDefaultPaymentMethod(value) ?? parseDefaultPaymentMethod(previousValue)
+  );
 }
 
 // Stable fallback so consumers keyed on `configuredChains` identity don't re-run.
@@ -592,6 +610,10 @@ export function useConnectionValue() {
     const ref = urlParams.get("ref");
     const refGroup = urlParams.get("ref_group");
     const propagateError = urlParams.get("propagate_error") === "true";
+    const defaultPaymentMethod = resolveDefaultPaymentMethod(
+      urlParams.get("default_payment_method"),
+      urlParamsRef.current?.defaultPaymentMethod,
+    );
     const errorDisplayMode = urlParams.get("error_display_mode") as
       | "modal"
       | "notification"
@@ -652,6 +674,7 @@ export function useConnectionValue() {
       refGroup: refGroup || urlParamsRef.current?.refGroup || null,
       propagateError:
         propagateError || urlParamsRef.current?.propagateError || false,
+      defaultPaymentMethod,
       errorDisplayMode:
         errorDisplayMode || urlParamsRef.current?.errorDisplayMode || undefined,
       chains: chains ?? urlParamsRef.current?.chains ?? [],
@@ -1205,6 +1228,7 @@ export function useConnectionValue() {
     namespace: urlParams.namespace,
     tokens: urlParams.tokens,
     propagateError: urlParams.propagateError,
+    defaultPaymentMethod: urlParams.defaultPaymentMethod,
     webauthnPopup,
     configuredChains: urlParams.chains ?? NO_CONFIGURED_CHAINS,
     preset: urlParams.preset,

--- a/packages/keychain/src/hooks/payments/coinflow.test.ts
+++ b/packages/keychain/src/hooks/payments/coinflow.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { resolveCoinflowMainnet } from "./coinflow";
+
+describe("resolveCoinflowMainnet", () => {
+  it("uses production Coinflow only on mainnet without a sandbox override", () => {
+    expect(resolveCoinflowMainnet(true, false, false)).toBe(true);
+  });
+
+  it("uses sandbox when configured on mainnet", () => {
+    expect(resolveCoinflowMainnet(true, true, false)).toBe(false);
+  });
+
+  it("keeps the local feature override and non-mainnet behavior", () => {
+    expect(resolveCoinflowMainnet(true, false, true)).toBe(false);
+    expect(resolveCoinflowMainnet(false, false, false)).toBe(false);
+  });
+});

--- a/packages/keychain/src/hooks/payments/coinflow.ts
+++ b/packages/keychain/src/hooks/payments/coinflow.ts
@@ -39,17 +39,28 @@ export type CoinflowIntent = Omit<CoinflowStarterpackIntent, "__typename">;
 const COINFLOW_US_ONLY_ERROR =
   "Credit card checkout is only available in the United States.";
 
+export const resolveCoinflowMainnet = (
+  isMainnet: boolean,
+  configuredSandbox: boolean,
+  featureSandbox: boolean,
+) => isMainnet && !configuredSandbox && !featureSandbox;
+
 /**
  * Effective network for everything Coinflow. Coinflow runs in its sandbox
  * (UAT) environment whenever this is false: on non-mainnet chains, or on any
- * chain when the "coinflow-sandbox" feature flag is enabled. The backend
- * derives sandbox from `!isMainnet`, so this one value drives every Coinflow
- * route input, the card form's `env`, and the checkout sandbox warnings.
+ * chain when the Controller option or local "coinflow-sandbox" feature flag is
+ * enabled. The backend derives sandbox from `!isMainnet`, so this one value
+ * drives every Coinflow route input, the card form's `env`, and the checkout
+ * sandbox warnings.
  */
 export const useCoinflowIsMainnet = () => {
-  const { isMainnet } = useConnection();
-  const sandboxEnabled = useFeature("coinflow-sandbox");
-  const isCoinflowMainnet = isMainnet && !sandboxEnabled;
+  const { isMainnet, coinflowSandbox } = useConnection();
+  const featureSandbox = useFeature("coinflow-sandbox");
+  const isCoinflowMainnet = resolveCoinflowMainnet(
+    isMainnet,
+    coinflowSandbox,
+    featureSandbox,
+  );
   return {
     isCoinflowMainnet,
     isCoinflowSandbox: !isCoinflowMainnet,

--- a/packages/keychain/src/hooks/payments/coinflow.ts
+++ b/packages/keychain/src/hooks/payments/coinflow.ts
@@ -168,6 +168,16 @@ export const useCoinflowCreditsPayment = () => {
 
 const SETTLEMENT_POLL_INTERVAL_MS = 2_000;
 
+/** A polling window elapsed, but the payment has not terminally failed. */
+export class CoinflowSettlementPendingError extends Error {
+  constructor(public readonly paymentId: string) {
+    super(
+      "Your payment was accepted but is still settling. Your balance will update automatically once it completes.",
+    );
+    this.name = "CoinflowSettlementPendingError";
+  }
+}
+
 /**
  * Wait for a Coinflow payment to settle. `coinflowCardCheckout` resolves when
  * the card is charged, but credits are only granted by the settlement webhook
@@ -202,9 +212,7 @@ export async function waitForCoinflowSettlement(
     }
   }
 
-  throw new Error(
-    "Your payment was accepted but is still settling. Your balance will update automatically once it completes.",
-  );
+  throw new CoinflowSettlementPendingError(paymentId);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/keychain/src/hooks/starterpack/token-fallback.ts
+++ b/packages/keychain/src/hooks/starterpack/token-fallback.ts
@@ -36,12 +36,14 @@ export interface UseTokenFallbackOptions {
   quantity: number;
   isCoinflowSelected: boolean;
   isApplePaySelected: boolean;
+  isCreditsSelected: boolean;
   selectedPlatform: ExternalPlatform | undefined;
   setSelectedToken: (token: TokenOption) => void;
 }
 
 export interface UseTokenFallbackReturn {
   isCheckingFallback: boolean;
+  status: "pending" | "funded" | "exhausted" | "indeterminate";
 }
 
 async function fetchBalance(
@@ -93,41 +95,97 @@ export function useTokenFallback({
   quantity,
   isCoinflowSelected,
   isApplePaySelected,
+  isCreditsSelected,
   selectedPlatform,
   setSelectedToken,
 }: UseTokenFallbackOptions): UseTokenFallbackReturn {
   const [isCheckingFallback, setIsCheckingFallback] = useState(false);
-  const hasAttemptedFallback = useRef(false);
+  const [status, setStatus] =
+    useState<UseTokenFallbackReturn["status"]>("pending");
+  const generationRef = useRef(0);
+  const scanKeyRef = useRef<string>();
+  const foundTokenRef = useRef<string>();
 
   useEffect(() => {
+    const quote =
+      starterpackDetails && isOnchainStarterpack(starterpackDetails)
+        ? starterpackDetails.quote
+        : undefined;
+    const scanKey =
+      controller && quote
+        ? [
+            controller.address(),
+            controller.chainId(),
+            quote.paymentToken,
+            quote.totalCost.toString(),
+            quantity.toString(),
+            selectedPlatform ?? "starknet",
+          ].join(":")
+        : undefined;
+
+    if (scanKeyRef.current !== scanKey) {
+      generationRef.current += 1;
+      scanKeyRef.current = scanKey;
+      foundTokenRef.current = undefined;
+      setStatus("pending");
+    }
+
+    if (isCoinflowSelected || isApplePaySelected || isCreditsSelected) {
+      setIsCheckingFallback(false);
+      return;
+    }
+
     if (
       isLoadingBalance ||
-      hasSufficientBalance ||
-      !!balanceError ||
-      hasAttemptedFallback.current ||
       !controller ||
       !starterpackDetails ||
       !isOnchainStarterpack(starterpackDetails) ||
       !selectedToken ||
-      isCoinflowSelected ||
-      isApplePaySelected ||
-      (selectedPlatform && selectedPlatform !== "starknet")
+      !quote ||
+      !scanKey
     ) {
+      setStatus("pending");
       return;
     }
 
-    const quote = starterpackDetails.quote;
-    if (!quote || quote.totalCost === 0n) return;
+    if (quote.totalCost === 0n || hasSufficientBalance) {
+      setIsCheckingFallback(false);
+      setStatus("funded");
+      return;
+    }
 
-    hasAttemptedFallback.current = true;
+    if (balanceError) {
+      setIsCheckingFallback(false);
+      setStatus("indeterminate");
+      return;
+    }
+
+    if (selectedPlatform && selectedPlatform !== "starknet") {
+      setIsCheckingFallback(false);
+      setStatus("exhausted");
+      return;
+    }
+
+    if (
+      foundTokenRef.current &&
+      num.toHex(foundTokenRef.current) === num.toHex(selectedToken.address)
+    ) {
+      setStatus("funded");
+      return;
+    }
 
     const abortController = new AbortController();
+    const generation = ++generationRef.current;
 
     const checkFallbacks = async () => {
       setIsCheckingFallback(true);
+      setStatus("pending");
+      let indeterminate = false;
       try {
         const candidates = availableTokens.filter(
-          (token) => token.address !== selectedToken.address,
+          (token) =>
+            !token.isCredits &&
+            num.toHex(token.address) !== num.toHex(selectedToken.address),
         );
 
         const ownerAddress = controller.address();
@@ -176,21 +234,34 @@ export function useTokenFallback({
             if (abortController.signal.aborted) return;
 
             if (balance !== null && balance >= requiredAmount) {
+              if (generation !== generationRef.current) return;
+              foundTokenRef.current = candidate.address;
               setSelectedToken(candidate);
+              setStatus("funded");
               return;
             }
+            if (balance === null) indeterminate = true;
           } catch (error) {
             console.warn(
               `Fallback check failed for ${candidate.symbol}:`,
               error,
             );
+            indeterminate = true;
             continue;
           }
+        }
+        if (
+          !abortController.signal.aborted &&
+          generation === generationRef.current
+        ) {
+          setStatus(indeterminate ? "indeterminate" : "exhausted");
         }
       } finally {
         // Always clear the loading flag, even on abort / early return, so the
         // Buy button doesn't stick in a spinning state.
-        setIsCheckingFallback(false);
+        if (generation === generationRef.current) {
+          setIsCheckingFallback(false);
+        }
       }
     };
 
@@ -198,6 +269,9 @@ export function useTokenFallback({
 
     return () => {
       abortController.abort();
+      if (generationRef.current === generation) {
+        generationRef.current += 1;
+      }
     };
   }, [
     controller,
@@ -210,9 +284,10 @@ export function useTokenFallback({
     quantity,
     isCoinflowSelected,
     isApplePaySelected,
+    isCreditsSelected,
     selectedPlatform,
     setSelectedToken,
   ]);
 
-  return { isCheckingFallback };
+  return { isCheckingFallback, status };
 }

--- a/packages/keychain/src/test/mocks/connection.tsx
+++ b/packages/keychain/src/test/mocks/connection.tsx
@@ -47,6 +47,7 @@ export const defaultMockConnection: ConnectionContextValue = {
     cover: "test-cover",
   },
   propagateError: false,
+  defaultPaymentMethod: undefined,
   webauthnPopup: {
     create: false,
     get: false,

--- a/packages/keychain/src/test/mocks/connection.tsx
+++ b/packages/keychain/src/test/mocks/connection.tsx
@@ -48,6 +48,7 @@ export const defaultMockConnection: ConnectionContextValue = {
   },
   propagateError: false,
   defaultPaymentMethod: undefined,
+  coinflowSandbox: false,
   webauthnPopup: {
     create: false,
     get: false,

--- a/packages/keychain/src/utils/credits-settlement.test.ts
+++ b/packages/keychain/src/utils/credits-settlement.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import { waitForCreditsBalance } from "./credits-settlement";
+
+describe("waitForCreditsBalance", () => {
+  it("polls until the required balance is visible", async () => {
+    vi.useFakeTimers();
+    const refetchBalance = vi
+      .fn<() => Promise<bigint>>()
+      .mockResolvedValueOnce(100n)
+      .mockResolvedValueOnce(250n);
+
+    const result = waitForCreditsBalance({
+      requiredCredits: 250n,
+      refetchBalance,
+      timeoutMs: 1_000,
+      pollIntervalMs: 10,
+    });
+    await vi.advanceTimersByTimeAsync(10);
+
+    await expect(result).resolves.toBe(250n);
+    expect(refetchBalance).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  it("returns a typed pending error when the balance does not converge", async () => {
+    const refetchBalance = vi.fn().mockResolvedValue(100n);
+
+    await expect(
+      waitForCreditsBalance({
+        requiredCredits: 250n,
+        refetchBalance,
+        timeoutMs: 0,
+      }),
+    ).rejects.toMatchObject({
+      name: "CreditsBalancePendingError",
+      requiredCredits: 250n,
+      observedCredits: 100n,
+    });
+  });
+});

--- a/packages/keychain/src/utils/credits-settlement.ts
+++ b/packages/keychain/src/utils/credits-settlement.ts
@@ -1,0 +1,44 @@
+export class CreditsBalancePendingError extends Error {
+  constructor(
+    public readonly requiredCredits: bigint,
+    public readonly observedCredits: bigint,
+  ) {
+    super(
+      "Your credits were added, but the updated balance is still syncing. The bundle was not purchased yet.",
+    );
+    this.name = "CreditsBalancePendingError";
+  }
+}
+
+/**
+ * Wait for a newly-settled credit deposit to become visible to the authoritative
+ * balance query. Coinflow settlement and the account query can converge a few
+ * seconds apart, so a single refetch is not sufficient for an automatic debit.
+ */
+export async function waitForCreditsBalance({
+  requiredCredits,
+  refetchBalance,
+  timeoutMs = 30_000,
+  pollIntervalMs = 1_000,
+}: {
+  requiredCredits: bigint;
+  refetchBalance: () => Promise<bigint>;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+}): Promise<bigint> {
+  const startedAt = Date.now();
+  let observedCredits = 0n;
+
+  do {
+    observedCredits = await refetchBalance();
+    if (observedCredits >= requiredCredits) return observedCredits;
+
+    const remainingMs = timeoutMs - (Date.now() - startedAt);
+    if (remainingMs <= 0) break;
+    await new Promise((resolve) =>
+      setTimeout(resolve, Math.min(pollIntervalMs, remainingMs)),
+    );
+  } while (Date.now() - startedAt < timeoutMs);
+
+  throw new CreditsBalancePendingError(requiredCredits, observedCredits);
+}

--- a/packages/keychain/src/utils/credits.ts
+++ b/packages/keychain/src/utils/credits.ts
@@ -74,10 +74,10 @@ export function usdToUsdcWei(usd: number): bigint {
   return BigInt(Math.round(usd * 10 ** USDC_DECIMALS));
 }
 
-// Backend bounds for a credits purchase (calculateCreditsDetails): $2 min /
+// Product bounds for a credits purchase: $5 min /
 // $25,000 max. The min also absorbs Coinbase's own Apple Pay onramp floor so
 // every fiat rail can validate against the one constant. The controller (USDC
 // deposit) rail isn't bound server-side, but the deposit flow still caps it at
 // the same max for sanity.
-export const MIN_CREDITS_PURCHASE_USD = Math.max(2, COINBASE_APPLE_PAY_MIN_USD);
+export const MIN_CREDITS_PURCHASE_USD = Math.max(5, COINBASE_APPLE_PAY_MIN_USD);
 export const MAX_CREDITS_PURCHASE_USD = 25_000;

--- a/packages/keychain/src/utils/payment-preference.test.ts
+++ b/packages/keychain/src/utils/payment-preference.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import {
+  paymentPreferenceKey,
+  readPaymentPreference,
+  resolveInitialPaymentMethod,
+  writePaymentPreference,
+} from "./payment-preference";
+
+const memoryStorage = () => {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, value),
+    removeItem: (key: string) => values.delete(key),
+  };
+};
+
+describe("payment preference", () => {
+  it("isolates explicit choices by origin and chain", () => {
+    const storage = memoryStorage();
+    writePaymentPreference({
+      origin: "https://glitchbomb.game",
+      chainId: "0x1",
+      method: "credits",
+      storage,
+    });
+
+    expect(
+      readPaymentPreference({
+        origin: "https://glitchbomb.game",
+        chainId: "0x1",
+        configuredDefault: true,
+        storage,
+      }),
+    ).toBe("credits");
+    expect(
+      readPaymentPreference({
+        origin: "https://other.game",
+        chainId: "0x1",
+        configuredDefault: true,
+        storage,
+      }),
+    ).toBeUndefined();
+    expect(paymentPreferenceKey("https://glitchbomb.game", "0x1")).toContain(
+      encodeURIComponent("https://glitchbomb.game"),
+    );
+  });
+
+  it("ignores a legacy cross-game choice when a default is configured", () => {
+    const storage = memoryStorage();
+    storage.setItem("@cartridge/lastPaymentMethod:0x1", "coinflow");
+
+    expect(
+      readPaymentPreference({
+        origin: "https://glitchbomb.game",
+        chainId: "0x1",
+        configuredDefault: true,
+        storage,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("keeps funded Controller ahead of the configured default", () => {
+    expect(
+      resolveInitialPaymentMethod({
+        configuredDefault: true,
+        funding: "funded",
+        credits: "available",
+        hasSufficientCredits: true,
+        cardTopupAvailable: true,
+        directCardAvailable: true,
+      }),
+    ).toEqual({ status: "resolved", method: "controller" });
+  });
+
+  it("preserves legacy Controller behavior when no default is configured", () => {
+    expect(
+      resolveInitialPaymentMethod({
+        configuredDefault: false,
+        funding: "pending",
+        credits: "pending",
+        hasSufficientCredits: false,
+        cardTopupAvailable: false,
+        directCardAvailable: false,
+      }),
+    ).toEqual({ status: "resolved", method: "controller" });
+  });
+
+  it("selects credits only after Controller funding is exhausted", () => {
+    expect(
+      resolveInitialPaymentMethod({
+        configuredDefault: true,
+        funding: "exhausted",
+        credits: "available",
+        hasSufficientCredits: false,
+        cardTopupAvailable: true,
+        directCardAvailable: true,
+      }),
+    ).toEqual({ status: "resolved", method: "credits" });
+  });
+
+  it("honors an explicit per-game preference", () => {
+    expect(
+      resolveInitialPaymentMethod({
+        remembered: "credits",
+        configuredDefault: true,
+        funding: "funded",
+        credits: "available",
+        hasSufficientCredits: true,
+        cardTopupAvailable: true,
+        directCardAvailable: true,
+      }),
+    ).toEqual({ status: "resolved", method: "credits" });
+  });
+
+  it("shows the picker when funding is indeterminate", () => {
+    expect(
+      resolveInitialPaymentMethod({
+        configuredDefault: true,
+        funding: "indeterminate",
+        credits: "available",
+        hasSufficientCredits: false,
+        cardTopupAvailable: true,
+        directCardAvailable: true,
+      }),
+    ).toEqual({
+      status: "resolved",
+      method: "controller",
+      showMethodPicker: true,
+    });
+  });
+});

--- a/packages/keychain/src/utils/payment-preference.test.ts
+++ b/packages/keychain/src/utils/payment-preference.test.ts
@@ -113,12 +113,25 @@ describe("payment preference", () => {
     ).toEqual({ status: "resolved", method: "credits" });
   });
 
-  it("shows the picker when funding is indeterminate", () => {
+  it("uses credits when Controller funding is indeterminate but card top-up is available", () => {
     expect(
       resolveInitialPaymentMethod({
         configuredDefault: true,
         funding: "indeterminate",
         credits: "available",
+        hasSufficientCredits: false,
+        cardTopupAvailable: true,
+        directCardAvailable: true,
+      }),
+    ).toEqual({ status: "resolved", method: "credits" });
+  });
+
+  it("shows the picker when funding is indeterminate and credits are unavailable", () => {
+    expect(
+      resolveInitialPaymentMethod({
+        configuredDefault: true,
+        funding: "indeterminate",
+        credits: "unavailable",
         hasSufficientCredits: false,
         cardTopupAvailable: true,
         directCardAvailable: true,

--- a/packages/keychain/src/utils/payment-preference.ts
+++ b/packages/keychain/src/utils/payment-preference.ts
@@ -144,14 +144,6 @@ export function resolveInitialPaymentMethod({
   if (funding === "funded") {
     return { status: "resolved", method: "controller" };
   }
-  if (funding === "indeterminate") {
-    return {
-      status: "resolved",
-      method: "controller",
-      showMethodPicker: true,
-    };
-  }
-
   if (credits === "pending") return { status: "pending" };
   if (credits === "available" && (hasSufficientCredits || cardTopupAvailable)) {
     return { status: "resolved", method: "credits" };

--- a/packages/keychain/src/utils/payment-preference.ts
+++ b/packages/keychain/src/utils/payment-preference.ts
@@ -1,0 +1,164 @@
+export type PaymentPreference = "controller" | "credits" | "coinflow";
+
+type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+const PREFIX = "@cartridge/lastPaymentMethod:v2";
+const LEGACY_PREFIX = "@cartridge/lastPaymentMethod";
+
+const isPaymentPreference = (
+  value: string | null,
+): value is PaymentPreference =>
+  value === "controller" || value === "credits" || value === "coinflow";
+
+export function paymentPreferenceKey(origin: string, chainId: string): string {
+  return `${PREFIX}:${encodeURIComponent(origin)}:${chainId}`;
+}
+
+export function readPaymentPreference({
+  origin,
+  chainId,
+  configuredDefault,
+  storage = localStorage,
+}: {
+  origin: string;
+  chainId: string;
+  configuredDefault: boolean;
+  storage?: StorageLike;
+}): PaymentPreference | undefined {
+  if (!origin) return undefined;
+
+  const key = paymentPreferenceKey(origin, chainId);
+  const scoped = storage.getItem(key);
+  if (isPaymentPreference(scoped)) return scoped;
+  if (scoped !== null) storage.removeItem(key);
+
+  // A configured game must not inherit another game's chain-global choice.
+  if (configuredDefault) return undefined;
+
+  const legacy = storage.getItem(`${LEGACY_PREFIX}:${chainId}`);
+  if (legacy !== "credits" && legacy !== "coinflow") return undefined;
+
+  storage.setItem(key, legacy);
+  return legacy;
+}
+
+export function writePaymentPreference({
+  origin,
+  chainId,
+  method,
+  storage = localStorage,
+}: {
+  origin: string;
+  chainId: string;
+  method: PaymentPreference;
+  storage?: StorageLike;
+}): void {
+  if (!origin) return;
+  storage.setItem(paymentPreferenceKey(origin, chainId), method);
+}
+
+export function clearPaymentPreference({
+  origin,
+  chainId,
+  storage = localStorage,
+}: {
+  origin: string;
+  chainId: string;
+  storage?: StorageLike;
+}): void {
+  if (!origin) return;
+  storage.removeItem(paymentPreferenceKey(origin, chainId));
+}
+
+export type FundingResolution =
+  | "pending"
+  | "funded"
+  | "exhausted"
+  | "indeterminate";
+
+export type CreditsResolution = "pending" | "available" | "unavailable";
+
+export type InitialPaymentResolution =
+  | { status: "pending" }
+  | {
+      status: "resolved";
+      method: PaymentPreference;
+      showMethodPicker?: boolean;
+    };
+
+/**
+ * Resolve the initial bundle payment rail without side effects. The caller is
+ * responsible for applying the result once per checkout.
+ */
+export function resolveInitialPaymentMethod({
+  remembered,
+  configuredDefault,
+  funding,
+  credits,
+  hasSufficientCredits,
+  cardTopupAvailable,
+  directCardAvailable,
+}: {
+  remembered?: PaymentPreference;
+  configuredDefault: boolean;
+  funding: FundingResolution;
+  credits: CreditsResolution;
+  hasSufficientCredits: boolean;
+  cardTopupAvailable: boolean;
+  directCardAvailable: boolean;
+}): InitialPaymentResolution {
+  if (remembered === "controller") {
+    return { status: "resolved", method: "controller" };
+  }
+
+  if (remembered === "coinflow") {
+    return directCardAvailable
+      ? { status: "resolved", method: "coinflow" }
+      : {
+          status: "resolved",
+          method: "controller",
+          showMethodPicker: true,
+        };
+  }
+
+  if (remembered === "credits") {
+    if (credits === "pending") return { status: "pending" };
+    if (
+      credits === "available" &&
+      (hasSufficientCredits || cardTopupAvailable)
+    ) {
+      return { status: "resolved", method: "credits" };
+    }
+    return {
+      status: "resolved",
+      method: "controller",
+      showMethodPicker: true,
+    };
+  }
+
+  if (!configuredDefault) {
+    return { status: "resolved", method: "controller" };
+  }
+
+  if (funding === "pending") return { status: "pending" };
+  if (funding === "funded") {
+    return { status: "resolved", method: "controller" };
+  }
+  if (funding === "indeterminate") {
+    return {
+      status: "resolved",
+      method: "controller",
+      showMethodPicker: true,
+    };
+  }
+
+  if (credits === "pending") return { status: "pending" };
+  if (credits === "available" && (hasSufficientCredits || cardTopupAvailable)) {
+    return { status: "resolved", method: "credits" };
+  }
+  return {
+    status: "resolved",
+    method: "controller",
+    showMethodPicker: true,
+  };
+}

--- a/packages/ui/src/components/primitives/drawer.test.tsx
+++ b/packages/ui/src/components/primitives/drawer.test.tsx
@@ -1,0 +1,28 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { DrawerContent } from "./drawer";
+
+vi.mock("@/index", () => ({
+  SheetTitle: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => (
+    <div {...props}>{children}</div>
+  ),
+  Thumbnail: ({ icon }: { icon: ReactNode }) => (
+    <div data-testid="thumbnail">{icon}</div>
+  ),
+}));
+
+describe("DrawerContent", () => {
+  it("renders a title without an icon thumbnail", () => {
+    const markup = renderToStaticMarkup(
+      <DrawerContent title="Deposit USD">
+        <div>Content</div>
+      </DrawerContent>,
+    );
+
+    expect(markup).toContain("Deposit USD");
+    expect(markup).toContain("Content");
+    expect(markup).not.toContain('data-testid="thumbnail"');
+    expect(markup).not.toContain("<svg");
+  });
+});

--- a/packages/ui/src/components/primitives/drawer.tsx
+++ b/packages/ui/src/components/primitives/drawer.tsx
@@ -39,7 +39,7 @@ export interface DrawerContentProps
   extends React.HTMLAttributes<HTMLDivElement> {
   title: string;
   subTitle?: string;
-  icon: React.ReactNode;
+  icon?: React.ReactNode;
   className?: string;
   titleClassName?: string;
   children: React.ReactNode;
@@ -59,13 +59,15 @@ export const DrawerContent = ({
         className={cn("text-lg text-start font-semibold", titleClassName)}
       >
         <div className="flex flex-row gap-3 items-center">
-          <Thumbnail
-            icon={React.cloneElement(icon as React.ReactElement, {
-              size: "lg",
-            })}
-            size="lg"
-            className="bg-background-100"
-          />
+          {icon && (
+            <Thumbnail
+              icon={React.cloneElement(icon as React.ReactElement, {
+                size: "lg",
+              })}
+              size="lg"
+              className="bg-background-100"
+            />
+          )}
           <div className="flex flex-col gap-0 max-w-[75%]">
             <div className="flex-grow truncate text-foreground-100">
               {title}


### PR DESCRIPTION
Adds `defaultPaymentMethod: "credit-card"` to Controller configuration and transports it into Keychain. Defaults eligible purchases to Credits/card top-up while retaining funded Controller tokens and scoped explicit preferences. Automatically resumes the starterpack debit after settlement with stale-attempt, route-change, and balance-convergence protections.

Uses the configured `$10`/`$20`/`$50` credit amounts with a `$5` floor. Adds `coinflowSandbox: true` as an explicit Controller option so the Mainnet Nums flow can exercise Coinflow UAT before the production integration is active. Sandbox payments intentionally do not grant production-spendable credits. The Next.js example enables both options for preview testing. Deposit USD drawers use a text-only header without the deposit icon.

Improves the Coinflow card form for the US-only rollout: removes the country input and always submits `US`, adds browser billing-autofill metadata so city/address/state/postal code populate reliably, and prefills first/last name from completed Prove verification without overwriting user edits.

Validated after rebasing onto current `main` with formatting/lint, TypeScript, 60 Keychain test files (702 passed, 2 skipped), Controller compatibility tests, and the existing production build coverage.