### PR TITLE
fix: harden Coinflow purchase gates

### DIFF
--- a/packages/keychain/src/components/credits/CoinflowCreditsCheckout.tsx
+++ b/packages/keychain/src/components/credits/CoinflowCreditsCheckout.tsx
@@ -32,7 +32,7 @@ interface CoinflowCreditsCheckoutProps {
 }
 
 /**
- * Credits checkout for the Coinflow (card) rail: review → verify (email) → pay.
+ * Credits checkout for the Coinflow (card) rail: review → pay.
  * The intent is created up front so the review can show the real total (incl.
  * fees) and surface any quote error; the same intent is reused by the
  * CoinflowDrawer in the pay phase.

--- a/packages/keychain/src/components/credits/useFiatCheckoutFlow.test.tsx
+++ b/packages/keychain/src/components/credits/useFiatCheckoutFlow.test.tsx
@@ -1,0 +1,51 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useFiatCheckoutFlow } from "./useFiatCheckoutFlow";
+
+const mocks = vi.hoisted(() => ({
+  identity: {
+    isEmailVerified: false,
+    isPhoneNumberVerified: false,
+    initiateEmailVerification: vi.fn(),
+    initiatePhoneNumberVerification: vi.fn(),
+    isVerifying: false,
+    isCanceled: false,
+  },
+}));
+
+vi.mock("@/components/identity/provider", () => ({
+  useIdentityContext: () => mocks.identity,
+}));
+
+describe("useFiatCheckoutFlow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.identity.isEmailVerified = false;
+    mocks.identity.isPhoneNumberVerified = false;
+    mocks.identity.isVerifying = false;
+    mocks.identity.isCanceled = false;
+  });
+
+  it("does not require email verification for Coinflow card purchases", () => {
+    const { result } = renderHook(() =>
+      useFiatCheckoutFlow({ method: "coinflow" }),
+    );
+
+    act(() => result.current.handleContinue());
+
+    expect(result.current.phase).toBe("pay");
+    expect(result.current.verifying).toBe(false);
+    expect(mocks.identity.initiateEmailVerification).not.toHaveBeenCalled();
+  });
+
+  it("keeps email and phone verification for Apple Pay", () => {
+    const { result } = renderHook(() =>
+      useFiatCheckoutFlow({ method: "apple-pay" }),
+    );
+
+    act(() => result.current.handleContinue());
+
+    expect(result.current.verifying).toBe(true);
+    expect(mocks.identity.initiateEmailVerification).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/keychain/src/components/credits/useFiatCheckoutFlow.tsx
+++ b/packages/keychain/src/components/credits/useFiatCheckoutFlow.tsx
@@ -3,14 +3,13 @@ import { useIdentityContext } from "@/components/identity/provider";
 
 /**
  * Drives the fiat (Apple Pay / card) credits checkout: review → [continue]
- * verify-if-needed → pay. Verification is required by the rail, not the product
- * — Coinflow needs a verified email; Apple Pay additionally needs a verified
- * phone — and happens *after* the checkout-details review, gated by continue.
+ * verify-if-needed → pay. Apple Pay requires a verified email and phone;
+ * Coinflow card purchases do not require contact verification.
  *
  * Rather than the shared Verification component (which, for "apple-pay", also
  * forces identity and fires a single combined onSuccess), we orchestrate the
- * required steps explicitly against the identity context: open email, then (for
- * Apple Pay) phone, then advance. The identity drawers themselves are rendered
+ * Apple Pay steps explicitly against the identity context: open email, then
+ * phone, then advance. The identity drawers themselves are rendered
  * by IdentityProvider; we just sequence which one opens.
  */
 export function useFiatCheckoutFlow({
@@ -27,7 +26,7 @@ export function useFiatCheckoutFlow({
     isCanceled,
   } = useIdentityContext();
 
-  const needsEmail = !isEmailVerified;
+  const needsEmail = method === "apple-pay" && !isEmailVerified;
   const needsPhone = method === "apple-pay" && !isPhoneNumberVerified;
   const needsVerification = needsEmail || needsPhone;
 

--- a/packages/keychain/src/components/identity/VerifyIdentityDrawer.test.tsx
+++ b/packages/keychain/src/components/identity/VerifyIdentityDrawer.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { VerifyIdentityDrawer } from "./VerifyIdentityDrawer";
+
+const mocks = vi.hoisted(() => ({
+  verifyAsync: vi.fn(),
+}));
+
+vi.mock("@/utils/api", () => ({
+  useAccountVerifyMutation: () => ({
+    mutateAsync: mocks.verifyAsync,
+    isLoading: false,
+    isError: false,
+    error: null,
+  }),
+}));
+
+vi.mock("@cartridge/controller-ui", () => ({
+  Button: (
+    props: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+      isLoading?: boolean;
+    },
+  ) => {
+    const { isLoading, ...buttonProps } = props;
+    void isLoading;
+    return <button {...buttonProps} />;
+  },
+  DateSelect: () => null,
+  Drawer: ({
+    isOpen,
+    children,
+  }: React.PropsWithChildren<{ isOpen: boolean }>) =>
+    isOpen ? <div>{children}</div> : null,
+  DrawerContent: ({ children }: React.PropsWithChildren) => (
+    <div>{children}</div>
+  ),
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => (
+    <input {...props} />
+  ),
+  UserIcon: () => null,
+  isValidCalendarDate: () => true,
+}));
+
+vi.mock("./error", () => ({
+  VerifyErrorAlert: ({ error }: { error: string }) => <div>{error}</div>,
+}));
+
+describe("VerifyIdentityDrawer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.verifyAsync.mockResolvedValue({ accountVerify: true });
+  });
+
+  it("does not report cancellation after successful Prove verification", async () => {
+    let finishRefresh: (() => void) | undefined;
+    const refresh = new Promise<void>((resolve) => {
+      finishRefresh = resolve;
+    });
+    const onVerified = vi.fn(() => refresh);
+    const onClose = vi.fn();
+
+    render(
+      <VerifyIdentityDrawer isOpen onClose={onClose} onVerified={onVerified} />,
+    );
+
+    fireEvent.change(screen.getByLabelText("First Name"), {
+      target: { value: "Ada" },
+    });
+    fireEvent.change(screen.getByLabelText("Last Name"), {
+      target: { value: "Lovelace" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    await waitFor(() => expect(onVerified).toHaveBeenCalledWith(true));
+    expect(onClose).not.toHaveBeenCalled();
+
+    finishRefresh?.();
+    await refresh;
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/packages/keychain/src/components/identity/VerifyIdentityDrawer.tsx
+++ b/packages/keychain/src/components/identity/VerifyIdentityDrawer.tsx
@@ -15,7 +15,7 @@ import { VerifyErrorAlert } from "./error";
 interface VerifyIdentityDrawerProps {
   isOpen: boolean;
   onClose: () => void;
-  onVerified: (result: boolean) => void;
+  onVerified: (result: boolean) => void | Promise<void>;
 }
 
 export function VerifyIdentityDrawer({
@@ -69,12 +69,14 @@ export function VerifyIdentityDrawer({
         setError("Account verification failed");
         return;
       }
-      onVerified(true);
-      onClose();
+      // The owner closes the drawer after it refreshes verified user data.
+      // Calling onClose here reports a cancellation and can discard the
+      // purchase/deposit that is waiting for Prove to finish.
+      await onVerified(true);
     } catch (err) {
       console.error("verifyAsync error:", (err as Error).message);
     }
-  }, [verifyAsync, firstName, lastName, dob, onVerified, onClose]);
+  }, [verifyAsync, firstName, lastName, dob, onVerified]);
 
   return (
     <Drawer isOpen={isOpen} onClose={onClose}>

--- a/packages/keychain/src/components/location/LocationGate.test.tsx
+++ b/packages/keychain/src/components/location/LocationGate.test.tsx
@@ -7,6 +7,7 @@ import { LocationGate } from "./LocationGate";
 
 const mocks = vi.hoisted(() => ({
   onExit: vi.fn(),
+  onVerified: vi.fn(),
   getCurrentPosition: vi.fn(),
   queryPermission: vi.fn(),
   reverseGeocodeLocation: vi.fn(),
@@ -76,7 +77,13 @@ vi.mock("./USMap", () => ({
 }));
 
 function renderGate(gate: LocationGateOptions = { blocked: ["US-NY"] }) {
-  return render(<LocationGate gate={gate} onExit={mocks.onExit} />);
+  return render(
+    <LocationGate
+      gate={gate}
+      onExit={mocks.onExit}
+      onVerified={mocks.onVerified}
+    />,
+  );
 }
 
 describe("LocationGate", () => {
@@ -153,6 +160,7 @@ describe("LocationGate", () => {
     await waitFor(() => {
       expect(mocks.setLocationGateVerified).toHaveBeenCalledWith(true);
     });
+    expect(mocks.onVerified).toHaveBeenCalledOnce();
     expect(mocks.reverseGeocodeLocation).toHaveBeenCalledWith(
       expect.objectContaining({ latitude: 34.05, longitude: -118.24 }),
     );
@@ -242,6 +250,9 @@ describe("LocationGate", () => {
 
     expect(
       await screen.findByText("Location Verification"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Location permission was denied."),
     ).toBeInTheDocument();
     expect(mocks.getCurrentPosition).not.toHaveBeenCalled();
     expect(mocks.setLocationGateVerified).not.toHaveBeenCalled();

--- a/packages/keychain/src/components/location/LocationGate.tsx
+++ b/packages/keychain/src/components/location/LocationGate.tsx
@@ -56,9 +56,11 @@ function errorResponse(gameName: string): LocationGateResponse {
 export function LocationGate({
   gate,
   onExit,
+  onVerified,
 }: {
   gate: LocationGateOptions;
   onExit: (response: LocationGateResponse) => void;
+  onVerified?: () => void;
 }) {
   const { setLocationGateVerified, theme } = useConnection();
   const { setShowClose } = useNavigation();
@@ -82,8 +84,9 @@ export function LocationGate({
       }
 
       setLocationGateVerified(true);
+      onVerified?.();
     },
-    [gate, setLocationGateVerified],
+    [gate, onVerified, setLocationGateVerified],
   );
 
   const handleLocationError = useCallback(
@@ -155,6 +158,9 @@ export function LocationGate({
           requestLocation(true);
         } else {
           setState("idle");
+          if (permission.state === "denied") {
+            setError("Location permission was denied.");
+          }
         }
       })
       .catch(showPrompt);

--- a/packages/keychain/src/components/purchase/checkout/onchain/index.tsx
+++ b/packages/keychain/src/components/purchase/checkout/onchain/index.tsx
@@ -62,6 +62,7 @@ import {
   CreditsBalancePendingError,
   waitForCreditsBalance,
 } from "@/utils/credits-settlement";
+import { usePurchaseLocationGate } from "@/components/purchase/usePurchaseLocationGate";
 
 export function OnchainCheckout() {
   const advancedView = useAdvancedView();
@@ -149,10 +150,11 @@ export function OnchainCheckout() {
   const [isCoinflowDrawerOpen, setIsCoinflowDrawerOpen] = useState(false);
   const [isCoinbaseDrawerOpen, setIsCoinbaseDrawerOpen] = useState(false);
   const [verificationMethod, setVerificationMethod] = useState<
-    "coinflow" | "apple-pay" | "identity" | null
+    "apple-pay" | "identity" | null
   >(null);
   const { isUS, countryCodeLoaded } = useGeoLocation();
   const configuredCard = defaultPaymentMethod === "credit-card";
+  const { runAfterLocationGate, locationGateView } = usePurchaseLocationGate();
 
   const handleIconTripleClick = useTripleClick({
     featureName: isUS ? "coinflow-support" : undefined,
@@ -597,7 +599,7 @@ export function OnchainCheckout() {
   const autoCreditsPurchaseRef = useRef<string>();
 
   const purchaseInFlightRef = useRef(false);
-  const handlePurchase = useCallback(async () => {
+  const continuePurchase = useCallback(async () => {
     if (purchaseInFlightRef.current) return;
     if (isApplePayAmountTooLow) return;
 
@@ -721,11 +723,6 @@ export function OnchainCheckout() {
         await onCreditsPurchase();
         navigate("/purchase/success", { reset: true });
       } else if (method === "coinflow") {
-        if (!isEmailVerified) {
-          setVerificationMethod("coinflow");
-          return;
-        }
-
         await onCreditCardPurchase();
         setIsCoinflowDrawerOpen(true);
       } else if (method === "apple-pay") {
@@ -809,6 +806,10 @@ export function OnchainCheckout() {
     isBlocked,
   ]);
 
+  const handlePurchase = useCallback(() => {
+    runAfterLocationGate(continuePurchase);
+  }, [runAfterLocationGate, continuePurchase]);
+
   const handleBridge = useCallback(async () => {
     clearError();
 
@@ -832,6 +833,10 @@ export function OnchainCheckout() {
     (!isFree && !isInitialPaymentResolved)
   ) {
     return <LoadingState />;
+  }
+
+  if (locationGateView) {
+    return locationGateView;
   }
 
   return (
@@ -1075,10 +1080,10 @@ export function OnchainCheckout() {
         method={verificationMethod}
         onClose={() => setVerificationMethod(null)}
         onSuccess={() => {
-          // Verification done — close drawer and re-run the purchase which
-          // will now pass the email/phone gate and open the payment drawer.
+          // Verification is part of the purchase attempt that already passed
+          // its fresh location check, so continue without starting a new one.
           setVerificationMethod(null);
-          handlePurchase();
+          void continuePurchase();
         }}
       />
     </>

--- a/packages/keychain/src/components/purchase/usePurchaseLocationGate.test.tsx
+++ b/packages/keychain/src/components/purchase/usePurchaseLocationGate.test.tsx
@@ -1,0 +1,73 @@
+import { act, renderHook } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { usePurchaseLocationGate } from "./usePurchaseLocationGate";
+
+const mocks = vi.hoisted(() => ({
+  connection: {
+    locationGate: { blocked: ["US-NY"] } as { blocked?: string[] },
+    setLocationGateVerified: vi.fn(),
+  },
+  geo: { isUS: true },
+}));
+
+vi.mock("@/hooks/connection", () => ({
+  useConnection: () => mocks.connection,
+}));
+
+vi.mock("@/hooks/geo", () => ({
+  useGeoLocation: () => mocks.geo,
+}));
+
+vi.mock("@/components/location/LocationGate", () => ({
+  LocationGate: () => null,
+}));
+
+describe("usePurchaseLocationGate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.connection.locationGate = { blocked: ["US-NY"] };
+    mocks.geo.isUS = true;
+  });
+
+  it("requires a fresh gate before every configured game purchase", () => {
+    const firstPurchase = vi.fn();
+    const secondPurchase = vi.fn();
+    const { result } = renderHook(() => usePurchaseLocationGate());
+
+    act(() => result.current.runAfterLocationGate(firstPurchase));
+
+    expect(mocks.connection.setLocationGateVerified).toHaveBeenCalledWith(
+      false,
+    );
+    expect(result.current.locationGateView).not.toBeNull();
+    expect(firstPurchase).not.toHaveBeenCalled();
+
+    act(() => {
+      const gate = result.current.locationGateView as ReactElement<{
+        onVerified: () => void;
+      }>;
+      gate.props.onVerified();
+    });
+    expect(firstPurchase).toHaveBeenCalledOnce();
+    expect(result.current.locationGateView).toBeNull();
+
+    act(() => result.current.runAfterLocationGate(secondPurchase));
+
+    expect(mocks.connection.setLocationGateVerified).toHaveBeenCalledTimes(2);
+    expect(result.current.locationGateView).not.toBeNull();
+    expect(secondPurchase).not.toHaveBeenCalled();
+  });
+
+  it("continues immediately when the game has no location gate", () => {
+    mocks.connection.locationGate = {};
+    const purchase = vi.fn();
+    const { result } = renderHook(() => usePurchaseLocationGate());
+
+    act(() => result.current.runAfterLocationGate(purchase));
+
+    expect(purchase).toHaveBeenCalledOnce();
+    expect(mocks.connection.setLocationGateVerified).not.toHaveBeenCalled();
+    expect(result.current.locationGateView).toBeNull();
+  });
+});

--- a/packages/keychain/src/components/purchase/usePurchaseLocationGate.tsx
+++ b/packages/keychain/src/components/purchase/usePurchaseLocationGate.tsx
@@ -1,0 +1,60 @@
+import { useCallback, useRef, useState } from "react";
+import { useConnection } from "@/hooks/connection";
+import { useGeoLocation } from "@/hooks/geo";
+import { hasConfiguredLocationGate } from "@/utils/location-gate";
+import { LocationGate } from "@/components/location/LocationGate";
+
+type PurchaseAction = () => void | Promise<void>;
+
+/**
+ * Requires a fresh location check before each purchase attempt for US users of
+ * games with a configured location gate. An already-granted browser permission
+ * is checked silently by LocationGate; denied/prompt permissions show its
+ * recovery UI.
+ */
+export function usePurchaseLocationGate() {
+  const { locationGate, setLocationGateVerified } = useConnection();
+  const { isUS } = useGeoLocation();
+  const [isPending, setIsPending] = useState(false);
+  const pendingActionRef = useRef<PurchaseAction>();
+
+  const runAfterLocationGate = useCallback(
+    (action: PurchaseAction) => {
+      if (!isUS || !hasConfiguredLocationGate(locationGate)) {
+        void action();
+        return;
+      }
+
+      pendingActionRef.current = action;
+      // Verification is deliberately per-attempt. A successful connect or an
+      // earlier purchase must never authorize the next purchase implicitly.
+      setLocationGateVerified(false);
+      setIsPending(true);
+    },
+    [isUS, locationGate, setLocationGateVerified],
+  );
+
+  const continuePendingPurchase = useCallback(() => {
+    const action = pendingActionRef.current;
+    pendingActionRef.current = undefined;
+    setIsPending(false);
+    void action?.();
+  }, []);
+
+  const cancelPendingPurchase = useCallback(() => {
+    pendingActionRef.current = undefined;
+    setIsPending(false);
+  }, []);
+
+  return {
+    runAfterLocationGate,
+    locationGateView:
+      isPending && locationGate ? (
+        <LocationGate
+          gate={locationGate}
+          onExit={cancelPendingPurchase}
+          onVerified={continuePendingPurchase}
+        />
+      ) : null,
+  };
+}

--- a/packages/keychain/src/components/purchase/verification/index.tsx
+++ b/packages/keychain/src/components/purchase/verification/index.tsx
@@ -59,7 +59,7 @@ export function Verification({
         text: "Email Address",
         icon: <EnvelopeIcon />,
         onClick: initiateEmailVerification,
-        required: !method || method === "apple-pay" || method === "coinflow",
+        required: !method || method === "apple-pay",
         completed: isEmailVerified,
       },
       {


### PR DESCRIPTION
Requires a fresh configured location check before each starterpack purchase, silently reusing granted permission and surfacing recovery guidance when location is denied. Keeps the credit deposit flow moving after successful Prove verification instead of emitting cancellation. Removes email verification from Coinflow card purchases while preserving Apple Pay requirements. Adds focused regressions; pre-commit checks passed across lint, test coverage, build, and GraphQL generation.