### PR TITLE
fix: avoid purchase flash after location verification

### DIFF
--- a/packages/keychain/src/components/purchase/usePurchaseLocationGate.test.tsx
+++ b/packages/keychain/src/components/purchase/usePurchaseLocationGate.test.tsx
@@ -30,7 +30,7 @@ describe("usePurchaseLocationGate", () => {
     mocks.geo.isUS = true;
   });
 
-  it("requires a fresh gate before every configured game purchase", () => {
+  it("requires a fresh gate before every configured game purchase", async () => {
     const firstPurchase = vi.fn();
     const secondPurchase = vi.fn();
     const { result } = renderHook(() => usePurchaseLocationGate());
@@ -41,7 +41,7 @@ describe("usePurchaseLocationGate", () => {
     expect(result.current.locationGateView).not.toBeNull();
     expect(firstPurchase).not.toHaveBeenCalled();
 
-    act(() => {
+    await act(async () => {
       const gate = result.current.locationGateView as ReactElement<{
         onVerified: () => void;
       }>;
@@ -66,6 +66,33 @@ describe("usePurchaseLocationGate", () => {
 
     expect(purchase).toHaveBeenCalledOnce();
     expect(mocks.connection.setLocationGateVerified).not.toHaveBeenCalled();
+    expect(result.current.locationGateView).toBeNull();
+  });
+
+  it("keeps the gate mounted until an async purchase continuation is ready", async () => {
+    let finishPurchase: (() => void) | undefined;
+    const purchase = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishPurchase = resolve;
+        }),
+    );
+    const { result } = renderHook(() => usePurchaseLocationGate());
+
+    act(() => result.current.runAfterLocationGate(purchase));
+
+    await act(async () => {
+      const gate = result.current.locationGateView as ReactElement<{
+        onVerified: () => void;
+      }>;
+      gate.props.onVerified();
+    });
+
+    expect(purchase).toHaveBeenCalledOnce();
+    expect(result.current.locationGateView).not.toBeNull();
+
+    await act(async () => finishPurchase?.());
+
     expect(result.current.locationGateView).toBeNull();
   });
 });

--- a/packages/keychain/src/components/purchase/usePurchaseLocationGate.tsx
+++ b/packages/keychain/src/components/purchase/usePurchaseLocationGate.tsx
@@ -34,8 +34,27 @@ export function usePurchaseLocationGate() {
   const continuePendingPurchase = useCallback(() => {
     const action = pendingActionRef.current;
     pendingActionRef.current = undefined;
-    setIsPending(false);
-    void action?.();
+
+    if (!action) {
+      setIsPending(false);
+      return;
+    }
+
+    void (async () => {
+      try {
+        // Keep the gate mounted while the next purchase UI initializes. If we
+        // clear it first, the review page flashes between location verification
+        // and Coinflow, which looks like the entire app refreshed.
+        await action();
+      } catch (error) {
+        console.error(
+          "Failed to continue purchase after location verification:",
+          error,
+        );
+      } finally {
+        setIsPending(false);
+      }
+    })();
   }, []);
 
   const cancelPendingPurchase = useCallback(() => {


### PR DESCRIPTION
Keeps the location gate mounted while the resumed asynchronous purchase initializes, preventing the review page from flashing between verification and Coinflow. The pending gate now clears only after the continuation settles and safely clears on errors. Adds a regression test that holds the continuation open and verifies the gate remains visible. Full pre-commit lint, formatting, tests, build, and GraphQL generation passed.