### PR TITLE
fix(keychain): disable text selection globally

### DIFF
--- a/packages/keychain/src/index.css
+++ b/packages/keychain/src/index.css
@@ -11,7 +11,12 @@
 @layer base {
   html,
   body {
-    @apply bg-background text-foreground ring-foreground touch-manipulation;
+    @apply bg-background text-foreground ring-foreground touch-manipulation select-none;
+  }
+
+  input,
+  textarea {
+    @apply select-text;
   }
 
   * {


### PR DESCRIPTION
## Summary

- Apply `select-none` on `html, body` in the keychain so UI text (usernames, labels, tooltips, etc.) is not selectable.
- Re-enable selection with `select-text` on `input` and `textarea` so typing/editing in form fields keeps working.

## Testing

- Verified on the local dev server: computed styles show `user-select: none` on `html`/`body` and `user-select: text` on inputs, with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)