### PR TITLE
fix(keychain): restore GPS geofencing

### DIFF
--- a/packages/keychain/src/components/location/LocationGate.test.tsx
+++ b/packages/keychain/src/components/location/LocationGate.test.tsx
@@ -1,0 +1,202 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { LocationGate } from "./LocationGate";
+
+const mocks = vi.hoisted(() => ({
+  closeModal: vi.fn(),
+  getCurrentPosition: vi.fn(),
+  getIpLocation: vi.fn(),
+  reverseGeocodeLocation: vi.fn(),
+  setLocationGateVerified: vi.fn(),
+}));
+
+vi.mock("@/hooks/connection", () => ({
+  useConnection: () => ({
+    closeModal: mocks.closeModal,
+    setLocationGateVerified: mocks.setLocationGateVerified,
+    theme: { name: "Test Game" },
+  }),
+}));
+
+vi.mock("@/components/ErrorAlert", () => ({
+  ErrorAlert: ({ description }: { description: string }) => (
+    <div>{description}</div>
+  ),
+}));
+
+vi.mock("@cartridge/controller-ui", () => ({
+  Button: (
+    props: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+      isLoading?: boolean;
+    },
+  ) => {
+    const { children, isLoading, ...buttonProps } = props;
+    void isLoading;
+    return <button {...buttonProps}>{children}</button>;
+  },
+  GlobeIcon: () => <span />,
+  HeaderInner: ({ title }: { title: string }) => <h1>{title}</h1>,
+  LayoutContent: ({ children }: React.PropsWithChildren) => (
+    <main>{children}</main>
+  ),
+  LayoutFooter: ({ children }: React.PropsWithChildren) => (
+    <footer>{children}</footer>
+  ),
+}));
+
+vi.mock("@/utils/ip", () => ({
+  getIpLocation: mocks.getIpLocation,
+}));
+
+vi.mock("@/utils/location-gate", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/utils/location-gate")>();
+  return {
+    ...actual,
+    reverseGeocodeLocation: mocks.reverseGeocodeLocation,
+  };
+});
+
+vi.mock("@cartridge/presets", () => ({
+  defaultTheme: { name: "Cartridge" },
+  loadConfig: vi.fn(),
+}));
+
+vi.mock("./USMap", () => ({
+  USMap: () => <div data-testid="us-map" />,
+}));
+
+const route = `/location-gate?${new URLSearchParams({
+  returnTo: "/connect?id=connect-1",
+  gate: JSON.stringify({ blocked: ["US-NY"] }),
+})}`;
+
+function renderGate() {
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <LocationGate />
+    </MemoryRouter>,
+  );
+}
+
+describe("LocationGate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    Object.defineProperty(navigator, "geolocation", {
+      configurable: true,
+      value: { getCurrentPosition: mocks.getCurrentPosition },
+    });
+  });
+
+  it("requests browser geolocation after the user continues", () => {
+    renderGate();
+
+    expect(screen.getByText("Location Verification")).toBeInTheDocument();
+    expect(mocks.getCurrentPosition).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "CONTINUE" }));
+
+    expect(mocks.getCurrentPosition).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(Function),
+      {
+        enableHighAccuracy: true,
+        maximumAge: 60000,
+        timeout: 15000,
+      },
+    );
+  });
+
+  it("uses the GPS result as the primary geofence signal", async () => {
+    mocks.reverseGeocodeLocation.mockResolvedValue({
+      countryCode: "US",
+      regionCode: "US-CA",
+    });
+    renderGate();
+    fireEvent.click(screen.getByRole("button", { name: "CONTINUE" }));
+
+    const onSuccess = mocks.getCurrentPosition.mock.calls[0][0];
+    onSuccess({
+      coords: { latitude: 34.05, longitude: -118.24 },
+      timestamp: 1,
+    });
+
+    await waitFor(() => {
+      expect(mocks.setLocationGateVerified).toHaveBeenCalledWith(true);
+    });
+    expect(mocks.reverseGeocodeLocation).toHaveBeenCalledWith(
+      expect.objectContaining({ latitude: 34.05, longitude: -118.24 }),
+    );
+    expect(mocks.getIpLocation).not.toHaveBeenCalled();
+  });
+
+  it("falls back to IP geolocation when browser geolocation fails", async () => {
+    mocks.getIpLocation.mockResolvedValue({
+      countryCode: "US",
+      regionCode: "US-NY",
+    });
+    renderGate();
+    fireEvent.click(screen.getByRole("button", { name: "CONTINUE" }));
+
+    const onError = mocks.getCurrentPosition.mock.calls[0][1];
+    onError({ code: 1, message: "Permission denied" });
+
+    expect(await screen.findByText("Region Restricted")).toBeInTheDocument();
+    expect(mocks.getIpLocation).toHaveBeenCalledOnce();
+    expect(mocks.setLocationGateVerified).not.toHaveBeenCalled();
+  });
+
+  it("falls back to IP geolocation when browser geolocation is unavailable", async () => {
+    Object.defineProperty(navigator, "geolocation", {
+      configurable: true,
+      value: undefined,
+    });
+    mocks.getIpLocation.mockResolvedValue({
+      countryCode: "US",
+      regionCode: "US-CA",
+    });
+    renderGate();
+
+    fireEvent.click(screen.getByRole("button", { name: "CONTINUE" }));
+
+    await waitFor(() => {
+      expect(mocks.setLocationGateVerified).toHaveBeenCalledWith(true);
+    });
+    expect(mocks.getCurrentPosition).not.toHaveBeenCalled();
+    expect(mocks.getIpLocation).toHaveBeenCalledOnce();
+  });
+
+  it("cancels the location gate without requesting location", () => {
+    renderGate();
+
+    fireEvent.click(screen.getByRole("button", { name: "CANCEL" }));
+
+    expect(mocks.closeModal).toHaveBeenCalledOnce();
+    expect(mocks.getCurrentPosition).not.toHaveBeenCalled();
+    expect(mocks.getIpLocation).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when neither GPS nor IP can resolve a location", async () => {
+    mocks.reverseGeocodeLocation.mockRejectedValue(
+      new Error("Reverse geocoding failed"),
+    );
+    mocks.getIpLocation.mockResolvedValue({
+      countryCode: null,
+      regionCode: null,
+    });
+    renderGate();
+    fireEvent.click(screen.getByRole("button", { name: "CONTINUE" }));
+
+    const onSuccess = mocks.getCurrentPosition.mock.calls[0][0];
+    onSuccess({
+      coords: { latitude: 0, longitude: 0 },
+      timestamp: 1,
+    });
+
+    expect(
+      await screen.findByText("Unable to verify location."),
+    ).toBeInTheDocument();
+    expect(mocks.setLocationGateVerified).not.toHaveBeenCalled();
+  });
+});

--- a/packages/keychain/src/components/location/LocationGate.tsx
+++ b/packages/keychain/src/components/location/LocationGate.tsx
@@ -12,11 +12,19 @@ import { defaultTheme, loadConfig } from "@cartridge/presets";
 import { ErrorAlert } from "@/components/ErrorAlert";
 import { useConnection } from "@/hooks/connection";
 import { cleanupCallbacks, getCallbacks } from "@/utils/connection/callbacks";
-import { evaluateLocationGate } from "@/utils/location-gate";
-import { useGeoLocation } from "@/hooks/geo";
+import {
+  evaluateLocationGate,
+  reverseGeocodeLocation,
+} from "@/utils/location-gate";
+import { getIpLocation, type IpLocation } from "@/utils/ip";
 import { USMap } from "./USMap";
 
-type GateState = "checking" | "blocked" | "error";
+type GateState = "idle" | "requesting" | "blocked";
+
+const CANCEL_RESPONSE = {
+  code: ResponseCodes.CANCELED,
+  message: "Canceled",
+};
 
 function errorResponse(gameName: string) {
   return {
@@ -29,7 +37,8 @@ export function LocationGate() {
   const { closeModal, setLocationGateVerified, theme } = useConnection();
   const { search } = useLocation();
   const navigate = useNavigate();
-  const [state, setState] = useState<GateState>("checking");
+  const [state, setState] = useState<GateState>("idle");
+  const [error, setError] = useState<string | null>(null);
 
   const [presetGate, setPresetGate] = useState<LocationGateOptions | null>(
     null,
@@ -96,39 +105,84 @@ export function LocationGate() {
     [connectId, closeModal],
   );
 
-  const { countryCode, regionCode, countryCodeLoaded, isError } =
-    useGeoLocation();
+  const evaluateAndContinue = useCallback(
+    (geo: IpLocation) => {
+      if (!gate || !returnTo) {
+        throw new Error("Location requirements are missing");
+      }
+      if (!geo.countryCode && !geo.regionCode) {
+        throw new Error("Location could not be resolved");
+      }
 
-  // Evaluate the gate once the IP location resolves and the gate is available.
-  useEffect(() => {
-    if (!gate || !returnTo || !countryCodeLoaded) return;
+      const result = evaluateLocationGate({ gate, geo });
+      if (!result.allowed) {
+        setState("blocked");
+        return;
+      }
 
-    if (isError) {
-      setState("error");
+      setLocationGateVerified(true);
+      navigate(returnTo, { replace: true });
+    },
+    [gate, navigate, returnTo, setLocationGateVerified],
+  );
+
+  const fallBackToIpLocation = useCallback(async () => {
+    const ipLocation = await getIpLocation();
+    evaluateAndContinue(ipLocation);
+  }, [evaluateAndContinue]);
+
+  const handleLocationFailure = useCallback(async () => {
+    try {
+      await fallBackToIpLocation();
+    } catch (locationError) {
+      console.error("Location gate failed:", locationError);
+      setState("idle");
+      setError("Unable to verify location.");
+    }
+  }, [fallBackToIpLocation]);
+
+  const handleContinue = useCallback(() => {
+    if (!gate || !returnTo) {
+      setError("Location requirements are missing.");
       return;
     }
 
-    const result = evaluateLocationGate({
-      gate,
-      geo: { countryCode, regionCode },
-    });
+    setError(null);
+    setState("requesting");
 
-    if (result.allowed) {
-      setLocationGateVerified(true);
-      navigate(returnTo, { replace: true });
-    } else {
-      setState("blocked");
+    if (typeof navigator === "undefined" || !navigator.geolocation) {
+      void handleLocationFailure();
+      return;
     }
-  }, [
-    gate,
-    returnTo,
-    navigate,
-    setLocationGateVerified,
-    countryCode,
-    regionCode,
-    countryCodeLoaded,
-    isError,
-  ]);
+
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        void (async () => {
+          try {
+            const geo = await reverseGeocodeLocation(position.coords);
+            evaluateAndContinue({
+              countryCode: geo.countryCode ?? null,
+              regionCode: geo.regionCode ?? null,
+            });
+          } catch {
+            await handleLocationFailure();
+          }
+        })();
+      },
+      () => {
+        void handleLocationFailure();
+      },
+      {
+        enableHighAccuracy: true,
+        timeout: 15000,
+        maximumAge: 60000,
+      },
+    );
+  }, [evaluateAndContinue, gate, handleLocationFailure, returnTo]);
+
+  const handleCancel = useCallback(() => {
+    resolveConnect(CANCEL_RESPONSE);
+  }, [resolveConnect]);
 
   const gameName =
     theme.name && theme.name !== defaultTheme.name ? theme.name : "This game";
@@ -138,24 +192,26 @@ export function LocationGate() {
     return gate.blocked.filter((code) => code.toUpperCase().startsWith("US-"));
   }, [gate]);
 
-  // Show nothing while checking
-  if (state === "checking") {
+  if (!gate) {
     return null;
   }
 
-  if (state === "error") {
+  if (state === "blocked") {
     return (
       <>
         <HeaderInner
-          title="Location Check"
+          title="Region Restricted"
           icon={<GlobeIcon variant="solid" size="lg" />}
         />
         <LayoutContent className="p-4">
-          <ErrorAlert
-            title="Error"
-            description="Unable to verify location."
-            isExpanded={true}
-          />
+          {blockedUSStates.length > 0 && (
+            <div className="mb-3">
+              <USMap blockedStates={blockedUSStates} />
+            </div>
+          )}
+          <p className="text-sm text-foreground-300 leading-relaxed">
+            {gameName} is not available in your region.
+          </p>
         </LayoutContent>
         <LayoutFooter>
           <Button
@@ -173,26 +229,36 @@ export function LocationGate() {
   return (
     <>
       <HeaderInner
-        title="Region Restricted"
+        title="Location Verification"
         icon={<GlobeIcon variant="solid" size="lg" />}
       />
-      <LayoutContent className="p-4">
+      <LayoutContent className="p-4 gap-3">
         {blockedUSStates.length > 0 && (
-          <div className="mb-3">
-            <USMap blockedStates={blockedUSStates} />
-          </div>
+          <USMap blockedStates={blockedUSStates} />
         )}
         <p className="text-sm text-foreground-300 leading-relaxed">
-          {gameName} is not available in your region.
+          {gameName} needs your location to confirm availability in your region.
         </p>
       </LayoutContent>
       <LayoutFooter>
+        {error && (
+          <ErrorAlert title="Error" description={error} isExpanded={true} />
+        )}
+        <Button
+          variant="primary"
+          className="w-full"
+          onClick={handleContinue}
+          isLoading={state === "requesting"}
+        >
+          CONTINUE
+        </Button>
         <Button
           variant="secondary"
           className="w-full"
-          onClick={() => resolveConnect(errorResponse(gameName))}
+          onClick={handleCancel}
+          disabled={state === "requesting"}
         >
-          CLOSE
+          CANCEL
         </Button>
       </LayoutFooter>
     </>

--- a/packages/keychain/src/utils/location-gate.test.ts
+++ b/packages/keychain/src/utils/location-gate.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { reverseGeocodeLocation } from "./location-gate";
+
+describe("reverseGeocodeLocation", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("resolves browser coordinates to country and region codes", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        countryCode: "US",
+        principalSubdivisionCode: "US-NY",
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      reverseGeocodeLocation({ latitude: 40.7128, longitude: -74.006 }),
+    ).resolves.toEqual({ countryCode: "US", regionCode: "US-NY" });
+
+    const requestedUrl = new URL(fetchMock.mock.calls[0][0]);
+    expect(requestedUrl.hostname).toBe("api.bigdatacloud.net");
+    expect(requestedUrl.searchParams.get("latitude")).toBe("40.7128");
+    expect(requestedUrl.searchParams.get("longitude")).toBe("-74.006");
+  });
+
+  it("rejects a response that cannot resolve a country", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      }),
+    );
+
+    await expect(
+      reverseGeocodeLocation({ latitude: 0, longitude: 0 }),
+    ).rejects.toThrow("did not resolve to a country");
+  });
+
+  it("rejects a failed reverse-geocoding response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+      }),
+    );
+
+    await expect(
+      reverseGeocodeLocation({ latitude: 40.7128, longitude: -74.006 }),
+    ).rejects.toThrow("Failed to resolve browser location");
+  });
+});

--- a/packages/keychain/src/utils/location-gate.ts
+++ b/packages/keychain/src/utils/location-gate.ts
@@ -1,4 +1,7 @@
-import type { LocationGateOptions } from "@cartridge/controller";
+import type {
+  LocationCoordinates,
+  LocationGateOptions,
+} from "@cartridge/controller";
 
 /**
  * Returns true if the location gate has any configured rules (allowed or blocked).
@@ -14,6 +17,40 @@ type GeoLocation = {
   countryCode?: string | null;
   regionCode?: string | null;
 };
+
+/**
+ * Resolve browser coordinates into the country and ISO subdivision codes used
+ * by location-gate rules.
+ */
+export async function reverseGeocodeLocation(
+  coords: Pick<LocationCoordinates, "latitude" | "longitude">,
+): Promise<GeoLocation> {
+  const url = new URL(
+    "https://api.bigdatacloud.net/data/reverse-geocode-client",
+  );
+  url.searchParams.set("latitude", coords.latitude.toString());
+  url.searchParams.set("longitude", coords.longitude.toString());
+  url.searchParams.set("localityLanguage", "en");
+
+  const response = await fetch(url.toString());
+  if (!response.ok) {
+    throw new Error("Failed to resolve browser location");
+  }
+
+  const data = (await response.json()) as {
+    countryCode?: string | null;
+    principalSubdivisionCode?: string | null;
+  };
+
+  if (!data.countryCode) {
+    throw new Error("Browser location did not resolve to a country");
+  }
+
+  return {
+    countryCode: data.countryCode,
+    regionCode: data.principalSubdivisionCode ?? null,
+  };
+}
 
 /**
  * Splits a list of location codes into country codes and region codes.


### PR DESCRIPTION
## Summary

Restores browser GPS consent and high-accuracy geolocation as the primary signal for the keychain location gate.
Reverse-geocodes GPS coordinates into the existing country and region rules while retaining IP geolocation as a fallback when browser location fails or is unavailable.
Fails closed when neither source resolves and adds coverage for allowed, blocked, cancellation, fallback, and error paths.

## Test plan

- [x] `pnpm lint:check`
- [x] `pnpm test:ci`
- [x] `pnpm build`
- [x] 9 focused location-gate tests

Pre-landing review and design review lite found no issues.
