### PR TITLE
fix(keychain): improve location permission recovery

### DIFF
--- a/packages/keychain/src/components/location/LocationGate.test.tsx
+++ b/packages/keychain/src/components/location/LocationGate.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { LocationGateOptions } from "@cartridge/controller";
 import { connect } from "@/utils/connection/connect";
 import { LocationGate } from "./LocationGate";
 
@@ -21,7 +22,7 @@ vi.mock("@/hooks/connection", () => ({
 }));
 
 vi.mock("@/components/ErrorAlert", () => ({
-  ErrorAlert: ({ description }: { description: string }) => (
+  ErrorAlert: ({ description }: { description: React.ReactNode }) => (
     <div>{description}</div>
   ),
 }));
@@ -60,15 +61,19 @@ vi.mock("@cartridge/presets", () => ({
 }));
 
 vi.mock("./USMap", () => ({
-  USMap: () => <div data-testid="us-map" />,
+  USMap: ({ supportedStates }: { supportedStates: string[] }) => (
+    <div
+      data-testid="us-map"
+      data-supported-states={supportedStates.join(",")}
+    />
+  ),
 }));
 
-const route = `/location-gate?${new URLSearchParams({
-  returnTo: "/connect?id=connect-1",
-  gate: JSON.stringify({ blocked: ["US-NY"] }),
-})}`;
-
-function renderGate() {
+function renderGate(gate: LocationGateOptions = { blocked: ["US-NY"] }) {
+  const route = `/location-gate?${new URLSearchParams({
+    returnTo: "/connect?id=connect-1",
+    gate: JSON.stringify(gate),
+  })}`;
   return render(
     <MemoryRouter initialEntries={[route]}>
       <LocationGate />
@@ -88,7 +93,20 @@ describe("LocationGate", () => {
       configurable: true,
       value: { query: mocks.queryPermission },
     });
+    Object.defineProperty(navigator, "userAgent", {
+      configurable: true,
+      value: "Mozilla/5.0 AppleWebKit/537.36 Chrome/126.0.0.0 Safari/537.36",
+    });
     mocks.queryPermission.mockResolvedValue({ state: "prompt" });
+  });
+
+  it("shows a map of the supported states on the verification screen", async () => {
+    renderGate({ allowed: ["US-CA", "US-TX"], blocked: ["US-TX"] });
+
+    expect(await screen.findByTestId("us-map")).toHaveAttribute(
+      "data-supported-states",
+      "US-CA",
+    );
   });
 
   it("requests browser geolocation after the user continues", async () => {
@@ -135,6 +153,10 @@ describe("LocationGate", () => {
   });
 
   it("does not pass when browser geolocation permission is denied", async () => {
+    Object.defineProperty(navigator, "userAgent", {
+      configurable: true,
+      value: "Mozilla/5.0 Firefox/128.0",
+    });
     renderGate();
     fireEvent.click(await screen.findByRole("button", { name: "CONTINUE" }));
 
@@ -144,6 +166,19 @@ describe("LocationGate", () => {
     expect(
       await screen.findByText("Location permission was denied."),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", {
+        name: "Learn how to enable location in Firefox.",
+      }),
+    ).toHaveAttribute(
+      "href",
+      "https://support.mozilla.org/en-US/kb/does-firefox-share-my-location-websites",
+    );
+    expect(screen.getByRole("link")).toHaveAttribute("target", "_blank");
+    expect(screen.getByRole("link")).toHaveAttribute(
+      "rel",
+      "noopener noreferrer",
+    );
     expect(mocks.setLocationGateVerified).not.toHaveBeenCalled();
   });
 

--- a/packages/keychain/src/components/location/LocationGate.tsx
+++ b/packages/keychain/src/components/location/LocationGate.tsx
@@ -17,6 +17,7 @@ import {
   reverseGeocodeLocation,
 } from "@/utils/location-gate";
 import { USMap } from "./USMap";
+import { STATE_PATHS } from "./us-state-paths";
 
 type GateState = "checking" | "idle" | "requesting" | "blocked";
 
@@ -34,6 +35,42 @@ function errorResponse(gameName: string) {
   return {
     code: ResponseCodes.ERROR,
     message: `${gameName} is not available in your region.`,
+  };
+}
+
+type BrowserHelp = {
+  name: string;
+  url: string;
+};
+
+function getLocationPermissionHelp(userAgent: string): BrowserHelp {
+  if (/Edg\//i.test(userAgent)) {
+    return {
+      name: "Microsoft Edge",
+      url: "https://support.microsoft.com/en-us/microsoft-edge/location-and-privacy-in-microsoft-edge-31b5d154-0b1b-90ef-e389-7c7d4ffe7b04",
+    };
+  }
+  if (/Firefox|FxiOS/i.test(userAgent)) {
+    return {
+      name: "Firefox",
+      url: "https://support.mozilla.org/en-US/kb/does-firefox-share-my-location-websites",
+    };
+  }
+  if (/Chrome|CriOS|Chromium/i.test(userAgent)) {
+    return {
+      name: "Chrome",
+      url: "https://support.google.com/chrome/answer/142065?hl=en",
+    };
+  }
+  if (/Safari/i.test(userAgent)) {
+    return {
+      name: "Safari",
+      url: "https://support.apple.com/guide/safari/customize-settings-per-website-ibrw7f78f7fe/mac",
+    };
+  }
+  return {
+    name: "your browser",
+    url: "https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API#security_considerations",
   };
 }
 
@@ -227,10 +264,32 @@ export function LocationGate() {
   const gameName =
     theme.name && theme.name !== defaultTheme.name ? theme.name : "This game";
 
-  const blockedUSStates = useMemo(() => {
-    if (!gate?.blocked) return [];
-    return gate.blocked.filter((code) => code.toUpperCase().startsWith("US-"));
+  const supportedUSStates = useMemo(() => {
+    const allStates = Object.keys(STATE_PATHS);
+    const allowed = new Set(
+      (gate?.allowed ?? []).map((code) => code.trim().toUpperCase()),
+    );
+    const blocked = new Set(
+      (gate?.blocked ?? []).map((code) => code.trim().toUpperCase()),
+    );
+    const hasAllowlist = allowed.size > 0;
+    const supportsAllUSStates = !hasAllowlist || allowed.has("US");
+
+    if (blocked.has("US")) return [];
+
+    return allStates.filter(
+      (state) =>
+        (supportsAllUSStates || allowed.has(state)) && !blocked.has(state),
+    );
   }, [gate]);
+
+  const permissionHelp = useMemo(
+    () =>
+      getLocationPermissionHelp(
+        typeof navigator === "undefined" ? "" : navigator.userAgent,
+      ),
+    [],
+  );
 
   if (!gate || state === "checking") {
     return null;
@@ -244,11 +303,9 @@ export function LocationGate() {
           icon={<GlobeIcon variant="solid" size="lg" />}
         />
         <LayoutContent className="p-4">
-          {blockedUSStates.length > 0 && (
-            <div className="mb-3">
-              <USMap blockedStates={blockedUSStates} />
-            </div>
-          )}
+          <div className="mb-3">
+            <USMap supportedStates={supportedUSStates} />
+          </div>
           <p className="text-sm text-foreground-300 leading-relaxed">
             {gameName} is not available in your region.
           </p>
@@ -273,16 +330,34 @@ export function LocationGate() {
         icon={<GlobeIcon variant="solid" size="lg" />}
       />
       <LayoutContent className="p-4 gap-3">
-        {blockedUSStates.length > 0 && (
-          <USMap blockedStates={blockedUSStates} />
-        )}
+        <USMap supportedStates={supportedUSStates} />
         <p className="text-sm text-foreground-300 leading-relaxed">
           {gameName} needs your location to confirm availability in your region.
         </p>
       </LayoutContent>
       <LayoutFooter>
         {error && (
-          <ErrorAlert title="Error" description={error} isExpanded={true} />
+          <ErrorAlert
+            title="Error"
+            description={
+              error === "Location permission was denied." ? (
+                <>
+                  <span>{error} </span>
+                  <a
+                    href={permissionHelp.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline"
+                  >
+                    Learn how to enable location in {permissionHelp.name}.
+                  </a>
+                </>
+              ) : (
+                error
+              )
+            }
+            isExpanded={true}
+          />
         )}
         <Button
           variant="primary"

--- a/packages/keychain/src/components/location/LocationGate.tsx
+++ b/packages/keychain/src/components/location/LocationGate.tsx
@@ -16,8 +16,8 @@ import {
   evaluateLocationGate,
   reverseGeocodeLocation,
 } from "@/utils/location-gate";
+import { getLocationPermissionHelp, getSupportedUSStates } from "./location-ui";
 import { USMap } from "./USMap";
-import { STATE_PATHS } from "./us-state-paths";
 
 type GateState = "checking" | "idle" | "requesting" | "blocked";
 
@@ -35,42 +35,6 @@ function errorResponse(gameName: string) {
   return {
     code: ResponseCodes.ERROR,
     message: `${gameName} is not available in your region.`,
-  };
-}
-
-type BrowserHelp = {
-  name: string;
-  url: string;
-};
-
-function getLocationPermissionHelp(userAgent: string): BrowserHelp {
-  if (/Edg\//i.test(userAgent)) {
-    return {
-      name: "Microsoft Edge",
-      url: "https://support.microsoft.com/en-us/microsoft-edge/location-and-privacy-in-microsoft-edge-31b5d154-0b1b-90ef-e389-7c7d4ffe7b04",
-    };
-  }
-  if (/Firefox|FxiOS/i.test(userAgent)) {
-    return {
-      name: "Firefox",
-      url: "https://support.mozilla.org/en-US/kb/does-firefox-share-my-location-websites",
-    };
-  }
-  if (/Chrome|CriOS|Chromium/i.test(userAgent)) {
-    return {
-      name: "Chrome",
-      url: "https://support.google.com/chrome/answer/142065?hl=en",
-    };
-  }
-  if (/Safari/i.test(userAgent)) {
-    return {
-      name: "Safari",
-      url: "https://support.apple.com/guide/safari/customize-settings-per-website-ibrw7f78f7fe/mac",
-    };
-  }
-  return {
-    name: "your browser",
-    url: "https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API#security_considerations",
   };
 }
 
@@ -264,24 +228,7 @@ export function LocationGate() {
   const gameName =
     theme.name && theme.name !== defaultTheme.name ? theme.name : "This game";
 
-  const supportedUSStates = useMemo(() => {
-    const allStates = Object.keys(STATE_PATHS);
-    const allowed = new Set(
-      (gate?.allowed ?? []).map((code) => code.trim().toUpperCase()),
-    );
-    const blocked = new Set(
-      (gate?.blocked ?? []).map((code) => code.trim().toUpperCase()),
-    );
-    const hasAllowlist = allowed.size > 0;
-    const supportsAllUSStates = !hasAllowlist || allowed.has("US");
-
-    if (blocked.has("US")) return [];
-
-    return allStates.filter(
-      (state) =>
-        (supportsAllUSStates || allowed.has(state)) && !blocked.has(state),
-    );
-  }, [gate]);
+  const supportedUSStates = useMemo(() => getSupportedUSStates(gate), [gate]);
 
   const permissionHelp = useMemo(
     () =>

--- a/packages/keychain/src/components/location/LocationPrompt.test.tsx
+++ b/packages/keychain/src/components/location/LocationPrompt.test.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { act } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { LocationPrompt } from "./LocationPrompt";
+
+const mocks = vi.hoisted(() => ({
+  cancelWithoutClosing: vi.fn(),
+  getCurrentPosition: vi.fn(),
+  handleCompletion: vi.fn(),
+  setShowClose: vi.fn(),
+}));
+
+vi.mock("@/hooks/connection", () => ({
+  useConnection: () => ({
+    locationGate: { allowed: ["US-CA", "US-TX"], blocked: ["US-TX"] },
+  }),
+}));
+
+vi.mock("@/hooks/route", () => ({
+  useRouteCallbacks: () => ({
+    cancelWithoutClosing: mocks.cancelWithoutClosing,
+  }),
+  useRouteCompletion: () => mocks.handleCompletion,
+  useRouteParams: () => ({
+    params: { id: "location-1" },
+    resolve: vi.fn(),
+  }),
+}));
+
+vi.mock("@/context", () => ({
+  useNavigation: () => ({ setShowClose: mocks.setShowClose }),
+}));
+
+vi.mock("@/components/ErrorAlert", () => ({
+  ErrorAlert: ({ description }: { description: React.ReactNode }) => (
+    <div>{description}</div>
+  ),
+}));
+
+vi.mock("@cartridge/controller-ui", () => ({
+  Button: (
+    props: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+      isLoading?: boolean;
+    },
+  ) => {
+    const { children, isLoading, ...buttonProps } = props;
+    void isLoading;
+    return <button {...buttonProps}>{children}</button>;
+  },
+  GlobeIcon: () => <span />,
+  HeaderInner: ({ title }: { title: string }) => <h1>{title}</h1>,
+  LayoutContent: ({ children }: React.PropsWithChildren) => (
+    <main>{children}</main>
+  ),
+  LayoutFooter: ({ children }: React.PropsWithChildren) => (
+    <footer>{children}</footer>
+  ),
+}));
+
+vi.mock("./USMap", () => ({
+  USMap: ({ supportedStates }: { supportedStates: string[] }) => (
+    <div
+      data-testid="us-map"
+      data-supported-states={supportedStates.join(",")}
+    />
+  ),
+}));
+
+describe("LocationPrompt", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(navigator, "geolocation", {
+      configurable: true,
+      value: { getCurrentPosition: mocks.getCurrentPosition },
+    });
+    Object.defineProperty(navigator, "userAgent", {
+      configurable: true,
+      value: "Mozilla/5.0 Firefox/128.0",
+    });
+  });
+
+  it("shows the supported-states map on the verification screen", () => {
+    render(<LocationPrompt />);
+
+    expect(screen.getByText("Location Verification")).toBeInTheDocument();
+    expect(screen.getByTestId("us-map")).toHaveAttribute(
+      "data-supported-states",
+      "US-CA",
+    );
+  });
+
+  it("links to browser help when location permission is denied", async () => {
+    render(<LocationPrompt />);
+
+    fireEvent.click(screen.getByRole("button", { name: "CONTINUE" }));
+    const onError = mocks.getCurrentPosition.mock.calls[0][1];
+    act(() => onError({ code: 1, message: "Permission denied" }));
+
+    expect(
+      await screen.findByRole("link", {
+        name: "Learn how to enable location in Firefox.",
+      }),
+    ).toHaveAttribute(
+      "href",
+      "https://support.mozilla.org/en-US/kb/does-firefox-share-my-location-websites",
+    );
+  });
+});

--- a/packages/keychain/src/components/location/LocationPrompt.tsx
+++ b/packages/keychain/src/components/location/LocationPrompt.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Button,
   GlobeIcon,
@@ -16,6 +16,9 @@ import {
 import { cleanupCallbacks } from "@/utils/connection/callbacks";
 import { parseLocationPromptParams } from "@/utils/connection/location";
 import { useNavigation } from "@/context";
+import { useConnection } from "@/hooks/connection";
+import { getLocationPermissionHelp, getSupportedUSStates } from "./location-ui";
+import { USMap } from "./USMap";
 
 const CANCEL_RESPONSE = {
   code: ResponseCodes.CANCELED,
@@ -29,8 +32,21 @@ export function LocationPrompt() {
   const handleCompletion = useRouteCompletion();
   const { cancelWithoutClosing } = useRouteCallbacks(params, CANCEL_RESPONSE);
   const { setShowClose } = useNavigation();
+  const { locationGate } = useConnection();
   const [state, setState] = useState<LocationState>("idle");
   const [error, setError] = useState<string | null>(null);
+
+  const supportedUSStates = useMemo(
+    () => getSupportedUSStates(locationGate),
+    [locationGate],
+  );
+  const permissionHelp = useMemo(
+    () =>
+      getLocationPermissionHelp(
+        typeof navigator === "undefined" ? "" : navigator.userAgent,
+      ),
+    [],
+  );
 
   useEffect(() => {
     setShowClose(true);
@@ -100,7 +116,8 @@ export function LocationPrompt() {
         title="Location Verification"
         icon={<GlobeIcon variant="solid" size="lg" />}
       />
-      <LayoutContent className="p-4">
+      <LayoutContent className="p-4 gap-3">
+        <USMap supportedStates={supportedUSStates} />
         <p className="text-sm text-foreground-300 leading-relaxed">
           This game needs your location to verify eligibility. We'll share your
           location with the game to complete verification.
@@ -108,7 +125,27 @@ export function LocationPrompt() {
       </LayoutContent>
       <LayoutFooter>
         {error && (
-          <ErrorAlert title="Error" description={error} isExpanded={true} />
+          <ErrorAlert
+            title="Error"
+            description={
+              error === "Location permission was denied." ? (
+                <>
+                  <span>{error} </span>
+                  <a
+                    href={permissionHelp.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline"
+                  >
+                    Learn how to enable location in {permissionHelp.name}.
+                  </a>
+                </>
+              ) : (
+                error
+              )
+            }
+            isExpanded={true}
+          />
         )}
         <Button
           variant="primary"

--- a/packages/keychain/src/components/location/USMap.tsx
+++ b/packages/keychain/src/components/location/USMap.tsx
@@ -2,14 +2,14 @@ import { useMemo } from "react";
 import { STATE_PATHS } from "./us-state-paths";
 
 type USMapProps = {
-  /** Region codes to highlight as blocked, e.g. ["US-HI", "US-NY"] */
-  blockedStates: string[];
+  /** Region codes to highlight as supported, e.g. ["US-CA", "US-TX"] */
+  supportedStates: string[];
 };
 
-export function USMap({ blockedStates }: USMapProps) {
-  const blockedSet = useMemo(
-    () => new Set(blockedStates.map((s) => s.toUpperCase())),
-    [blockedStates],
+export function USMap({ supportedStates }: USMapProps) {
+  const supportedSet = useMemo(
+    () => new Set(supportedStates.map((state) => state.toUpperCase())),
+    [supportedStates],
   );
 
   return (
@@ -29,18 +29,18 @@ export function USMap({ blockedStates }: USMapProps) {
         xmlns="http://www.w3.org/2000/svg"
         className="w-full"
         role="img"
-        aria-label="Map of the United States showing restricted states"
+        aria-label="Map of supported states in the United States"
       >
         {Object.entries(STATE_PATHS).map(([code, d]) => {
-          const isBlocked = blockedSet.has(code);
+          const isSupported = supportedSet.has(code);
           return (
             <path
               key={code}
               d={d}
               className={
-                isBlocked
-                  ? "fill-background-200 stroke-background"
-                  : "fill-primary-100 stroke-background"
+                isSupported
+                  ? "fill-primary-100 stroke-background"
+                  : "fill-background-200 stroke-background"
               }
               strokeWidth={0.7}
               strokeLinejoin="round"

--- a/packages/keychain/src/components/location/location-ui.ts
+++ b/packages/keychain/src/components/location/location-ui.ts
@@ -1,0 +1,59 @@
+import type { LocationGateOptions } from "@cartridge/controller";
+import { STATE_PATHS } from "./us-state-paths";
+
+export function getSupportedUSStates(
+  gate?: LocationGateOptions | null,
+): string[] {
+  const allStates = Object.keys(STATE_PATHS);
+  const allowed = new Set(
+    (gate?.allowed ?? []).map((code) => code.trim().toUpperCase()),
+  );
+  const blocked = new Set(
+    (gate?.blocked ?? []).map((code) => code.trim().toUpperCase()),
+  );
+  const hasAllowlist = allowed.size > 0;
+  const supportsAllUSStates = !hasAllowlist || allowed.has("US");
+
+  if (blocked.has("US")) return [];
+
+  return allStates.filter(
+    (state) =>
+      (supportsAllUSStates || allowed.has(state)) && !blocked.has(state),
+  );
+}
+
+type BrowserHelp = {
+  name: string;
+  url: string;
+};
+
+export function getLocationPermissionHelp(userAgent: string): BrowserHelp {
+  if (/Edg\//i.test(userAgent)) {
+    return {
+      name: "Microsoft Edge",
+      url: "https://support.microsoft.com/en-us/microsoft-edge/location-and-privacy-in-microsoft-edge-31b5d154-0b1b-90ef-e389-7c7d4ffe7b04",
+    };
+  }
+  if (/Firefox|FxiOS/i.test(userAgent)) {
+    return {
+      name: "Firefox",
+      url: "https://support.mozilla.org/en-US/kb/does-firefox-share-my-location-websites",
+    };
+  }
+  if (/Chrome|CriOS|Chromium/i.test(userAgent)) {
+    return {
+      name: "Chrome",
+      url: "https://support.google.com/chrome/answer/142065?hl=en",
+    };
+  }
+  if (/Safari/i.test(userAgent)) {
+    return {
+      name: "Safari",
+      url: "https://support.apple.com/guide/safari/customize-settings-per-website-ibrw7f78f7fe/mac",
+    };
+  }
+  return {
+    name: "your browser",
+    url: "https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API#security_considerations",
+  };
+}


### PR DESCRIPTION
## Summary
- Add official browser-specific help links when GPS permission is denied.
- Always display the U.S. supported-states map during location verification.
- Derive supported states correctly from allowlists and blocklists, with blocked rules taking precedence.

## Validation
- `pnpm test:ci`
- `pnpm keychain build`
- keychain lint, formatting, and TypeScript checks