### PR TITLE
feat(keychain): show USD equivalent in bundle checkout cost breakdown

### DIFF
--- a/packages/keychain/src/components/purchase/checkout/onchain/index.tsx
+++ b/packages/keychain/src/components/purchase/checkout/onchain/index.tsx
@@ -861,7 +861,7 @@ export function OnchainCheckout() {
         }
       />
 
-      <LayoutContent>
+      <LayoutContent className="select-none">
         <Receiving
           title={`You Receive ${quantity > 1 ? `(${quantity})` : ""}`}
           items={purchaseItems}
@@ -870,7 +870,7 @@ export function OnchainCheckout() {
         />
       </LayoutContent>
 
-      <LayoutFooter>
+      <LayoutFooter className="select-none">
         {needsReauth ? (
           <>
             <ErrorCard

--- a/packages/keychain/src/components/purchase/review/cost.tsx
+++ b/packages/keychain/src/components/purchase/review/cost.tsx
@@ -157,6 +157,7 @@ export function OnchainCostBreakdown({
     isFetchingConversion,
     feeEstimationError,
     quantity,
+    usdAmount,
     isApplePaySelected,
     isCoinflowSelected,
     isCreditsSelected,
@@ -277,6 +278,14 @@ export function OnchainCostBreakdown({
     ],
   );
 
+  // USD equivalent of the purchase, shown as a "(…)" prefix before the token
+  // amount. usdAmount is derived from the quote's USDC total, so it is only
+  // shown when available (> 0).
+  const totalUsd = usdAmount * quantity;
+  const usdEquivalent = totalUsd > 0 && (
+    <span className="text-foreground-300">{`($${totalUsd.toFixed(2)})`}</span>
+  );
+
   const value = isCreditsSelected ? (
     isCreditsQuoteLoading ? (
       <Spinner />
@@ -316,13 +325,19 @@ export function OnchainCostBreakdown({
       <Spinner />
     )
   ) : isPaymentTokenSameAsSelected ? (
-    <span className="text-foreground-300">{formatAmount(paymentAmount)}</span>
+    <>
+      {usdEquivalent}
+      <span className="text-foreground-300">{formatAmount(paymentAmount)}</span>
+    </>
   ) : (
     convertedEquivalent !== null &&
     displayToken && (
-      <span className="text-foreground-100">
-        {formatAmount(convertedEquivalent)}
-      </span>
+      <>
+        {usdEquivalent}
+        <span className="text-foreground-100">
+          {formatAmount(convertedEquivalent)}
+        </span>
+      </>
     )
   );
 

--- a/packages/keychain/src/components/purchase/review/onchain-cost.stories.tsx
+++ b/packages/keychain/src/components/purchase/review/onchain-cost.stories.tsx
@@ -5,6 +5,10 @@ import {
   OnchainPurchaseContextType,
   TokenOption,
 } from "@/context/starterpack/onchain-purchase";
+import {
+  CreditPurchaseContext,
+  CreditPurchaseContextType,
+} from "@/context/starterpack/credit-purchase";
 import { ReactNode } from "react";
 import { USDC_ICON } from "@/utils/ekubo";
 
@@ -23,7 +27,13 @@ const mockUsdcToken = {
 } satisfies TokenOption;
 
 // Mock provider for stories
-const MockOnchainPurchaseProvider = ({ children }: { children: ReactNode }) => {
+const MockOnchainPurchaseProvider = ({
+  children,
+  overrides,
+}: {
+  children: ReactNode;
+  overrides?: Partial<OnchainPurchaseContextType>;
+}) => {
   const mockValue: OnchainPurchaseContextType = {
     purchaseItems: [],
     purchaseDescription: undefined,
@@ -88,9 +98,33 @@ const MockOnchainPurchaseProvider = ({ children }: { children: ReactNode }) => {
     submitCoinbaseLimitsUpgrade: async () => undefined,
   };
 
+  const mockCreditValue: CreditPurchaseContextType = {
+    usdAmount: 0,
+    setUsdAmount: () => {},
+    coinflowIntent: undefined,
+    coinflowQuote: undefined,
+    isCoinflowQuoteLoading: false,
+    coinflowEnv: "sandbox",
+    isCoinflowLoading: false,
+    creditsQuote: undefined,
+    isCreditsQuoteLoading: false,
+    creditsQuoteError: undefined,
+    creditsBalance: 0n,
+    refetchCreditsBalance: async () => 0n,
+    isCreditsBalanceLoading: false,
+    creditsBalanceError: undefined,
+    hasSufficientCredits: false,
+    isCreditsLoading: false,
+    creditsFulfillment: undefined,
+    onCreditCardPurchase: async () => {},
+    onCreditsPurchase: async () => {},
+  };
+
   return (
-    <OnchainPurchaseContext.Provider value={mockValue}>
-      {children}
+    <OnchainPurchaseContext.Provider value={{ ...mockValue, ...overrides }}>
+      <CreditPurchaseContext.Provider value={mockCreditValue}>
+        {children}
+      </CreditPurchaseContext.Provider>
     </OnchainPurchaseContext.Provider>
   );
 };
@@ -98,8 +132,8 @@ const MockOnchainPurchaseProvider = ({ children }: { children: ReactNode }) => {
 const meta = {
   component: OnchainCostBreakdown,
   decorators: [
-    (Story) => (
-      <MockOnchainPurchaseProvider>
+    (Story, { parameters }) => (
+      <MockOnchainPurchaseProvider overrides={parameters.mockOverrides}>
         <Story />
       </MockOnchainPurchaseProvider>
     ),
@@ -116,6 +150,29 @@ type Story = StoryObj<typeof meta>;
 
 // USDC payment example with referral
 export const USDCPayment: Story = {
+  args: {
+    quote: {
+      basePrice: 100000000n, // $100 USDC (6 decimals)
+      protocolFee: 2500000n, // $2.50 protocol fee
+      referralFee: 5000000n, // $5 USDC referral fee
+      totalCost: 107500000n, // $107.50 total
+      paymentToken: USDC_ADDRESS,
+      paymentTokenMetadata: {
+        symbol: "USDC",
+        decimals: 6,
+      },
+    },
+    platform: "starknet",
+  },
+};
+
+// USD-equivalent prefix shown before the token amount when usdAmount is known
+export const USDCPaymentWithUsdPrefix: Story = {
+  parameters: {
+    mockOverrides: {
+      usdAmount: 107.5,
+    } satisfies Partial<OnchainPurchaseContextType>,
+  },
   args: {
     quote: {
       basePrice: 100000000n, // $100 USDC (6 decimals)


### PR DESCRIPTION
## Summary

- Prefix the payment-token amount in the bundle checkout cost breakdown with its USD equivalent when available, rendered as `($107.50) 107.50` — the price in parentheses in `foreground-300`, the token amount keeping its existing style.
- Applied to both token branches (payment token identical to the quote's, and Ekubo-converted equivalent). Fiat rails (Credits/Coinflow/Apple Pay) already display USD and the Layerswap total includes bridge fees, so they are unchanged.
- Make the onchain checkout page `select-none` (content + footer).
- Fix the `onchain-cost` stories, which were broken by the missing `CreditPurchaseContext` mock, and add a `USDCPaymentWithUsdPrefix` story covering the new prefix.

## Testing

- Verified in Storybook: prefix shown with `usdAmount` set, rendering unchanged when unavailable.
- `tsc -b`, ESLint and Prettier pass; pre-commit hooks (lint, tests, build) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)