### PR TITLE
feat(keychain): disable unaffordable payment tokens + singlePurchaseOnly option

### DIFF
--- a/packages/controller/src/types.ts
+++ b/packages/controller/src/types.ts
@@ -368,6 +368,8 @@ export type BundleOptions = {
   onPurchaseComplete?: () => void;
   /** Options for social claim conditional starterpack */
   socialClaimOptions?: SocialClaimOptions;
+  /** When true, hides the quantity selector and fixes the purchase to a single bundle */
+  singlePurchaseOnly?: boolean;
 };
 
 export type StarterpackOptions = {
@@ -375,6 +377,8 @@ export type StarterpackOptions = {
   preimage?: string;
   /** Callback fired after the Play button closes the starterpack modal */
   onPurchaseComplete?: () => void;
+  /** When true, hides the quantity selector and fixes the purchase to a single starterpack */
+  singlePurchaseOnly?: boolean;
 };
 
 export type MerkleDropsOptions = {

--- a/packages/keychain/src/components/purchase/checkout/onchain/index.tsx
+++ b/packages/keychain/src/components/purchase/checkout/onchain/index.tsx
@@ -79,6 +79,7 @@ export function OnchainCheckout() {
     registryAddress,
     bundleId,
     starterpackId,
+    singlePurchaseOnly,
   } = useStarterpackContext();
   const {
     isFetchingConversion,
@@ -1039,6 +1040,7 @@ export function OnchainCheckout() {
                   onPurchase={handlePurchase}
                   onBridge={handleBridge}
                   isApplePayAmountTooLow={isApplePayAmountTooLow}
+                  hideQuantity={singlePurchaseOnly}
                   purchaseLabel={
                     isCoinflowSelected
                       ? "Continue"

--- a/packages/keychain/src/components/purchase/checkout/onchain/quantity.tsx
+++ b/packages/keychain/src/components/purchase/checkout/onchain/quantity.tsx
@@ -13,6 +13,8 @@ interface QuantityControlsProps {
   onBridge: () => void;
   purchaseLabel?: string;
   isApplePayAmountTooLow?: boolean;
+  /** Hide the +/- quantity buttons (quantity is fixed to 1). */
+  hideQuantity?: boolean;
 }
 
 export function QuantityControls({
@@ -28,28 +30,34 @@ export function QuantityControls({
   onBridge,
   purchaseLabel: customPurchaseLabel,
   isApplePayAmountTooLow,
+  hideQuantity = false,
 }: QuantityControlsProps) {
-  const purchaseLabel = customPurchaseLabel || `Buy ${quantity}`;
+  const purchaseLabel =
+    customPurchaseLabel || (hideQuantity ? "Buy" : `Buy ${quantity}`);
   const isQuantityDisabled =
     (globalDisabled && hasSufficientBalance && !isApplePayAmountTooLow) ||
     isSendingDeposit;
 
   return (
     <div className="flex flex-row gap-3">
-      <Button
-        variant="secondary"
-        onClick={onDecrement}
-        disabled={isQuantityDisabled || quantity <= 1}
-      >
-        <MinusIcon size="xs" />
-      </Button>
-      <Button
-        variant="secondary"
-        onClick={onIncrement}
-        disabled={isQuantityDisabled}
-      >
-        <PlusIcon size="xs" variant="solid" />
-      </Button>
+      {!hideQuantity && (
+        <>
+          <Button
+            variant="secondary"
+            onClick={onDecrement}
+            disabled={isQuantityDisabled || quantity <= 1}
+          >
+            <MinusIcon size="xs" />
+          </Button>
+          <Button
+            variant="secondary"
+            onClick={onIncrement}
+            disabled={isQuantityDisabled}
+          >
+            <PlusIcon size="xs" variant="solid" />
+          </Button>
+        </>
+      )}
       <Button
         className="w-full"
         isLoading={isLoading || isSendingDeposit}

--- a/packages/keychain/src/components/purchase/review/cost.tsx
+++ b/packages/keychain/src/components/purchase/review/cost.tsx
@@ -53,6 +53,7 @@ export function CostBreakdown({
   selectedToken,
   onSelectToken,
   tokenSelectDisabled,
+  disabledTokens,
   feesTooltip,
   isLoading,
   value,
@@ -62,6 +63,8 @@ export function CostBreakdown({
   selectedToken?: TokenOption;
   onSelectToken: (address: string) => void;
   tokenSelectDisabled?: boolean;
+  /** Hex-normalized token addresses to render as non-selectable. */
+  disabledTokens?: Set<string>;
   feesTooltip?: ReactNode;
   isLoading?: boolean;
   value: ReactNode;
@@ -99,7 +102,14 @@ export function CostBreakdown({
           />
           <SelectContent>
             {tokens.map((token) => (
-              <SelectItem key={token.address} value={token.address}>
+              <SelectItem
+                key={token.address}
+                value={token.address}
+                disabled={
+                  !token.isCredits &&
+                  (disabledTokens?.has(num.toHex(token.address)) ?? false)
+                }
+              >
                 <div className="flex items-center gap-2">
                   {token.icon ? (
                     <Thumbnail
@@ -138,6 +148,7 @@ export function OnchainCostBreakdown({
     depositAmount: layerswapDepositAmount,
     layerswapFees,
     availableTokens,
+    insufficientTokens,
     selectedPlatform,
     selectedToken,
     setSelectedToken,
@@ -237,6 +248,14 @@ export function OnchainCostBreakdown({
         (t) => t.address.toLowerCase() === address.toLowerCase(),
       );
       if (!token) return;
+      // Insufficient-balance tokens are disabled in the selector; guard here
+      // too so no other code path can select a token that can't pay.
+      if (
+        !token.isCredits &&
+        insufficientTokens.has(num.toHex(token.address))
+      ) {
+        return;
+      }
       // The credits pseudo-token is a payment-method choice, not a token:
       // route it through the rail so the payment method and the displayed
       // token can never disagree, and leave the rail again when a real token
@@ -250,6 +269,7 @@ export function OnchainCostBreakdown({
     },
     [
       availableTokens,
+      insufficientTokens,
       setSelectedToken,
       onCreditsSelect,
       isCreditsRailSelected,
@@ -315,6 +335,7 @@ export function OnchainCostBreakdown({
       tokenSelectDisabled={
         availableTokens.length <= 1 || isTokenSelectionLocked
       }
+      disabledTokens={insufficientTokens}
       isLoading={isFetchingConversion || isFetchingCoinbaseQuote}
       value={value}
       feesTooltip={

--- a/packages/keychain/src/components/purchase/review/onchain-cost.stories.tsx
+++ b/packages/keychain/src/components/purchase/review/onchain-cost.stories.tsx
@@ -36,6 +36,7 @@ const MockOnchainPurchaseProvider = ({ children }: { children: ReactNode }) => {
     walletAddress: undefined,
     clearSelectedWallet: () => {},
     availableTokens: [mockUsdcToken],
+    insufficientTokens: new Set<string>(),
     selectedToken: mockUsdcToken,
     setSelectedToken: () => {},
     convertedPrice: null,

--- a/packages/keychain/src/components/purchase/starterpack/starterpack.tsx
+++ b/packages/keychain/src/components/purchase/starterpack/starterpack.tsx
@@ -80,16 +80,20 @@ export function PurchaseStarterpack() {
       // store bundle info into provider before navigating to checkout
       const registryAddress = searchParams.get("registryAddress");
       const shareMessage = searchParams.get("shareMessage");
+      const singlePurchaseOnly =
+        searchParams.get("singlePurchaseOnly") === "true";
       setBundle(
         Number(bundleId),
         registryAddress!,
         shareMessage ? { shareMessage } : undefined,
+        singlePurchaseOnly,
       );
     } else if (starterpackId) {
       // store starterpack info into provider before navigating to checkout
       setStarterpack(
         starterpackId,
         import.meta.env.VITE_STARTERPACK_REGISTRY_CONTRACT,
+        searchParams.get("singlePurchaseOnly") === "true",
       );
     }
   }, [
@@ -287,6 +291,7 @@ export function OnchainStarterPackInner({
   error?: Error | null;
 }) {
   const { navigate } = useNavigation();
+  const { singlePurchaseOnly } = useStarterpackContext();
   const {
     selectedWallet,
     quantity,
@@ -376,26 +381,30 @@ export function OnchainStarterPackInner({
         </div>
         {quote && <OnchainCostBreakdown quote={quote} />}
         <div className="flex flex-row gap-3">
-          <Button
-            variant="secondary"
-            onClick={decrementQuantity}
-            disabled={quantity <= 1 || disableActions}
-          >
-            <MinusIcon size="xs" />
-          </Button>
-          <Button
-            variant="secondary"
-            onClick={incrementQuantity}
-            disabled={disableActions}
-          >
-            <PlusIcon size="xs" variant="solid" />
-          </Button>
+          {!singlePurchaseOnly && (
+            <>
+              <Button
+                variant="secondary"
+                onClick={decrementQuantity}
+                disabled={quantity <= 1 || disableActions}
+              >
+                <MinusIcon size="xs" />
+              </Button>
+              <Button
+                variant="secondary"
+                onClick={incrementQuantity}
+                disabled={disableActions}
+              >
+                <PlusIcon size="xs" variant="solid" />
+              </Button>
+            </>
+          )}
           <Button
             className="w-full"
             onClick={onProceed}
             disabled={disableActions}
           >
-            Buy {quantity}
+            {singlePurchaseOnly ? "Buy" : `Buy ${quantity}`}
           </Button>
         </div>
       </LayoutFooter>

--- a/packages/keychain/src/components/purchase/wallet/wallet.stories.tsx
+++ b/packages/keychain/src/components/purchase/wallet/wallet.stories.tsx
@@ -29,6 +29,7 @@ const mockStarterpackValue = {
   clearError: () => {},
   socialClaimOptions: undefined,
   socialClaimConditions: undefined,
+  singlePurchaseOnly: false,
 };
 
 // Mock onchain purchase context
@@ -44,6 +45,7 @@ const mockOnchainPurchaseValue: OnchainPurchaseContextType = {
   walletAddress: undefined,
   clearSelectedWallet: () => {},
   availableTokens: [] as TokenOption[],
+  insufficientTokens: new Set<string>(),
   selectedToken: undefined,
   setSelectedToken: () => {},
   convertedPrice: null,

--- a/packages/keychain/src/context/starterpack/onchain-purchase.tsx
+++ b/packages/keychain/src/context/starterpack/onchain-purchase.tsx
@@ -32,6 +32,7 @@ import {
   useExternalWallet,
   useLayerswap,
   useTokenSelection,
+  useTokenSufficiency,
   useCoinbase,
   COINBASE_APPLE_PAY_MIN_USD,
   type TokenOption,
@@ -76,6 +77,8 @@ export interface OnchainPurchaseContextType {
 
   // Token selection
   availableTokens: TokenOption[];
+  /** Hex-normalized addresses of tokens the paying wallet cannot cover. */
+  insufficientTokens: Set<string>;
   selectedToken: TokenOption | undefined;
   setSelectedToken: (token: TokenOption | undefined) => void;
   convertedPrice: {
@@ -176,6 +179,7 @@ export const OnchainPurchaseProvider = ({
     setDisplayError,
     registryAddress,
     socialClaimConditions,
+    singlePurchaseOnly,
   } = useStarterpackContext();
   const { connectedHandle } = useSocialClaimConnection(socialClaimConditions);
 
@@ -470,6 +474,18 @@ export const OnchainPurchaseProvider = ({
     return [...availableTokens, CREDITS_TOKEN];
   }, [availableTokens, isApplePaySelected, isCoinflowSelected]);
 
+  // Per-token balance sufficiency so the selector can disable tokens the
+  // paying wallet can't cover (the credits pseudo-token is never checked).
+  const { insufficientTokens } = useTokenSufficiency({
+    controller,
+    starterpackDetails: onchainDetails,
+    availableTokens,
+    quantity,
+    selectedWallet,
+    walletAddress,
+    selectedPlatform,
+  });
+
   // Wrap onSendDeposit to clear errors before sending
   const onSendDeposit = useCallback(async () => {
     setDisplayError(undefined);
@@ -496,9 +512,11 @@ export const OnchainPurchaseProvider = ({
 
   // Apple Pay has a per-transaction minimum ($1.86). If the starterpack's
   // unit cost in USDC is below that, bump the quantity so the total clears
-  // the minimum and surface it to the user via applePayMinQuantity.
+  // the minimum and surface it to the user via applePayMinQuantity. With
+  // singlePurchaseOnly the quantity must stay at 1, so no bump — the
+  // "Amount Too Low" gate blocks Apple Pay instead.
   useEffect(() => {
-    if (!isApplePaySelected) {
+    if (!isApplePaySelected || singlePurchaseOnly) {
       if (applePayMinQuantity !== undefined) setApplePayMinQuantity(undefined);
       return;
     }
@@ -526,6 +544,7 @@ export const OnchainPurchaseProvider = ({
     }
   }, [
     isApplePaySelected,
+    singlePurchaseOnly,
     convertedPrice,
     quantity,
     setQuantity,
@@ -873,6 +892,7 @@ export const OnchainPurchaseProvider = ({
     walletAddress,
     clearSelectedWallet,
     availableTokens: listedTokens,
+    insufficientTokens,
     selectedToken,
     setSelectedToken,
     convertedPrice,

--- a/packages/keychain/src/context/starterpack/starterpack.tsx
+++ b/packages/keychain/src/context/starterpack/starterpack.tsx
@@ -33,11 +33,19 @@ export interface StarterpackContextType {
     id: number,
     registryAddress: string,
     socialClaimOptions?: SocialClaimOptions,
+    singlePurchaseOnly?: boolean,
   ) => void;
 
   // Starterpack identification
   starterpackId: string | number | undefined;
-  setStarterpack: (id: string | number, registryAddress: string) => void;
+  setStarterpack: (
+    id: string | number,
+    registryAddress: string,
+    singlePurchaseOnly?: boolean,
+  ) => void;
+
+  // When true, the quantity selector is hidden and purchases are fixed to 1
+  singlePurchaseOnly: boolean;
 
   // Merkle drop identification
   merkleDropKeys: string[] | undefined;
@@ -87,6 +95,7 @@ export const StarterpackProvider = ({ children }: StarterpackProviderProps) => {
   const [transactionHash, setTransactionHash] = useState<string | undefined>();
   const [displayError, setDisplayError] = useState<Error | undefined>();
   const [claimItemsState, setClaimItemsState] = useState<Item[]>([]);
+  const [singlePurchaseOnly, setSinglePurchaseOnly] = useState(false);
 
   // Detect which source (claimed or onchain) based on starterpack ID
   const type = detectStarterpackType(starterpackId ?? bundleId);
@@ -189,10 +198,12 @@ export const StarterpackProvider = ({ children }: StarterpackProviderProps) => {
       id: number,
       registryAddress: string,
       socialClaimOptions?: SocialClaimOptions,
+      singlePurchaseOnly?: boolean,
     ) => {
       setBundleId(id);
       setRegistryAddress(registryAddress);
       setSocialClaimOptions(socialClaimOptions);
+      setSinglePurchaseOnly(singlePurchaseOnly ?? false);
       setStarterpackId(undefined);
       setMerkleDropKeys(undefined);
       setMerkleDropOptions(undefined);
@@ -201,9 +212,14 @@ export const StarterpackProvider = ({ children }: StarterpackProviderProps) => {
   );
 
   const setStarterpack = useCallback(
-    (id: number | string, registryAddress: string) => {
+    (
+      id: number | string,
+      registryAddress: string,
+      singlePurchaseOnly?: boolean,
+    ) => {
       setStarterpackId(id);
       setRegistryAddress(registryAddress);
+      setSinglePurchaseOnly(singlePurchaseOnly ?? false);
       setBundleId(undefined);
       setSocialClaimOptions(undefined);
       setMerkleDropKeys(undefined);
@@ -220,6 +236,7 @@ export const StarterpackProvider = ({ children }: StarterpackProviderProps) => {
       setBundleId(undefined);
       setRegistryAddress(undefined);
       setSocialClaimOptions(undefined);
+      setSinglePurchaseOnly(false);
     },
     [],
   );
@@ -264,6 +281,7 @@ export const StarterpackProvider = ({ children }: StarterpackProviderProps) => {
     clearError,
     socialClaimOptions,
     socialClaimConditions,
+    singlePurchaseOnly,
   };
 
   return (

--- a/packages/keychain/src/hooks/starterpack/index.ts
+++ b/packages/keychain/src/hooks/starterpack/index.ts
@@ -39,6 +39,12 @@ export type {
   UseTokenFallbackReturn,
 } from "./token-fallback";
 
+export { useTokenSufficiency } from "./token-sufficiency";
+export type {
+  UseTokenSufficiencyOptions,
+  UseTokenSufficiencyReturn,
+} from "./token-sufficiency";
+
 // The Coinbase rail hook now lives under hooks/payments (it is payment-rail
 // infrastructure, not starterpack-specific). Re-exported here for back-compat
 // with existing barrel imports.

--- a/packages/keychain/src/hooks/starterpack/token-fallback.ts
+++ b/packages/keychain/src/hooks/starterpack/token-fallback.ts
@@ -17,7 +17,11 @@ import Controller from "@/utils/controller";
  * quotes between them are wasted Ekubo requests. Treat the pair as equivalent
  * when estimating how much of a fallback candidate the user would need.
  */
-function isUsdcVariantPair(a: string, b: string, chainId: string): boolean {
+export function isUsdcVariantPair(
+  a: string,
+  b: string,
+  chainId: string,
+): boolean {
   const usdc = USDC_ADDRESSES[chainId];
   const usdce = USDCE_ADDRESSES[chainId];
   if (!usdc || !usdce) return false;
@@ -46,7 +50,7 @@ export interface UseTokenFallbackReturn {
   status: "pending" | "funded" | "exhausted" | "indeterminate";
 }
 
-async function fetchBalance(
+export async function fetchErc20Balance(
   controller: Controller,
   tokenAddress: string,
   ownerAddress: string,
@@ -225,7 +229,7 @@ export function useTokenFallback({
 
             if (abortController.signal.aborted) return;
 
-            const balance = await fetchBalance(
+            const balance = await fetchErc20Balance(
               controller,
               candidate.address,
               ownerAddress,

--- a/packages/keychain/src/hooks/starterpack/token-sufficiency.test.tsx
+++ b/packages/keychain/src/hooks/starterpack/token-sufficiency.test.tsx
@@ -1,0 +1,179 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { vi } from "vitest";
+import { num, uint256 } from "starknet";
+import { useTokenSufficiency } from "./token-sufficiency";
+import type { OnchainStarterpackDetails } from "@/context/starterpack/types";
+import type { TokenOption } from "./token-selection";
+import type Controller from "@/utils/controller";
+
+const mocks = vi.hoisted(() => ({
+  fetchSwapQuote: vi.fn(),
+  isQuoteChain: vi.fn(() => true),
+}));
+
+vi.mock("@/utils/ekubo", () => ({
+  fetchSwapQuote: mocks.fetchSwapQuote,
+  isQuoteChain: mocks.isQuoteChain,
+  USDC_ADDRESSES: {},
+  USDCE_ADDRESSES: {},
+}));
+
+const PAYMENT_TOKEN = "0x1";
+const OTHER_TOKEN = "0x2";
+const OWNER = "0xowner";
+
+function makeToken(address: string, symbol: string): TokenOption {
+  return {
+    name: symbol,
+    symbol,
+    decimals: 18,
+    address,
+    icon: undefined,
+    contract: {} as TokenOption["contract"],
+  };
+}
+
+const CREDITS: TokenOption = {
+  ...makeToken("credits", "USD"),
+  isCredits: true,
+};
+
+function makeDetails(totalCost: bigint): OnchainStarterpackDetails {
+  return {
+    type: "onchain",
+    id: 1,
+    name: "Bundle",
+    description: "",
+    imageUri: "",
+    items: [],
+    isQuoteLoading: false,
+    isConditional: false,
+    quote: {
+      basePrice: totalCost,
+      referralFee: 0n,
+      protocolFee: 0n,
+      totalCost,
+      paymentToken: PAYMENT_TOKEN,
+      paymentTokenMetadata: { symbol: "USDC", decimals: 6 },
+    },
+  };
+}
+
+function makeController(balances: Record<string, bigint | Error>): Controller {
+  return {
+    address: () => OWNER,
+    chainId: () => "0x534e5f4d41494e",
+    provider: {
+      callContract: vi.fn(async ({ contractAddress }) => {
+        const balance = balances[contractAddress];
+        if (balance === undefined || balance instanceof Error) {
+          throw balance ?? new Error("unknown token");
+        }
+        const { low, high } = uint256.bnToUint256(balance);
+        return [num.toHex(low), num.toHex(high)];
+      }),
+    },
+  } as unknown as Controller;
+}
+
+function renderSufficiency(
+  controller: Controller,
+  tokens: TokenOption[],
+  totalCost = 100n,
+  quantity = 1,
+) {
+  // Create the details object once: the hook's effect is keyed on object
+  // identity, so a fresh object per render would loop forever.
+  const details = makeDetails(totalCost);
+  return renderHook(() =>
+    useTokenSufficiency({
+      controller,
+      starterpackDetails: details,
+      availableTokens: tokens,
+      quantity,
+      selectedWallet: undefined,
+      walletAddress: undefined,
+      selectedPlatform: undefined,
+    }),
+  );
+}
+
+describe("useTokenSufficiency", () => {
+  beforeEach(() => {
+    mocks.fetchSwapQuote.mockReset();
+    mocks.isQuoteChain.mockReturnValue(true);
+  });
+
+  it("flags the payment token when its balance is below the total cost", async () => {
+    const controller = makeController({ [PAYMENT_TOKEN]: 40n });
+    const { result } = renderSufficiency(
+      controller,
+      [makeToken(PAYMENT_TOKEN, "USDC")],
+      100n,
+    );
+
+    await waitFor(() => {
+      expect(result.current.isCheckingSufficiency).toBe(false);
+      expect(
+        result.current.insufficientTokens.has(num.toHex(PAYMENT_TOKEN)),
+      ).toBe(true);
+    });
+  });
+
+  it("accounts for quantity when checking the payment token", async () => {
+    const controller = makeController({ [PAYMENT_TOKEN]: 150n });
+    const { result } = renderSufficiency(
+      controller,
+      [makeToken(PAYMENT_TOKEN, "USDC")],
+      100n,
+      2,
+    );
+
+    await waitFor(() => {
+      expect(result.current.isCheckingSufficiency).toBe(false);
+      expect(
+        result.current.insufficientTokens.has(num.toHex(PAYMENT_TOKEN)),
+      ).toBe(true);
+    });
+  });
+
+  it("leaves funded tokens enabled and prices other tokens via swap quote", async () => {
+    mocks.fetchSwapQuote.mockResolvedValue({ total: 500n });
+    const controller = makeController({
+      [PAYMENT_TOKEN]: 100n,
+      [OTHER_TOKEN]: 499n,
+    });
+    const { result } = renderSufficiency(controller, [
+      makeToken(PAYMENT_TOKEN, "USDC"),
+      makeToken(OTHER_TOKEN, "STRK"),
+    ]);
+
+    await waitFor(() => {
+      expect(result.current.isCheckingSufficiency).toBe(false);
+      expect(
+        result.current.insufficientTokens.has(num.toHex(PAYMENT_TOKEN)),
+      ).toBe(false);
+      expect(
+        result.current.insufficientTokens.has(num.toHex(OTHER_TOKEN)),
+      ).toBe(true);
+    });
+  });
+
+  it("never flags the credits pseudo-token and tolerates balance errors", async () => {
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const controller = makeController({
+      [PAYMENT_TOKEN]: new Error("rpc down"),
+    });
+    const { result } = renderSufficiency(controller, [
+      makeToken(PAYMENT_TOKEN, "USDC"),
+      CREDITS,
+    ]);
+
+    await waitFor(() => {
+      expect(result.current.isCheckingSufficiency).toBe(false);
+    });
+    // Unknown balance and credits both stay selectable.
+    expect(result.current.insufficientTokens.size).toBe(0);
+    consoleWarn.mockRestore();
+  });
+});

--- a/packages/keychain/src/hooks/starterpack/token-sufficiency.ts
+++ b/packages/keychain/src/hooks/starterpack/token-sufficiency.ts
@@ -1,0 +1,169 @@
+import { useState, useEffect } from "react";
+import { num } from "starknet";
+import type { ExternalPlatform, ExternalWallet } from "@cartridge/controller";
+import { fetchSwapQuote, isQuoteChain } from "@/utils/ekubo";
+import { isOnchainStarterpack } from "@/context/starterpack/types";
+import type { OnchainStarterpackDetails } from "@/context/starterpack/types";
+import type { TokenOption } from "./token-selection";
+import { fetchErc20Balance, isUsdcVariantPair } from "./token-fallback";
+import Controller from "@/utils/controller";
+
+export interface UseTokenSufficiencyOptions {
+  controller: Controller | undefined;
+  starterpackDetails: OnchainStarterpackDetails | undefined;
+  availableTokens: TokenOption[];
+  quantity: number;
+  selectedWallet: ExternalWallet | undefined;
+  walletAddress: string | undefined;
+  selectedPlatform: ExternalPlatform | undefined;
+}
+
+export interface UseTokenSufficiencyReturn {
+  /**
+   * Hex-normalized addresses of tokens whose balance cannot cover the
+   * purchase. Tokens still being checked (or whose balance/quote could not be
+   * resolved) are NOT included — the selector only disables tokens that are
+   * confirmed unpayable.
+   */
+  insufficientTokens: Set<string>;
+  isCheckingSufficiency: boolean;
+}
+
+/**
+ * Checks, for every selectable payment token, whether the paying wallet holds
+ * enough of it to cover the purchase — so the token selector can disable the
+ * ones that would only dead-end in an "insufficient balance" auto-switch.
+ * The credits/USD pseudo-token is never checked: it is a payment-method
+ * choice and stays selectable so users can top up.
+ */
+export function useTokenSufficiency({
+  controller,
+  starterpackDetails,
+  availableTokens,
+  quantity,
+  selectedWallet,
+  walletAddress,
+  selectedPlatform,
+}: UseTokenSufficiencyOptions): UseTokenSufficiencyReturn {
+  const [insufficientTokens, setInsufficientTokens] = useState<Set<string>>(
+    new Set(),
+  );
+  const [isCheckingSufficiency, setIsCheckingSufficiency] = useState(false);
+
+  useEffect(() => {
+    const quote =
+      starterpackDetails && isOnchainStarterpack(starterpackDetails)
+        ? starterpackDetails.quote
+        : undefined;
+
+    // Bridging flows lock the token to USDC and pay from another chain, so
+    // Starknet balances are irrelevant there.
+    const isBridging = !!selectedPlatform && selectedPlatform !== "starknet";
+
+    // Mirror useTokenBalance: external Starknet wallets pay from their own
+    // address, everything else pays from the controller.
+    const isExternalStarknetWallet =
+      selectedWallet?.type === "argent" || selectedWallet?.type === "braavos";
+    const ownerAddress =
+      isExternalStarknetWallet && walletAddress
+        ? walletAddress
+        : controller?.address();
+
+    if (
+      !controller ||
+      !quote ||
+      quote.totalCost === 0n ||
+      isBridging ||
+      !ownerAddress ||
+      availableTokens.length === 0
+    ) {
+      setInsufficientTokens(new Set());
+      setIsCheckingSufficiency(false);
+      return;
+    }
+
+    const abortController = new AbortController();
+    const chainId = controller.chainId();
+    const totalCost = quote.totalCost * BigInt(quantity);
+    const candidates = availableTokens.filter((token) => !token.isCredits);
+
+    const checkAll = async () => {
+      setIsCheckingSufficiency(true);
+      setInsufficientTokens(new Set());
+
+      const results = await Promise.all(
+        candidates.map(async (candidate) => {
+          try {
+            const isPaymentToken =
+              num.toHex(candidate.address) === num.toHex(quote.paymentToken);
+
+            let requiredAmount: bigint;
+            if (
+              isPaymentToken ||
+              isUsdcVariantPair(candidate.address, quote.paymentToken, chainId)
+            ) {
+              requiredAmount = totalCost;
+            } else if (!isQuoteChain(chainId)) {
+              // No swap/price source: the token can't be priced, so don't
+              // claim insufficiency.
+              return null;
+            } else {
+              const swapResult = await fetchSwapQuote(
+                totalCost,
+                quote.paymentToken,
+                candidate.address,
+                chainId,
+                abortController.signal,
+              );
+              requiredAmount = swapResult.total;
+            }
+
+            if (abortController.signal.aborted) return null;
+
+            const balance = await fetchErc20Balance(
+              controller,
+              candidate.address,
+              ownerAddress,
+            );
+
+            if (balance !== null && balance < requiredAmount) {
+              return num.toHex(candidate.address);
+            }
+            return null;
+          } catch (error) {
+            if (!abortController.signal.aborted) {
+              console.warn(
+                `Sufficiency check failed for ${candidate.symbol}:`,
+                error,
+              );
+            }
+            // Unknown ≠ insufficient: leave the token selectable.
+            return null;
+          }
+        }),
+      );
+
+      if (abortController.signal.aborted) return;
+      setInsufficientTokens(
+        new Set(results.filter((address): address is string => !!address)),
+      );
+      setIsCheckingSufficiency(false);
+    };
+
+    checkAll();
+
+    return () => {
+      abortController.abort();
+    };
+  }, [
+    controller,
+    starterpackDetails,
+    availableTokens,
+    quantity,
+    selectedWallet,
+    walletAddress,
+    selectedPlatform,
+  ]);
+
+  return { insufficientTokens, isCheckingSufficiency };
+}

--- a/packages/keychain/src/utils/connection/index.ts
+++ b/packages/keychain/src/utils/connection/index.ts
@@ -198,6 +198,9 @@ export function connectToController<
               `shareMessage=${encodeURIComponent(options.socialClaimOptions.shareMessage)}`,
             );
           }
+          if (options?.singlePurchaseOnly) {
+            searchParams.push("singlePurchaseOnly=true");
+          }
           navigate(
             `/purchase/bundle/${id}${searchParams.length > 0 ? `?${searchParams.join("&")}` : ""}`,
             { replace: true },
@@ -221,6 +224,9 @@ export function connectToController<
           const searchParams: string[] = [];
           if (options?.preimage) {
             searchParams.push(`preimage=${options.preimage}`);
+          }
+          if (options?.singlePurchaseOnly) {
+            searchParams.push("singlePurchaseOnly=true");
           }
           navigate(
             `/purchase/starterpack/${id}${searchParams.length > 0 ? `?${searchParams.join("&")}` : ""}`,


### PR DESCRIPTION
## Summary

Two bundle/starterpack purchase UX fixes:

- **Token selector**: currencies whose balance cannot cover the purchase are now disabled in the dropdown (new `useTokenSufficiency` hook reusing the fallback pricing logic — direct cost for the payment token / USDC variants, Ekubo quote otherwise). This removes the confusing flow where picking an unaffordable token triggered the balance check and silently auto-switched to another currency. The **USD (credits) option is never disabled** so users can always deposit funds. Unknown balances/quotes leave the token selectable (unknown ≠ insufficient).
- **`singlePurchaseOnly` option** on `BundleOptions` and `StarterpackOptions`: when set, the +/- quantity buttons are hidden and quantity is fixed at 1; the Apple Pay minimum quantity auto-bump is skipped (its existing "Amount Too Low" gate takes over). Without the option, behavior is unchanged.

## Test plan

- [x] New unit tests for `useTokenSufficiency` (payment token, quantity scaling, swap-quoted tokens, credits pseudo-token, balance errors)
- [x] Full keychain suite (752 tests) and controller suite (72 tests) pass
- [x] `tsc -b` and eslint clean on both packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)