### PR TITLE
fix(keychain): enforce authenticated GPS geofence

### DIFF
--- a/packages/keychain/src/components/ConnectRoute.test.tsx
+++ b/packages/keychain/src/components/ConnectRoute.test.tsx
@@ -11,6 +11,19 @@ vi.mock("@/utils/url-validator", () => ({
   safeRedirect: (...args: unknown[]) => mockSafeRedirect(...args),
 }));
 
+const mockUseGeoLocation = vi.fn();
+vi.mock("@/hooks/geo", () => ({
+  useGeoLocation: () => mockUseGeoLocation(),
+}));
+
+const mockCreateLocationGateUrl = vi.fn((args: unknown) => {
+  void args;
+  return "/location-gate";
+});
+vi.mock("@/utils/connection/location-gate", () => ({
+  createLocationGateUrl: (args: unknown) => mockCreateLocationGateUrl(args),
+}));
+
 const mockIsIframe = vi.fn();
 vi.mock("@cartridge/controller-ui/utils", async (importOriginal) => {
   const actual =
@@ -129,6 +142,15 @@ describe("ConnectRoute", () => {
     mockUseRouteParams.mockReturnValue(mockParams);
     mockUseRouteCompletion.mockReturnValue(vi.fn());
     mockLocation.search = "";
+    mockUseGeoLocation.mockReturnValue({
+      countryCode: "US",
+      regionCode: "US-CA",
+      isUS: true,
+      countryCodeLoaded: true,
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
     // mockSnapshotLocalStorageToCookie.mockResolvedValue("mock-encrypted-blob");
 
     mockUseConnection.mockReturnValue({});
@@ -158,6 +180,70 @@ describe("ConnectRoute", () => {
         });
         expect(mockCleanupCallbacks).toHaveBeenCalledWith("test-id");
       });
+    });
+
+    it("runs a configured location gate for US users", async () => {
+      mockUseConnection.mockReturnValue({
+        controller: mockController,
+        policies: null,
+        locationGate: { blocked: ["US-NY"] },
+        locationGateVerified: false,
+      });
+
+      renderWithProviders(<ConnectRoute />);
+
+      await waitFor(() => {
+        expect(mockCreateLocationGateUrl).toHaveBeenCalledOnce();
+      });
+      expect(mockParams.resolve).not.toHaveBeenCalled();
+    });
+
+    it("skips a configured location gate for non-US users", async () => {
+      mockUseGeoLocation.mockReturnValue({
+        countryCode: "CA",
+        regionCode: "CA-ON",
+        isUS: false,
+        countryCodeLoaded: true,
+        isLoading: false,
+        isError: false,
+        error: null,
+      });
+      mockUseConnection.mockReturnValue({
+        controller: mockController,
+        policies: null,
+        locationGate: { blocked: ["US-NY"] },
+        locationGateVerified: false,
+      });
+
+      renderWithProviders(<ConnectRoute />);
+
+      await waitFor(() => {
+        expect(mockParams.resolve).toHaveBeenCalled();
+      });
+      expect(mockCreateLocationGateUrl).not.toHaveBeenCalled();
+    });
+
+    it("waits for country detection before deciding on location gating", () => {
+      mockUseGeoLocation.mockReturnValue({
+        countryCode: null,
+        regionCode: null,
+        isUS: false,
+        countryCodeLoaded: false,
+        isLoading: true,
+        isError: false,
+        error: null,
+      });
+      mockUseConnection.mockReturnValue({
+        controller: mockController,
+        policies: null,
+        locationGate: { blocked: ["US-NY"] },
+        locationGateVerified: false,
+      });
+
+      renderWithProviders(<ConnectRoute />);
+
+      expect(mockCreateLocationGateUrl).not.toHaveBeenCalled();
+      expect(mockParams.resolve).not.toHaveBeenCalled();
     });
 
     it("keeps onboarding visible on first mount for v0.13.13", async () => {

--- a/packages/keychain/src/components/ConnectRoute.tsx
+++ b/packages/keychain/src/components/ConnectRoute.tsx
@@ -34,6 +34,7 @@ import {
   LayoutFooter,
 } from "@cartridge/controller-ui";
 import { ControllerErrorAlert } from "@/components/ErrorAlert";
+import { useGeoLocation } from "@/hooks/geo";
 
 const CANCEL_RESPONSE = {
   code: ResponseCodes.CANCELED,
@@ -93,6 +94,7 @@ export function ConnectRoute() {
   // Check if this is standalone mode (not in iframe)
   const isStandalone = useMemo(() => !isIframe(), []);
   const canKeepOpen = supportsConnectKeepOpen(controllerVersion, isStandalone);
+  const { isUS, countryCodeLoaded } = useGeoLocation();
 
   // Get redirect_url from query params for standalone mode
   const redirectUrl = useMemo(() => {
@@ -296,10 +298,16 @@ export function ConnectRoute() {
       return;
     }
 
-    // If location gate is configured but not yet verified, redirect to it
-    // before allowing any auto-connect. This catches the race condition where
-    // connect() was called before the preset config loaded.
-    if (hasConfiguredLocationGate(locationGate) && !locationGateVerified) {
+    const hasLocationGate = hasConfiguredLocationGate(locationGate);
+
+    // Location gating is a US-only feature. Wait for the shared IP-country
+    // lookup before deciding whether a GPS check is required so connect cannot
+    // race ahead for a US user.
+    if (hasLocationGate && !countryCodeLoaded) {
+      return;
+    }
+
+    if (hasLocationGate && isUS && !locationGateVerified) {
       const currentUrl = window.location.pathname + window.location.search;
       navigate(
         createLocationGateUrl({ returnTo: currentUrl, gate: locationGate! }),
@@ -437,6 +445,8 @@ export function ConnectRoute() {
     clearConnectParams,
     locationGate,
     locationGateVerified,
+    countryCodeLoaded,
+    isUS,
     navigate,
     isNewControllerRef,
     canKeepOpen,

--- a/packages/keychain/src/components/app.tsx
+++ b/packages/keychain/src/components/app.tsx
@@ -158,16 +158,6 @@ function Authentication() {
     );
   }
 
-  // Location gate must render even without a controller so that new users
-  // verify their location before the connect flow proceeds.
-  if (!controller && pathname === "/location-gate") {
-    return (
-      <Layout>
-        <Outlet />
-      </Layout>
-    );
-  }
-
   // No controller, show CreateController
   if (!controller) {
     // Extract signers from URL if present (for connect flow)

--- a/packages/keychain/src/components/connect/create/useCreateController.ts
+++ b/packages/keychain/src/components/connect/create/useCreateController.ts
@@ -355,9 +355,8 @@ export function useCreateController({
   const canKeepOpen = supportsConnectKeepOpen(controllerVersion, !isIframe());
 
   // When location gate is configured and not yet verified, skip auto-session
-  // creation and connect resolution. The natural re-render will show LocationGate
-  // (since the URL is still /location-gate), and after verification LocationGate
-  // navigates to /connect where ConnectRoute handles session + resolution.
+  // creation and connect resolution. Once authentication sets the controller,
+  // ConnectRoute redirects to LocationGate and resumes after verification.
   const locationGatePending =
     hasConfiguredLocationGate(locationGate) && !locationGateVerified;
 
@@ -552,9 +551,9 @@ export function useCreateController({
         // }
 
         // If location gate is pending, skip session creation and connect
-        // resolution. The re-render will show LocationGate at the current URL;
-        // after verification it navigates to /connect where ConnectRoute handles
-        // session creation and resolution.
+        // resolution. The controller re-render lets ConnectRoute redirect to
+        // LocationGate; after verification, ConnectRoute handles session
+        // creation and resolution.
         if (locationGatePending) {
           return;
         }
@@ -868,9 +867,9 @@ export function useCreateController({
       // }
 
       // If location gate is pending, skip session creation and connect
-      // resolution. The re-render will show LocationGate at the current URL;
-      // after verification it navigates to /connect where ConnectRoute handles
-      // session creation and resolution.
+      // resolution. The controller re-render lets ConnectRoute redirect to
+      // LocationGate; after verification, ConnectRoute handles session
+      // creation and resolution.
       if (locationGatePending) {
         return;
       }

--- a/packages/keychain/src/components/location/LocationGate.test.tsx
+++ b/packages/keychain/src/components/location/LocationGate.test.tsx
@@ -1,12 +1,13 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { connect } from "@/utils/connection/connect";
 import { LocationGate } from "./LocationGate";
 
 const mocks = vi.hoisted(() => ({
   closeModal: vi.fn(),
   getCurrentPosition: vi.fn(),
-  getIpLocation: vi.fn(),
+  queryPermission: vi.fn(),
   reverseGeocodeLocation: vi.fn(),
   setLocationGateVerified: vi.fn(),
 }));
@@ -43,10 +44,6 @@ vi.mock("@cartridge/controller-ui", () => ({
   LayoutFooter: ({ children }: React.PropsWithChildren) => (
     <footer>{children}</footer>
   ),
-}));
-
-vi.mock("@/utils/ip", () => ({
-  getIpLocation: mocks.getIpLocation,
 }));
 
 vi.mock("@/utils/location-gate", async (importOriginal) => {
@@ -87,12 +84,19 @@ describe("LocationGate", () => {
       configurable: true,
       value: { getCurrentPosition: mocks.getCurrentPosition },
     });
+    Object.defineProperty(navigator, "permissions", {
+      configurable: true,
+      value: { query: mocks.queryPermission },
+    });
+    mocks.queryPermission.mockResolvedValue({ state: "prompt" });
   });
 
-  it("requests browser geolocation after the user continues", () => {
+  it("requests browser geolocation after the user continues", async () => {
     renderGate();
 
-    expect(screen.getByText("Location Verification")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Location Verification"),
+    ).toBeInTheDocument();
     expect(mocks.getCurrentPosition).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole("button", { name: "CONTINUE" }));
@@ -114,7 +118,7 @@ describe("LocationGate", () => {
       regionCode: "US-CA",
     });
     renderGate();
-    fireEvent.click(screen.getByRole("button", { name: "CONTINUE" }));
+    fireEvent.click(await screen.findByRole("button", { name: "CONTINUE" }));
 
     const onSuccess = mocks.getCurrentPosition.mock.calls[0][0];
     onSuccess({
@@ -128,65 +132,102 @@ describe("LocationGate", () => {
     expect(mocks.reverseGeocodeLocation).toHaveBeenCalledWith(
       expect.objectContaining({ latitude: 34.05, longitude: -118.24 }),
     );
-    expect(mocks.getIpLocation).not.toHaveBeenCalled();
   });
 
-  it("falls back to IP geolocation when browser geolocation fails", async () => {
-    mocks.getIpLocation.mockResolvedValue({
-      countryCode: "US",
-      regionCode: "US-NY",
-    });
+  it("does not pass when browser geolocation permission is denied", async () => {
     renderGate();
-    fireEvent.click(screen.getByRole("button", { name: "CONTINUE" }));
+    fireEvent.click(await screen.findByRole("button", { name: "CONTINUE" }));
 
     const onError = mocks.getCurrentPosition.mock.calls[0][1];
     onError({ code: 1, message: "Permission denied" });
 
-    expect(await screen.findByText("Region Restricted")).toBeInTheDocument();
-    expect(mocks.getIpLocation).toHaveBeenCalledOnce();
+    expect(
+      await screen.findByText("Location permission was denied."),
+    ).toBeInTheDocument();
     expect(mocks.setLocationGateVerified).not.toHaveBeenCalled();
   });
 
-  it("falls back to IP geolocation when browser geolocation is unavailable", async () => {
+  it("does not pass when browser geolocation is unavailable", async () => {
     Object.defineProperty(navigator, "geolocation", {
       configurable: true,
       value: undefined,
     });
-    mocks.getIpLocation.mockResolvedValue({
+    renderGate();
+
+    fireEvent.click(await screen.findByRole("button", { name: "CONTINUE" }));
+
+    expect(
+      await screen.findByText(
+        "Location services are not available in this browser.",
+      ),
+    ).toBeInTheDocument();
+    expect(mocks.getCurrentPosition).not.toHaveBeenCalled();
+    expect(mocks.setLocationGateVerified).not.toHaveBeenCalled();
+  });
+
+  it("silently checks location when browser permission is already granted", async () => {
+    mocks.queryPermission.mockResolvedValue({ state: "granted" });
+    mocks.reverseGeocodeLocation.mockResolvedValue({
       countryCode: "US",
       regionCode: "US-CA",
     });
+
     renderGate();
 
-    fireEvent.click(screen.getByRole("button", { name: "CONTINUE" }));
+    await waitFor(() => {
+      expect(mocks.getCurrentPosition).toHaveBeenCalledOnce();
+    });
+    expect(screen.queryByText("Location Verification")).not.toBeInTheDocument();
+
+    const onSuccess = mocks.getCurrentPosition.mock.calls[0][0];
+    onSuccess({
+      coords: { latitude: 34.05, longitude: -118.24 },
+      timestamp: 1,
+    });
 
     await waitFor(() => {
       expect(mocks.setLocationGateVerified).toHaveBeenCalledWith(true);
     });
-    expect(mocks.getCurrentPosition).not.toHaveBeenCalled();
-    expect(mocks.getIpLocation).toHaveBeenCalledOnce();
   });
 
-  it("cancels the location gate without requesting location", () => {
+  it("shows consent without checking when browser permission is denied", async () => {
+    mocks.queryPermission.mockResolvedValue({ state: "denied" });
+
     renderGate();
 
-    fireEvent.click(screen.getByRole("button", { name: "CANCEL" }));
+    expect(
+      await screen.findByText("Location Verification"),
+    ).toBeInTheDocument();
+    expect(mocks.getCurrentPosition).not.toHaveBeenCalled();
+    expect(mocks.setLocationGateVerified).not.toHaveBeenCalled();
+  });
+
+  it("shows consent when the browser permission status cannot be queried", async () => {
+    mocks.queryPermission.mockRejectedValue(new Error("Unsupported"));
+
+    renderGate();
+
+    expect(
+      await screen.findByText("Location Verification"),
+    ).toBeInTheDocument();
+    expect(mocks.getCurrentPosition).not.toHaveBeenCalled();
+  });
+
+  it("cancels the location gate without requesting location", async () => {
+    renderGate();
+
+    fireEvent.click(await screen.findByRole("button", { name: "CANCEL" }));
 
     expect(mocks.closeModal).toHaveBeenCalledOnce();
     expect(mocks.getCurrentPosition).not.toHaveBeenCalled();
-    expect(mocks.getIpLocation).not.toHaveBeenCalled();
   });
 
-  it("fails closed when neither GPS nor IP can resolve a location", async () => {
+  it("fails closed when GPS cannot resolve a location", async () => {
     mocks.reverseGeocodeLocation.mockRejectedValue(
       new Error("Reverse geocoding failed"),
     );
-    mocks.getIpLocation.mockResolvedValue({
-      countryCode: null,
-      regionCode: null,
-    });
     renderGate();
-    fireEvent.click(screen.getByRole("button", { name: "CONTINUE" }));
+    fireEvent.click(await screen.findByRole("button", { name: "CONTINUE" }));
 
     const onSuccess = mocks.getCurrentPosition.mock.calls[0][0];
     onSuccess({
@@ -198,5 +239,23 @@ describe("LocationGate", () => {
       await screen.findByText("Unable to verify location."),
     ).toBeInTheDocument();
     expect(mocks.setLocationGateVerified).not.toHaveBeenCalled();
+  });
+});
+
+describe("location gate routing", () => {
+  it("starts authentication before a configured location gate", () => {
+    const navigate = vi.fn();
+    const connectFn = connect({
+      navigate,
+      setRpcUrl: vi.fn(),
+      getLocationGate: () => ({ blocked: ["US-NY"] }),
+    })();
+
+    void connectFn({ signupOptions: ["password"] });
+
+    expect(navigate).toHaveBeenCalledWith(
+      expect.stringMatching(/^\/connect\?/),
+      { replace: true },
+    );
   });
 });

--- a/packages/keychain/src/components/location/LocationGate.tsx
+++ b/packages/keychain/src/components/location/LocationGate.tsx
@@ -16,10 +16,14 @@ import {
   evaluateLocationGate,
   reverseGeocodeLocation,
 } from "@/utils/location-gate";
-import { getIpLocation, type IpLocation } from "@/utils/ip";
 import { USMap } from "./USMap";
 
-type GateState = "idle" | "requesting" | "blocked";
+type GateState = "checking" | "idle" | "requesting" | "blocked";
+
+type ResolvedLocation = {
+  countryCode?: string | null;
+  regionCode?: string | null;
+};
 
 const CANCEL_RESPONSE = {
   code: ResponseCodes.CANCELED,
@@ -37,7 +41,7 @@ export function LocationGate() {
   const { closeModal, setLocationGateVerified, theme } = useConnection();
   const { search } = useLocation();
   const navigate = useNavigate();
-  const [state, setState] = useState<GateState>("idle");
+  const [state, setState] = useState<GateState>("checking");
   const [error, setError] = useState<string | null>(null);
 
   const [presetGate, setPresetGate] = useState<LocationGateOptions | null>(
@@ -106,7 +110,7 @@ export function LocationGate() {
   );
 
   const evaluateAndContinue = useCallback(
-    (geo: IpLocation) => {
+    (geo: ResolvedLocation) => {
       if (!gate || !returnTo) {
         throw new Error("Location requirements are missing");
       }
@@ -126,59 +130,95 @@ export function LocationGate() {
     [gate, navigate, returnTo, setLocationGateVerified],
   );
 
-  const fallBackToIpLocation = useCallback(async () => {
-    const ipLocation = await getIpLocation();
-    evaluateAndContinue(ipLocation);
-  }, [evaluateAndContinue]);
-
-  const handleLocationFailure = useCallback(async () => {
-    try {
-      await fallBackToIpLocation();
-    } catch (locationError) {
-      console.error("Location gate failed:", locationError);
+  const handleLocationError = useCallback(
+    (geoError?: Pick<GeolocationPositionError, "code" | "message">) => {
       setState("idle");
-      setError("Unable to verify location.");
+      if (geoError?.code === 1) {
+        setError("Location permission was denied.");
+        return;
+      }
+      setError(geoError?.message || "Unable to verify location.");
+    },
+    [],
+  );
+
+  const requestLocation = useCallback(
+    (silent = false) => {
+      if (!gate || !returnTo) {
+        setState("idle");
+        setError("Location requirements are missing.");
+        return;
+      }
+
+      if (typeof navigator === "undefined" || !navigator.geolocation) {
+        setState("idle");
+        setError("Location services are not available in this browser.");
+        return;
+      }
+
+      setError(null);
+      setState(silent ? "checking" : "requesting");
+
+      navigator.geolocation.getCurrentPosition(
+        (position) => {
+          void (async () => {
+            try {
+              const geo = await reverseGeocodeLocation(position.coords);
+              evaluateAndContinue({
+                countryCode: geo.countryCode ?? null,
+                regionCode: geo.regionCode ?? null,
+              });
+            } catch (locationError) {
+              console.error("Location gate failed:", locationError);
+              setState("idle");
+              setError("Unable to verify location.");
+            }
+          })();
+        },
+        handleLocationError,
+        {
+          enableHighAccuracy: true,
+          timeout: 15000,
+          maximumAge: 60000,
+        },
+      );
+    },
+    [evaluateAndContinue, gate, handleLocationError, returnTo],
+  );
+
+  useEffect(() => {
+    if (!gate || !returnTo) return;
+
+    let cancelled = false;
+    const showPrompt = () => {
+      if (!cancelled) setState("idle");
+    };
+
+    if (typeof navigator === "undefined" || !navigator.permissions?.query) {
+      showPrompt();
+      return;
     }
-  }, [fallBackToIpLocation]);
+
+    navigator.permissions
+      .query({ name: "geolocation" })
+      .then((permission) => {
+        if (cancelled) return;
+        if (permission.state === "granted") {
+          requestLocation(true);
+        } else {
+          setState("idle");
+        }
+      })
+      .catch(showPrompt);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [gate, requestLocation, returnTo]);
 
   const handleContinue = useCallback(() => {
-    if (!gate || !returnTo) {
-      setError("Location requirements are missing.");
-      return;
-    }
-
-    setError(null);
-    setState("requesting");
-
-    if (typeof navigator === "undefined" || !navigator.geolocation) {
-      void handleLocationFailure();
-      return;
-    }
-
-    navigator.geolocation.getCurrentPosition(
-      (position) => {
-        void (async () => {
-          try {
-            const geo = await reverseGeocodeLocation(position.coords);
-            evaluateAndContinue({
-              countryCode: geo.countryCode ?? null,
-              regionCode: geo.regionCode ?? null,
-            });
-          } catch {
-            await handleLocationFailure();
-          }
-        })();
-      },
-      () => {
-        void handleLocationFailure();
-      },
-      {
-        enableHighAccuracy: true,
-        timeout: 15000,
-        maximumAge: 60000,
-      },
-    );
-  }, [evaluateAndContinue, gate, handleLocationFailure, returnTo]);
+    requestLocation();
+  }, [requestLocation]);
 
   const handleCancel = useCallback(() => {
     resolveConnect(CANCEL_RESPONSE);
@@ -192,7 +232,7 @@ export function LocationGate() {
     return gate.blocked.filter((code) => code.toUpperCase().startsWith("US-"));
   }, [gate]);
 
-  if (!gate) {
+  if (!gate || state === "checking") {
     return null;
   }
 

--- a/packages/keychain/src/components/purchase/checkout/onchain/index.tsx
+++ b/packages/keychain/src/components/purchase/checkout/onchain/index.tsx
@@ -136,8 +136,8 @@ export function OnchainCheckout() {
   const { isUS, countryCodeLoaded } = useGeoLocation();
 
   const handleIconTripleClick = useTripleClick({
-    featureName: "coinflow-support",
-    callback: onCoinflowSelect,
+    featureName: isUS ? "coinflow-support" : undefined,
+    callback: isUS ? onCoinflowSelect : undefined,
   });
 
   const totalUsdAmount = useMemo(() => {
@@ -370,6 +370,7 @@ export function OnchainCheckout() {
           onApplePaySelect();
           break;
         case "coinflow":
+          if (!isUS) return;
           onCoinflowSelect();
           break;
         case "credits":
@@ -394,6 +395,7 @@ export function OnchainCheckout() {
       onCreditsSelect,
       clearSelectedWallet,
       onExternalConnect,
+      isUS,
     ],
   );
 
@@ -436,7 +438,12 @@ export function OnchainCheckout() {
           ? "credits"
           : "onchain";
 
-    if (method === "coinflow" && !isCoinflowStarterpackSupported) return;
+    if (
+      method === "coinflow" &&
+      (!isUS || !isCoinflowEnabled || !isCoinflowStarterpackSupported)
+    ) {
+      return;
+    }
     if (method === "credits" && !hasSufficientCredits) {
       // Not enough credits — the CTA reads "Deposit USD": open the top-up
       // drawer and refresh the balance once the deposit lands.
@@ -520,7 +527,9 @@ export function OnchainCheckout() {
     hasSufficientBalance,
     isFree,
     isCoinflowSelected,
+    isCoinflowEnabled,
     isCoinflowStarterpackSupported,
+    isUS,
     isApplePaySelected,
     applePayLimitExceeded,
     fetchCoinbaseLimits,

--- a/packages/keychain/src/components/purchase/checkout/onchain/wallet-drawer.tsx
+++ b/packages/keychain/src/components/purchase/checkout/onchain/wallet-drawer.tsx
@@ -18,6 +18,7 @@ import { useAdvancedView, useFeature } from "@/hooks/features";
 import { useTripleClick } from "@/hooks/tripple-click";
 import { posthog } from "@/components/provider/posthog";
 import { captureAnalyticsEvent } from "@/types/analytics";
+import { useGeoLocation } from "@/hooks/geo";
 import { getWallet, networkWalletData } from "../../wallet/config";
 import { Network } from "../../types";
 
@@ -87,6 +88,7 @@ export function WalletSelectionDrawer({
   showCredits = false,
 }: WalletSelectionDrawerProps) {
   const isCoinflowEnabled = useFeature("coinflow-support");
+  const { isUS } = useGeoLocation();
   const advancedView = useAdvancedView();
 
   const handleIconTripleClick = useTripleClick({
@@ -393,7 +395,7 @@ export function WalletSelectionDrawer({
                 )}
               />
             )}
-            {showFiatOptions && isCoinflowEnabled && (
+            {showFiatOptions && isUS && isCoinflowEnabled && (
               <PurchaseCard
                 key="coinflow-checkout"
                 text="Credit Card"

--- a/packages/keychain/src/hooks/payments/coinflow.test.tsx
+++ b/packages/keychain/src/hooks/payments/coinflow.test.tsx
@@ -1,0 +1,145 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import useCoinflowPayment, {
+  useCoinflowCreditsPayment,
+  useCoinflowStarterpackQuote,
+} from "./coinflow";
+
+const mocks = vi.hoisted(() => ({
+  geo: {
+    countryCode: "US",
+    regionCode: "US-CA",
+    isUS: true,
+    countryCodeLoaded: true,
+    isLoading: false,
+    isError: false,
+    error: null,
+  },
+  createStarterpackIntent: vi.fn(),
+  createCreditsIntent: vi.fn(),
+  queryStarterpackQuote: vi.fn(),
+}));
+
+vi.mock("../connection", () => ({
+  useConnection: () => ({
+    controller: { username: () => "testuser" },
+    isMainnet: true,
+  }),
+}));
+
+vi.mock("../features", () => ({
+  useFeature: () => false,
+}));
+
+vi.mock("../geo", () => ({
+  useGeoLocation: () => mocks.geo,
+}));
+
+vi.mock("@/utils/graphql", () => ({
+  request: vi.fn(),
+}));
+
+vi.mock("@/utils/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/utils/api")>();
+  return {
+    ...actual,
+    useCreateCoinflowStarterpackIntentMutation: () => ({
+      mutateAsync: mocks.createStarterpackIntent,
+      isLoading: false,
+    }),
+    useCreateCoinflowCreditsIntentMutation: () => ({
+      mutateAsync: mocks.createCreditsIntent,
+      isLoading: false,
+    }),
+    useCoinflowStarterpackQuoteQuery: (...args: unknown[]) => {
+      mocks.queryStarterpackQuote(...args);
+      return { data: undefined, isLoading: false };
+    },
+  };
+});
+
+describe("Coinflow US availability", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.assign(mocks.geo, {
+      countryCode: "US",
+      regionCode: "US-CA",
+      isUS: true,
+      countryCodeLoaded: true,
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+    mocks.createStarterpackIntent.mockResolvedValue({
+      createCoinflowStarterpackIntent: { id: "payment-1" },
+    });
+    mocks.createCreditsIntent.mockResolvedValue({
+      createCoinflowCreditsIntent: { id: "payment-2" },
+    });
+  });
+
+  it("creates a starterpack card intent for a US user", async () => {
+    const { result } = renderHook(() => useCoinflowPayment());
+
+    await act(async () => {
+      await result.current.createIntent({
+        starterpackId: "1",
+        quantity: 1,
+        registryAddress: "0x123",
+      });
+    });
+
+    expect(mocks.createStarterpackIntent).toHaveBeenCalledOnce();
+  });
+
+  it("rejects starterpack and credits card intents outside the US", async () => {
+    Object.assign(mocks.geo, {
+      countryCode: "CA",
+      regionCode: "CA-ON",
+      isUS: false,
+    });
+    const starterpack = renderHook(() => useCoinflowPayment());
+    const credits = renderHook(() => useCoinflowCreditsPayment());
+
+    await act(async () => {
+      await expect(
+        starterpack.result.current.createIntent({
+          starterpackId: "1",
+          quantity: 1,
+          registryAddress: "0x123",
+        }),
+      ).rejects.toThrow(
+        "Credit card checkout is only available in the United States.",
+      );
+      await expect(
+        credits.result.current.createIntent({ amount: 10, decimals: 0 }),
+      ).rejects.toThrow(
+        "Credit card checkout is only available in the United States.",
+      );
+    });
+
+    expect(mocks.createStarterpackIntent).not.toHaveBeenCalled();
+    expect(mocks.createCreditsIntent).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch Coinflow quotes outside the US", () => {
+    Object.assign(mocks.geo, {
+      countryCode: "FR",
+      regionCode: null,
+      isUS: false,
+    });
+
+    renderHook(() =>
+      useCoinflowStarterpackQuote({
+        starterpackId: "1",
+        quantity: 1,
+        registryAddress: "0x123",
+      }),
+    );
+
+    expect(mocks.queryStarterpackQuote).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ enabled: false }),
+    );
+  });
+});

--- a/packages/keychain/src/hooks/payments/coinflow.ts
+++ b/packages/keychain/src/hooks/payments/coinflow.ts
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react";
 import { useConnection } from "../connection";
 import { useFeature } from "../features";
+import { useGeoLocation } from "../geo";
 import { request } from "@/utils/graphql";
 import {
   CoinflowPaymentDocument,
@@ -35,6 +36,9 @@ export type {
 // assignable to it.
 export type CoinflowIntent = Omit<CoinflowStarterpackIntent, "__typename">;
 
+const COINFLOW_US_ONLY_ERROR =
+  "Credit card checkout is only available in the United States.";
+
 /**
  * Effective network for everything Coinflow. Coinflow runs in its sandbox
  * (UAT) environment whenever this is false: on non-mainnet chains, or on any
@@ -54,6 +58,7 @@ export const useCoinflowIsMainnet = () => {
 
 const useCoinflowPayment = () => {
   const { controller } = useConnection();
+  const { isUS, countryCodeLoaded } = useGeoLocation();
   const [error, setError] = useState<Error | null>(null);
 
   const { isCoinflowMainnet } = useCoinflowIsMainnet();
@@ -71,6 +76,9 @@ const useCoinflowPayment = () => {
 
       try {
         setError(null);
+        if (!countryCodeLoaded || !isUS) {
+          throw new Error(COINFLOW_US_ONLY_ERROR);
+        }
 
         const result = await mutateAsync({
           input: {
@@ -85,7 +93,7 @@ const useCoinflowPayment = () => {
         throw e;
       }
     },
-    [controller, isCoinflowMainnet, mutateAsync],
+    [controller, countryCodeLoaded, isUS, isCoinflowMainnet, mutateAsync],
   );
 
   return {
@@ -111,6 +119,7 @@ export default useCoinflowPayment;
  */
 export const useCoinflowCreditsPayment = () => {
   const { controller } = useConnection();
+  const { isUS, countryCodeLoaded } = useGeoLocation();
   const [error, setError] = useState<Error | null>(null);
 
   const { isCoinflowMainnet } = useCoinflowIsMainnet();
@@ -125,6 +134,9 @@ export const useCoinflowCreditsPayment = () => {
 
       try {
         setError(null);
+        if (!countryCodeLoaded || !isUS) {
+          throw new Error(COINFLOW_US_ONLY_ERROR);
+        }
 
         const result = await mutateAsync({
           input: {
@@ -139,7 +151,7 @@ export const useCoinflowCreditsPayment = () => {
         throw e;
       }
     },
-    [controller, isCoinflowMainnet, mutateAsync],
+    [controller, countryCodeLoaded, isUS, isCoinflowMainnet, mutateAsync],
   );
 
   return {
@@ -224,10 +236,13 @@ export const useCoinflowStarterpackQuote = ({
   enabled = true,
 }: UseCoinflowStarterpackQuoteParams) => {
   const { controller } = useConnection();
+  const { isUS, countryCodeLoaded } = useGeoLocation();
   const { isCoinflowMainnet } = useCoinflowIsMainnet();
 
   const isReady =
     enabled &&
+    countryCodeLoaded &&
+    isUS &&
     !!controller &&
     !!starterpackId &&
     !!registryAddress &&

--- a/packages/keychain/src/utils/connection/connect.ts
+++ b/packages/keychain/src/utils/connection/connect.ts
@@ -8,7 +8,6 @@ import {
 } from "@cartridge/controller";
 import { SessionPolicies } from "@cartridge/presets";
 import { generateCallbackId, storeCallbacks, getCallbacks } from "./callbacks";
-import { createLocationGateUrl } from "./location-gate";
 import type { SemVer } from "semver";
 import gte from "semver/functions/gte";
 
@@ -179,7 +178,6 @@ export function parseConnectParams(searchParams: URLSearchParams): {
 export function connect({
   navigate,
   setRpcUrl,
-  getLocationGate,
   resetLocationGateVerified,
 }: {
   navigate: (
@@ -256,20 +254,9 @@ export function connect({
           reject,
         });
 
-        const locationGate = getLocationGate?.();
-        const hasLocationGate =
-          !!locationGate &&
-          ((locationGate.allowed?.length ?? 0) > 0 ||
-            (locationGate.blocked?.length ?? 0) > 0);
-
-        const destination = hasLocationGate
-          ? createLocationGateUrl({
-              returnTo: url,
-              gate: locationGate!,
-            })
-          : url;
-
-        navigate(destination, { replace: true });
+        // Authentication must complete before ConnectRoute redirects an
+        // authenticated controller to the configured location gate.
+        navigate(url, { replace: true });
       });
     };
   };

--- a/packages/keychain/src/utils/connection/headless.test.ts
+++ b/packages/keychain/src/utils/connection/headless.test.ts
@@ -6,6 +6,7 @@ const mockGenerateStarknetKeypair = vi.fn();
 const mockEncryptPrivateKey = vi.fn();
 const mockComputeAccountAddress = vi.fn();
 const mockControllerLogin = vi.fn();
+const mockGetIpLocation = vi.fn();
 
 vi.mock("@/components/connect/create/utils", () => ({
   fetchController: (...args: unknown[]) => mockFetchController(...args),
@@ -47,9 +48,44 @@ vi.mock("@/utils/controller", () => ({
   },
 }));
 
+vi.mock("@/utils/ip", () => ({
+  getIpLocation: () => mockGetIpLocation(),
+}));
+
 describe("headless connect auto-signup", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetIpLocation.mockResolvedValue({
+      countryCode: "CA",
+      regionCode: "CA-ON",
+    });
+  });
+
+  it("requires the GPS-capable UI flow for a US headless user", async () => {
+    mockGetIpLocation.mockResolvedValue({
+      countryCode: "US",
+      regionCode: "US-CA",
+    });
+    const { headlessConnect } = await import("./headless");
+    const connect = headlessConnect({
+      setController: vi.fn(),
+      getParent: vi.fn(() => undefined),
+      getConnectionState: () => ({
+        rpcUrl: "https://rpc.example",
+        isPoliciesResolved: true,
+        isConfigLoading: false,
+      }),
+      getLocationGate: () => ({ blocked: ["US-NY"] }),
+    })("https://game.example");
+
+    await expect(
+      connect({ username: "alice", signer: "password", password: "pw" }),
+    ).resolves.toEqual({
+      code: ResponseCodes.ERROR,
+      message:
+        "Location verification is required. Use the UI connect flow instead.",
+    });
+    expect(mockControllerLogin).not.toHaveBeenCalled();
   });
 
   it("creates a new password account when username does not exist", async () => {
@@ -95,6 +131,7 @@ describe("headless connect auto-signup", () => {
       setController,
       getParent,
       getConnectionState,
+      getLocationGate: () => ({ blocked: ["US-NY"] }),
     })("https://game.example");
 
     const result = await connect({
@@ -115,5 +152,6 @@ describe("headless connect auto-signup", () => {
     );
     expect(mockController.register).toHaveBeenCalled();
     expect(setController).toHaveBeenCalledWith(mockController);
+    expect(mockGetIpLocation).toHaveBeenCalledOnce();
   });
 });

--- a/packages/keychain/src/utils/connection/headless.ts
+++ b/packages/keychain/src/utils/connection/headless.ts
@@ -40,6 +40,7 @@ import {
   requiresSessionApproval,
 } from "./session-creation";
 import { hasConfiguredLocationGate } from "@/utils/location-gate";
+import { getIpLocation } from "@/utils/ip";
 
 export type HeadlessConnectionState = {
   origin?: string;
@@ -666,14 +667,17 @@ export const headlessConnect =
       };
     }
 
-    // Headless connect cannot show the location gate UI, so reject when
-    // a location gate is configured.
+    // Location gating is US-only. Headless connect cannot request GPS, so US
+    // users must switch to the UI flow while confirmed non-US users continue.
     if (hasConfiguredLocationGate(getLocationGate?.())) {
-      return {
-        code: ResponseCodes.ERROR,
-        message:
-          "Location verification is required. Use the UI connect flow instead.",
-      };
+      const { countryCode } = await getIpLocation();
+      if (countryCode === "US") {
+        return {
+          code: ResponseCodes.ERROR,
+          message:
+            "Location verification is required. Use the UI connect flow instead.",
+        };
+      }
     }
 
     const state = await waitForConnectionReady(getConnectionState);


### PR DESCRIPTION
## Summary
- Run GPS location verification only after authentication, require GPS without IP fallback, and silently verify previously granted browser permission.
- Enable configured GPS geofencing only for users whose shared IP-country lookup resolves to the U.S.; non-U.S. UI and headless connections skip the gate.
- Limit Coinflow credit-card visibility, quotes, starterpack intents, and credits intents to U.S. users.

## Validation
- `pnpm format`
- `pnpm --filter @cartridge/keychain lint`
- `pnpm --filter @cartridge/keychain format:check`
- `pnpm test:ci`
- `pnpm keychain build`