### PR TITLE
Prepare release: 0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.14.2] - 2026-09-08
+
+### 🐛 Bug Fixes
+- **Self-funded sessions**: Added 50% gas-price headroom to the WASM session fallback so small gas-price increases between estimation and submission no longer cause resource-bound failures. Default sponsored execution and JavaScript-supplied fee bounds retain their existing behavior ([#2672](https://github.com/cartridge-gg/controller/pull/2672)).
+
+### 📦 Dependencies
+- **@cartridge/controller-wasm**: Updated to `0.10.3`, including the shared Rust/WASM fallback and gas-price buffer ([#107](https://github.com/cartridge-gg/controller-rs/pull/107), [#108](https://github.com/cartridge-gg/controller-rs/pull/108)).
+- **@cartridge/connector**: Released alongside controller at `0.14.2`; no connector-specific behavior changes.
+
 ## [0.14.1] - 2026-09-04
 
 ### ✨ New Features

--- a/examples/capacitor/package.json
+++ b/examples/capacitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartridge-capacitor-example",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "private": true,
   "engines": {
     "node": ">=22"

--- a/examples/minimal/package.json
+++ b/examples/minimal/package.json
@@ -4,7 +4,7 @@
   "engines": {
     "node": ">=22"
   },
-  "version": "0.14.1",
+  "version": "0.14.2",
   "type": "module",
   "scripts": {
     "dev": "env-cmd -f .env.dev vite --port 3003",

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -4,7 +4,7 @@
   "engines": {
     "node": ">=22"
   },
-  "version": "0.14.1",
+  "version": "0.14.2",
   "scripts": {
     "dev": "env-cmd -f .env.dev next dev -p 3002",
     "dev:live": "env-cmd -f .env.live next dev -p 3002",

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartridge-node-example",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Example of using Cartridge session controller with Node.js",
   "engines": {
     "node": ">=22"

--- a/examples/svelte/package.json
+++ b/examples/svelte/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cartridge/controller-example-svelte",
-	"version": "0.14.1",
+	"version": "0.14.2",
 	"private": true,
 	"engines": {
 		"node": ">=22"

--- a/packages/connector/package.json
+++ b/packages/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cartridge/connector",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Cartridge Controller Connector",
   "repository": {
     "type": "git",

--- a/packages/controller/package.json
+++ b/packages/controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cartridge/controller",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Cartridge Controller",
   "repository": {
     "type": "git",

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cartridge/eslint",
   "private": true,
-  "version": "0.14.1",
+  "version": "0.14.2",
   "type": "module",
   "exports": {
     ".": "./index.js"

--- a/packages/keychain/package.json
+++ b/packages/keychain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cartridge/keychain",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cartridge/tsconfig",
   "private": true,
-  "version": "0.14.1",
+  "version": "0.14.2",
   "files": [
     "base.json",
     "react.json"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cartridge/controller-ui",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Catridge UI component library, backend utils for apps spread accross org",
   "packageManager": "pnpm@10.10.0",
   "main": "./dist/index.js",


### PR DESCRIPTION
Prepares the stable `0.14.2` release of `@cartridge/controller` and `@cartridge/connector`, consuming `@cartridge/controller-wasm@0.10.3` from [#2672](https://github.com/cartridge-gg/controller/pull/2672).

Self-funded session fallback now reserves 50% gas-price headroom. Regression coverage preserves default sponsored execution, exactly-once confirmation buffering, WASM-owned session estimation, and error propagation. This release changes workspace versions and adds the changelog entry; it introduces no additional runtime changes.

Validation: merged-source quality, TypeScript/unit tests, browser compatibility, and end-to-end checks passed. Release-branch checks must pass before merge; the publish workflow builds and validates packed consumers before publishing both packages to npm `latest`.

Prompted by: mataleone
