### PR TITLE
fix: avoid app refresh after purchase location check

### DIFF
--- a/packages/keychain/src/components/ConnectRoute.test.tsx
+++ b/packages/keychain/src/components/ConnectRoute.test.tsx
@@ -1,5 +1,4 @@
 import { vi, describe, it, expect, beforeEach } from "vitest";
-import { useState } from "react";
 import { screen, waitFor } from "@testing-library/react";
 import { ConnectRoute } from "./ConnectRoute";
 import { renderWithProviders } from "@/test/mocks/providers";
@@ -263,55 +262,58 @@ describe("ConnectRoute", () => {
       expect(mockParams.resolve).not.toHaveBeenCalled();
     });
 
-    it("resumes and resolves the pending connect after gate verification", async () => {
-      // Regression: the gate used to live on its own route; navigating there
-      // unmounted ConnectRoute, whose unmount cleanup deleted the stored
-      // connect callbacks — the parent SDK's connect() promise then never
-      // settled and the modal hung blank after verification.
-      Object.defineProperty(navigator, "permissions", {
-        configurable: true,
-        value: { query: vi.fn().mockResolvedValue({ state: "granted" }) },
-      });
-      Object.defineProperty(navigator, "geolocation", {
-        configurable: true,
-        value: {
-          getCurrentPosition: (
-            success: (position: {
-              coords: { latitude: number; longitude: number };
-            }) => void,
-          ) => success({ coords: { latitude: 34.05, longitude: -118.24 } }),
-        },
-      });
-      mockReverseGeocodeLocation.mockResolvedValue({
-        countryCode: "US",
-        regionCode: "US-CA",
-      });
+    it.each([
+      { authFlow: "login", isNewController: false, keepOpen: false },
+      { authFlow: "signup", isNewController: true, keepOpen: true },
+    ])(
+      "resumes the pending $authFlow after gate verification",
+      async ({ isNewController, keepOpen }) => {
+        // Regression: the gate used to live on its own route; navigating there
+        // unmounted ConnectRoute, whose unmount cleanup deleted the stored
+        // connect callbacks — the parent SDK's connect() promise then never
+        // settled and the modal hung blank after verification.
+        Object.defineProperty(navigator, "permissions", {
+          configurable: true,
+          value: { query: vi.fn().mockResolvedValue({ state: "granted" }) },
+        });
+        Object.defineProperty(navigator, "geolocation", {
+          configurable: true,
+          value: {
+            getCurrentPosition: (
+              success: (position: {
+                coords: { latitude: number; longitude: number };
+              }) => void,
+            ) => success({ coords: { latitude: 34.05, longitude: -118.24 } }),
+          },
+        });
+        mockReverseGeocodeLocation.mockResolvedValue({
+          countryCode: "US",
+          regionCode: "US-CA",
+        });
 
-      // Stateful harness: the real LocationGate flips locationGateVerified
-      // through the connection context, which resumes the connect effect.
-      function Harness() {
-        const [verified, setVerified] = useState(false);
+        const setLocationGateVerified = vi.fn();
         mockUseConnection.mockReturnValue({
           controller: mockController,
           policies: null,
           locationGate: { blocked: ["US-NY"] },
-          locationGateVerified: verified,
-          setLocationGateVerified: setVerified,
+          locationGateVerified: false,
+          setLocationGateVerified,
+          isNewControllerRef: { current: isNewController },
         });
-        return <ConnectRoute />;
-      }
 
-      renderWithProviders(<Harness />);
+        renderWithProviders(<ConnectRoute />);
 
-      await waitFor(() => {
-        expect(mockParams.resolve).toHaveBeenCalledWith({
-          code: ResponseCodes.SUCCESS,
-          address: "0x123456789abcdef",
-          keepOpen: false,
+        await waitFor(() => {
+          expect(mockParams.resolve).toHaveBeenCalledWith({
+            code: ResponseCodes.SUCCESS,
+            address: "0x123456789abcdef",
+            keepOpen,
+          });
         });
-      });
-      expect(mockCleanupCallbacks).toHaveBeenCalledWith("test-id");
-    });
+        expect(mockCleanupCallbacks).toHaveBeenCalledWith("test-id");
+        expect(setLocationGateVerified).not.toHaveBeenCalled();
+      },
+    );
 
     it("settles the pending connect when the gate is cancelled", async () => {
       const closeModal = vi.fn();

--- a/packages/keychain/src/components/ConnectRoute.tsx
+++ b/packages/keychain/src/components/ConnectRoute.tsx
@@ -61,7 +61,6 @@ export function ConnectRoute() {
     policiesStr,
     rpcUrl,
     locationGate,
-    locationGateVerified,
     isNewControllerRef,
     controllerVersion,
     closeModal,
@@ -70,6 +69,7 @@ export function ConnectRoute() {
   const [isSessionCreating, setIsSessionCreating] = useState(false);
   const [sessionError, setSessionError] = useState<Error>();
   const [showContinueButton, setShowContinueButton] = useState(false);
+  const [locationGateVerified, setLocationGateVerified] = useState(false);
   const [hasRequestedSession, setHasRequestedSession] = useState<
     boolean | undefined
   >(undefined);
@@ -464,6 +464,10 @@ export function ConnectRoute() {
     [params, closeModal],
   );
 
+  const handleGateVerified = useCallback(() => {
+    setLocationGateVerified(true);
+  }, []);
+
   // Don't render anything if we don't have controller yet - CreateController handles loading
   if (!controller) {
     return null;
@@ -480,7 +484,14 @@ export function ConnectRoute() {
   // Render the gate inline so this route (and its pending connect callbacks)
   // stays mounted while the user verifies their location.
   if (hasLocationGate && isUS && !locationGateVerified) {
-    return <LocationGate gate={locationGate!} onExit={handleGateExit} />;
+    return (
+      <LocationGate
+        gate={locationGate!}
+        onExit={handleGateExit}
+        onVerified={handleGateVerified}
+        persistVerification={false}
+      />
+    );
   }
 
   // Embedded mode: No policies and verified policies are handled in useCreateController

--- a/packages/keychain/src/components/location/LocationGate.test.tsx
+++ b/packages/keychain/src/components/location/LocationGate.test.tsx
@@ -76,12 +76,16 @@ vi.mock("./USMap", () => ({
   ),
 }));
 
-function renderGate(gate: LocationGateOptions = { blocked: ["US-NY"] }) {
+function renderGate(
+  gate: LocationGateOptions = { blocked: ["US-NY"] },
+  persistVerification = true,
+) {
   return render(
     <LocationGate
       gate={gate}
       onExit={mocks.onExit}
       onVerified={mocks.onVerified}
+      persistVerification={persistVerification}
     />,
   );
 }
@@ -165,6 +169,24 @@ describe("LocationGate", () => {
       expect.objectContaining({ latitude: 34.05, longitude: -118.24 }),
     );
     expect(mocks.onExit).not.toHaveBeenCalled();
+  });
+
+  it("can verify a purchase without updating global connection state", async () => {
+    mocks.reverseGeocodeLocation.mockResolvedValue({
+      countryCode: "US",
+      regionCode: "US-CA",
+    });
+    renderGate({ blocked: ["US-NY"] }, false);
+    fireEvent.click(await screen.findByRole("button", { name: "CONTINUE" }));
+
+    const onSuccess = mocks.getCurrentPosition.mock.calls[0][0];
+    onSuccess({
+      coords: { latitude: 34.05, longitude: -118.24 },
+      timestamp: 1,
+    });
+
+    await waitFor(() => expect(mocks.onVerified).toHaveBeenCalledOnce());
+    expect(mocks.setLocationGateVerified).not.toHaveBeenCalled();
   });
 
   it("does not pass when browser geolocation permission is denied", async () => {

--- a/packages/keychain/src/components/location/LocationGate.tsx
+++ b/packages/keychain/src/components/location/LocationGate.tsx
@@ -57,10 +57,13 @@ export function LocationGate({
   gate,
   onExit,
   onVerified,
+  persistVerification = true,
 }: {
   gate: LocationGateOptions;
   onExit: (response: LocationGateResponse) => void;
   onVerified?: () => void;
+  /** Connect flows persist this globally; purchase flows resume locally. */
+  persistVerification?: boolean;
 }) {
   const { setLocationGateVerified, theme } = useConnection();
   const { setShowClose } = useNavigation();
@@ -83,10 +86,12 @@ export function LocationGate({
         return;
       }
 
-      setLocationGateVerified(true);
+      if (persistVerification) {
+        setLocationGateVerified(true);
+      }
       onVerified?.();
     },
-    [gate, onVerified, setLocationGateVerified],
+    [gate, onVerified, persistVerification, setLocationGateVerified],
   );
 
   const handleLocationError = useCallback(

--- a/packages/keychain/src/components/purchase/usePurchaseLocationGate.test.tsx
+++ b/packages/keychain/src/components/purchase/usePurchaseLocationGate.test.tsx
@@ -37,9 +37,7 @@ describe("usePurchaseLocationGate", () => {
 
     act(() => result.current.runAfterLocationGate(firstPurchase));
 
-    expect(mocks.connection.setLocationGateVerified).toHaveBeenCalledWith(
-      false,
-    );
+    expect(mocks.connection.setLocationGateVerified).not.toHaveBeenCalled();
     expect(result.current.locationGateView).not.toBeNull();
     expect(firstPurchase).not.toHaveBeenCalled();
 
@@ -54,7 +52,7 @@ describe("usePurchaseLocationGate", () => {
 
     act(() => result.current.runAfterLocationGate(secondPurchase));
 
-    expect(mocks.connection.setLocationGateVerified).toHaveBeenCalledTimes(2);
+    expect(mocks.connection.setLocationGateVerified).not.toHaveBeenCalled();
     expect(result.current.locationGateView).not.toBeNull();
     expect(secondPurchase).not.toHaveBeenCalled();
   });

--- a/packages/keychain/src/components/purchase/usePurchaseLocationGate.tsx
+++ b/packages/keychain/src/components/purchase/usePurchaseLocationGate.tsx
@@ -13,7 +13,7 @@ type PurchaseAction = () => void | Promise<void>;
  * recovery UI.
  */
 export function usePurchaseLocationGate() {
-  const { locationGate, setLocationGateVerified } = useConnection();
+  const { locationGate } = useConnection();
   const { isUS } = useGeoLocation();
   const [isPending, setIsPending] = useState(false);
   const pendingActionRef = useRef<PurchaseAction>();
@@ -26,12 +26,9 @@ export function usePurchaseLocationGate() {
       }
 
       pendingActionRef.current = action;
-      // Verification is deliberately per-attempt. A successful connect or an
-      // earlier purchase must never authorize the next purchase implicitly.
-      setLocationGateVerified(false);
       setIsPending(true);
     },
-    [isUS, locationGate, setLocationGateVerified],
+    [isUS, locationGate],
   );
 
   const continuePendingPurchase = useCallback(() => {
@@ -54,6 +51,7 @@ export function usePurchaseLocationGate() {
           gate={locationGate}
           onExit={cancelPendingPurchase}
           onVerified={continuePendingPurchase}
+          persistVerification={false}
         />
       ) : null,
   };


### PR DESCRIPTION
Fixes Coinflow purchase continuity and location-gated controller flows:

- checks location gates before each game purchase/play and re-prompts when location services are disabled
- resumes the credit deposit flow automatically after Prove verification
- removes email-verification gating from Coinflow credit card purchases
- keeps successful purchase, login, and signup location checks local to their active flow so they do not refresh the top-level app/provider tree

Adds regression coverage for purchase flows and both login/signup connect modes. Full pre-commit lint, tests, coverage, build, and GraphQL generation passed locally.