### PR TITLE
Prepare release: 0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.14.1] - 2026-09-04
+
+### ✨ New Features
+- **@cartridge/controller**: Added `selfFundedGasMultiplier` (supported range `1.5`–`10`) so applications can reserve additional gas headroom for direct self-funded transactions and paymaster-unavailable session fallbacks (#2669)
+
+### 🚀 Improvements
+- **@cartridge/keychain**: Restored Ready wallet availability on the Slot funding page (#2667)
+- **Release automation**: Enabled bot-authored changelog generation and pull-request reviews so automated releases can complete without false-red checks (#2670)
+
+### 🐛 Bug Fixes
+- **@cartridge/keychain**: Fixed standalone logout and account deletion so configured `redirect_url` / `redirect_uri` targets regain control after the local session is cleared (#2668)
+- **@cartridge/keychain**: Fixed the Slot funding page after the React upgrade (#2666)
+- **Self-funded fees**: Applied the configured gas multiplier exactly once and safely fell back to the default for malformed or out-of-range values (#2669)
+
+### 📦 Dependencies
+- **@cartridge/controller-wasm**: Updated to `0.10.2` for configurable self-funded gas resource bounds (#2669)
+
 ## [0.14.0] - 2026-08-05
 
 ### ✨ New Features

--- a/examples/capacitor/package.json
+++ b/examples/capacitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartridge-capacitor-example",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "private": true,
   "engines": {
     "node": ">=22"

--- a/examples/minimal/package.json
+++ b/examples/minimal/package.json
@@ -4,7 +4,7 @@
   "engines": {
     "node": ">=22"
   },
-  "version": "0.14.0",
+  "version": "0.14.1",
   "type": "module",
   "scripts": {
     "dev": "env-cmd -f .env.dev vite --port 3003",

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -4,7 +4,7 @@
   "engines": {
     "node": ">=22"
   },
-  "version": "0.14.0",
+  "version": "0.14.1",
   "scripts": {
     "dev": "env-cmd -f .env.dev next dev -p 3002",
     "dev:live": "env-cmd -f .env.live next dev -p 3002",

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartridge-node-example",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Example of using Cartridge session controller with Node.js",
   "engines": {
     "node": ">=22"

--- a/examples/svelte/package.json
+++ b/examples/svelte/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cartridge/controller-example-svelte",
-	"version": "0.14.0",
+	"version": "0.14.1",
 	"private": true,
 	"engines": {
 		"node": ">=22"

--- a/packages/connector/package.json
+++ b/packages/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cartridge/connector",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Cartridge Controller Connector",
   "repository": {
     "type": "git",

--- a/packages/controller/package.json
+++ b/packages/controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cartridge/controller",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Cartridge Controller",
   "repository": {
     "type": "git",

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cartridge/eslint",
   "private": true,
-  "version": "0.14.0",
+  "version": "0.14.1",
   "type": "module",
   "exports": {
     ".": "./index.js"

--- a/packages/keychain/package.json
+++ b/packages/keychain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cartridge/keychain",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cartridge/tsconfig",
   "private": true,
-  "version": "0.14.0",
+  "version": "0.14.1",
   "files": [
     "base.json",
     "react.json"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cartridge/controller-ui",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Catridge UI component library, backend utils for apps spread accross org",
   "packageManager": "pnpm@10.10.0",
   "main": "./dist/index.js",


### PR DESCRIPTION
Prepares the stable `0.14.1` release of `@cartridge/controller` and `@cartridge/connector`, including the configurable self-funded gas multiplier backed by `@cartridge/controller-wasm@0.10.2`. It also includes the post-`0.14.0` standalone logout, Slot funding, Ready wallet, and release-automation fixes.

Prompted by: mataleone
